### PR TITLE
feat(jupiter): PR-255 detect connected google calendar and import schedule

### DIFF
--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -99,6 +99,17 @@ export const getGoogleCalendarConnectUrl = async (params: {
 	return response.data;
 };
 
+export const getGoogleCalendarStatus = async (): Promise<{
+	connected: boolean;
+	syncEnabled: boolean;
+}> => {
+	const response = await apiClient.get<{
+		connected: boolean;
+		syncEnabled: boolean;
+	}>('/auth/google/calendar/status');
+	return response.data;
+};
+
 /**
  * @deprecated getEncryptionKey removed for security (P1.3)
  * The encryption key endpoint was removed from the backend.

--- a/src/api/jupiter/index.ts
+++ b/src/api/jupiter/index.ts
@@ -35,3 +35,21 @@ export const generateJupiterAvailability = async (
 	);
 	return response.data;
 };
+
+export interface GoogleCalendarSchedule {
+	endTime: string;
+	startTime: string;
+	workingDays: string[];
+}
+
+export const importGoogleCalendarSchedule =
+	async (): Promise<GoogleCalendarSchedule | null> => {
+		try {
+			const response = await apiClient.get<GoogleCalendarSchedule>(
+				'/jupiter/availability/google-calendar/import'
+			);
+			return response.data;
+		} catch {
+			return null;
+		}
+	};

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -544,7 +544,8 @@
       "msg1": "Hi! I’m Júpiter, your scheduling assistant. I’m here to help you set up your availability in a way that feels natural and effortless.",
       "msg2": "Let’s start by setting up your calendar. How would you like to begin?",
       "chip-google": "Connect Google Calendar",
-      "chip-manual": "Create manually"
+      "chip-manual": "Create manually",
+      "google-already-connected": "Your Google Calendar is already connected! Would you like to import your schedule from it?"
     },
     "working-days": {
       "response": "Great! Which days do you usually work with your clients?",
@@ -641,7 +642,11 @@
       "success-line3": "I’ll automatically block times when you’re already busy.",
       "next-choice": "Would you like to:",
       "chip-use-existing": "Use my existing schedule as availability",
-      "chip-define-hours": "Define specific working hours"
+      "chip-define-hours": "Define specific working hours",
+      "define-hours-fallback": "Got it! Google Calendar import is coming soon. Let’s set your working hours manually for now.",
+      "importing": "Give me a moment — I’m importing your schedule from Google Calendar...",
+      "imported": "Done! I found your working days and hours. Just a couple more things to set up.",
+      "import-failed": "I couldn’t read your calendar schedule. Let’s set your working hours manually."
     },
     "errors": {
       "network": "Something went wrong. Let’s try that again.",

--- a/src/assets/locales/pt/translation.json
+++ b/src/assets/locales/pt/translation.json
@@ -543,7 +543,8 @@
       "msg1": "Olá! Eu sou a Júpiter, sua assistente de agendamento via IA. Estou aqui para te ajudar a configurar sua disponibilidade de forma simples e natural.",
       "msg2": "Vamos começar configurando sua agenda. Como você prefere?",
       "chip-google": "Conectar Google Agenda",
-      "chip-manual": "Criar manualmente"
+      "chip-manual": "Criar manualmente",
+      "google-already-connected": "Sua Google Agenda já está conectada! Você gostaria de importar sua agenda dela?"
     },
     "working-days": {
       "response": "Ótimo! Em quais dias você costuma atender seus clientes?",
@@ -640,7 +641,11 @@
       "success-line3": "Vou bloquear automaticamente os horários em que você já estiver ocupado.",
       "next-choice": "Você gostaria de:",
       "chip-use-existing": "Usar minha agenda atual como disponibilidade",
-      "chip-define-hours": "Definir horários de trabalho específicos"
+      "chip-define-hours": "Definir horários de trabalho específicos",
+      "define-hours-fallback": "Entendido! A importação do Google Agenda estará disponível em breve. Por enquanto, vamos definir seus horários manualmente.",
+      "importing": "Um momento — estou importando sua agenda do Google Agenda...",
+      "imported": "Pronto! Encontrei seus dias e horários de trabalho. Só mais algumas configurações.",
+      "import-failed": "Não consegui ler sua agenda. Vamos definir seus horários de trabalho manualmente."
     },
     "errors": {
       "network": "Algo deu errado. Vamos tentar de novo.",

--- a/src/pages/availability/google-calendar-path/GoogleCalendarSuccess.tsx
+++ b/src/pages/availability/google-calendar-path/GoogleCalendarSuccess.tsx
@@ -10,10 +10,12 @@ import {
 } from '../jupiter-conversation/JupiterConversation.styles';
 
 interface GoogleCalendarSuccessProps {
+	isImporting?: boolean;
 	onSelect: (key: string) => void;
 }
 
 export const GoogleCalendarSuccess = ({
+	isImporting = false,
 	onSelect,
 }: GoogleCalendarSuccessProps) => {
 	const { t } = useTranslation();
@@ -65,12 +67,14 @@ export const GoogleCalendarSuccess = ({
 				</IconRow>
 			</BotMessageGroup>
 
-			<ChipsInline>
-				<SingleSelectChips
-					options={postConnectOptions}
-					onSelect={onSelect}
-				/>
-			</ChipsInline>
+			{!isImporting && (
+				<ChipsInline>
+					<SingleSelectChips
+						options={postConnectOptions}
+						onSelect={onSelect}
+					/>
+				</ChipsInline>
+			)}
 		</>
 	);
 };

--- a/src/pages/availability/jupiter-conversation/JupiterConversation.tsx
+++ b/src/pages/availability/jupiter-conversation/JupiterConversation.tsx
@@ -43,6 +43,7 @@ export const JupiterConversation = () => {
 		step,
 		answers,
 		messages,
+		isImporting,
 		isPublishing,
 		workingDaysKey,
 		detectedTimezone,
@@ -361,7 +362,12 @@ export const JupiterConversation = () => {
 				);
 
 			case 'google-success':
-				return <GoogleCalendarSuccess onSelect={handleGooglePostConnect} />;
+				return (
+					<GoogleCalendarSuccess
+						isImporting={isImporting}
+						onSelect={handleGooglePostConnect}
+					/>
+				);
 
 			case 'done':
 				return null;

--- a/src/pages/availability/jupiter-conversation/useJupiterFlow.ts
+++ b/src/pages/availability/jupiter-conversation/useJupiterFlow.ts
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { getGoogleCalendarConnectUrl } from '@psycron/api/auth';
+import { getGoogleCalendarConnectUrl, getGoogleCalendarStatus } from '@psycron/api/auth';
 import type { IAvailabilityRecord } from '@psycron/api/availability/index.types';
-import { generateJupiterAvailability } from '@psycron/api/jupiter';
+import {
+	generateJupiterAvailability,
+	importGoogleCalendarSchedule,
+} from '@psycron/api/jupiter';
 import { useAlert } from '@psycron/context/alert/AlertContext';
 import { AVAILABILITYGENERATE, AVAILABILITYPATH } from '@psycron/pages/urls';
 import { useQueryClient } from '@tanstack/react-query';
@@ -87,6 +90,7 @@ export const useJupiterFlow = (initialAnswers?: JupiterAnswers) => {
 	);
 	const [messages, setMessages] = useState<JupiterMessage[]>([]);
 	const [isPublishing, setIsPublishing] = useState(false);
+	const [isImporting, setIsImporting] = useState(false);
 	const [workingDaysKey, setWorkingDaysKey] = useState(0);
 
 	const hasInitialized = useRef(false);
@@ -172,10 +176,23 @@ export const useJupiterFlow = (initialAnswers?: JupiterAnswers) => {
 	// ─── Step handlers ─────────────────────────────────────────────────────────
 
 	const handleCalendarChoice = useCallback(
-		(key: string) => {
+		async (key: string) => {
 			if (key === 'google') {
 				addUserMessage(t('jupiter.calendar-choice.chip-google'));
 				setAnswers((prev) => ({ ...prev, calendarChoice: 'google' }));
+
+				try {
+					const status = await getGoogleCalendarStatus();
+					if (status.connected) {
+						// Already connected — skip OAuth, go straight to google-success
+						addBotMessage(t('jupiter.calendar-choice.google-already-connected'));
+						setTimeout(() => setStep('google-success'), 300);
+						return;
+					}
+				} catch {
+					// Status check failed — fall through to normal OAuth flow
+				}
+
 				setStep('google-permissions');
 			} else {
 				addUserMessage(t('jupiter.calendar-choice.chip-manual'));
@@ -183,7 +200,7 @@ export const useJupiterFlow = (initialAnswers?: JupiterAnswers) => {
 				advance('jupiter.working-days.response', 'working-days', 500);
 			}
 		},
-		[addUserMessage, advance, t]
+		[addBotMessage, addUserMessage, advance, t]
 	);
 
 	const handleWorkingDays = useCallback(
@@ -358,23 +375,50 @@ export const useJupiterFlow = (initialAnswers?: JupiterAnswers) => {
 	const handleGoogleBack = useCallback(() => setStep('calendar-choice'), []);
 
 	const handleGooglePostConnect = useCallback(
-		(key: string) => {
+		async (key: string) => {
+			addUserMessage(
+				key === 'chip-use-existing'
+					? t('jupiter.google-calendar.chip-use-existing')
+					: t('jupiter.google-calendar.chip-define-hours')
+			);
+
 			if (key === 'chip-use-existing') {
-				addUserMessage(t('jupiter.google-calendar.chip-use-existing'));
-				// TODO: import from Google Calendar
-				setStep('preview');
+				setIsImporting(true);
+				addBotMessage(t('jupiter.google-calendar.importing'));
+
+				const schedule = await importGoogleCalendarSchedule();
+
+				setIsImporting(false);
+
+				if (schedule && schedule.workingDays.length > 0) {
+					const timeRange = `${schedule.startTime} - ${schedule.endTime}`;
+					setAnswers((prev) => ({
+						...prev,
+						workingDays: schedule.workingDays,
+						timeRange,
+					}));
+					setTimeout(() => {
+						addBotMessage(t('jupiter.google-calendar.imported'), false);
+						setStep('session-duration');
+					}, 300);
+				} else {
+					setTimeout(() => {
+						addBotMessage(t('jupiter.google-calendar.import-failed'), false);
+						setStep('working-days');
+					}, 300);
+				}
 			} else {
-				addUserMessage(t('jupiter.google-calendar.chip-define-hours'));
 				advance('jupiter.working-days.response', 'working-days');
 			}
 		},
-		[addUserMessage, advance, t]
+		[addBotMessage, addUserMessage, advance, setAnswers, t]
 	);
 
 	return {
 		step,
 		answers,
 		messages,
+		isImporting,
 		isPublishing,
 		workingDaysKey,
 		detectedTimezone,


### PR DESCRIPTION
## Summary

- **Skip OAuth if already connected**: `handleCalendarChoice('google')` now calls `GET /auth/google/calendar/status` first — if calendar is already linked, goes directly to `google-success` step, skipping the OAuth redirect entirely
- **Real schedule import**: `handleGooglePostConnect('chip-use-existing')` calls `GET /jupiter/availability/google-calendar/import`, pre-fills `workingDays` + `timeRange`, and jumps to `session-duration` (skipping those two steps)
- **Graceful fallback**: if import returns nothing, shows friendly message and falls back to manual `working-days` step
- **Loading state**: chips on `GoogleCalendarSuccess` are hidden while `isImporting` is true to prevent double-submit
- **i18n**: new keys `google-already-connected`, `importing`, `imported`, `import-failed` in both `en` and `pt`

## Dependencies

- Requires `psycron-app/psycron-be#PR-255` (BE `prompt: 'select_account'` fix) to be merged first
- Requires `psycron-app/psycron-be#PR-259` for `GET /jupiter/availability/google-calendar/import` endpoint

## Test plan

- [ ] Fresh flow (no calendar connected): clicking "Connect Google Calendar" still redirects to Google OAuth
- [ ] Already connected: clicking "Connect Google Calendar" skips OAuth and shows `google-success` screen with "already connected" message
- [ ] `chip-use-existing`: shows importing message, then pre-fills days + hours and advances to session-duration
- [ ] `chip-use-existing` with no calendar data: shows fallback message and goes to working-days step
- [ ] `chip-define-hours`: goes to working-days step (unchanged)
- [ ] Chips are hidden while import is in-flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)