### PR TITLE
feat(jupiter): PR-256/257 availability preview card and publishing overlay

### DIFF
--- a/src/pages/availability/jupiter-conversation/JupiterConversation.styles.tsx
+++ b/src/pages/availability/jupiter-conversation/JupiterConversation.styles.tsx
@@ -55,6 +55,7 @@ export const CardWrapper = styled(Box)`
 	flex-direction: column;
 	width: 100%;
 	flex: 1;
+	position: relative;
 
 	padding: ${spacing.small};
 
@@ -68,6 +69,26 @@ export const CardWrapper = styled(Box)`
 		background: ${palette.background.paper};
 		overflow: hidden;
 	}
+`;
+
+export const PublishingOverlay = styled(Box)`
+	position: absolute;
+	inset: 0;
+	z-index: 10;
+	backdrop-filter: blur(6px);
+	background-color: ${hexToRgba(palette.background.paper, 0.6)};
+	border-radius: inherit;
+	pointer-events: all;
+`;
+
+export const PublishingMessageWrapper = styled(Box)`
+	position: absolute;
+	inset: 0;
+	z-index: 11;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	pointer-events: none;
 `;
 
 export const CardHeader = styled(Box)`

--- a/src/pages/availability/jupiter-conversation/JupiterConversation.tsx
+++ b/src/pages/availability/jupiter-conversation/JupiterConversation.tsx
@@ -27,10 +27,10 @@ import {
 	PublishingMessageWrapper,
 	PublishingOverlay,
 	SendButton,
-	ThinkingBubble,
 	UserBubble,
 	UserMessageGroup,
 } from './JupiterConversation.styles';
+import { JupiterThinking } from './JupiterThinking';
 import { useJupiterFlow } from './useJupiterFlow';
 
 export const JupiterConversation = () => {
@@ -210,11 +210,7 @@ export const JupiterConversation = () => {
 						</SendButton>
 					</InputRow>
 					{isParsing && (
-						<ThinkingBubble>
-							<span />
-							<span />
-							<span />
-						</ThinkingBubble>
+						<JupiterThinking />
 					)}
 				</ChipsInline>
 			);
@@ -262,13 +258,7 @@ export const JupiterConversation = () => {
 							otherPlaceholder={t('jupiter.working-days.other-placeholder')}
 							onOtherSubmit={handleWorkingDaysOtherSubmit}
 						/>
-						{isParsing && (
-							<ThinkingBubble>
-								<span />
-								<span />
-								<span />
-							</ThinkingBubble>
-						)}
+						{isParsing && <JupiterThinking />}
 					</ChipsInline>
 				);
 
@@ -409,11 +399,7 @@ export const JupiterConversation = () => {
 				<>
 					<PublishingOverlay />
 					<PublishingMessageWrapper>
-						<ThinkingBubble>
-							<span />
-							<span />
-							<span />
-						</ThinkingBubble>
+						<JupiterThinking />
 					</PublishingMessageWrapper>
 				</>
 			)}

--- a/src/pages/availability/jupiter-conversation/JupiterConversation.tsx
+++ b/src/pages/availability/jupiter-conversation/JupiterConversation.tsx
@@ -24,6 +24,8 @@ import {
 	ConversationContainer,
 	IconRow,
 	InputRow,
+	PublishingMessageWrapper,
+	PublishingOverlay,
 	SendButton,
 	ThinkingBubble,
 	UserBubble,
@@ -402,6 +404,19 @@ export const JupiterConversation = () => {
 				{renderStepChips()}
 				<div ref={bottomRef} />
 			</ConversationContainer>
+
+			{isPublishing && (
+				<>
+					<PublishingOverlay />
+					<PublishingMessageWrapper>
+						<ThinkingBubble>
+							<span />
+							<span />
+							<span />
+						</ThinkingBubble>
+					</PublishingMessageWrapper>
+				</>
+			)}
 		</CardWrapper>
 	);
 };

--- a/src/pages/availability/jupiter-conversation/JupiterThinking.tsx
+++ b/src/pages/availability/jupiter-conversation/JupiterThinking.tsx
@@ -1,0 +1,9 @@
+import { ThinkingBubble } from './JupiterConversation.styles';
+
+export const JupiterThinking = () => (
+	<ThinkingBubble>
+		<span />
+		<span />
+		<span />
+	</ThinkingBubble>
+);


### PR DESCRIPTION
## Summary

- **PR-256**: `AvailabilityPreviewCard` was already fully built (colored dot rows, all five fields, publish + reset buttons, slide-in animation). Confirming done — no new work needed.
- **PR-257**: Publishing loading states implemented via a glass overlay + floating ThinkingBubble:
  - `PublishingOverlay` — `position: absolute`, `inset: 0`, `backdrop-filter: blur(6px)` + semi-transparent bg — covers the entire `CardWrapper`, blocking all interaction behind it
  - `PublishingMessageWrapper` — sits above the overlay (z-index 11), centers the ThinkingBubble
  - `ThinkingBubble` (existing component, three animated dots) signals Jupiter is processing — consistent with the AI personality
  - On success: `navigate()` fires and the overlay disappears naturally with the page transition
  - On error: `setIsPublishing(false)` restores full chat state + bot error message appears

## Test plan

- [x] Click "Publish Availability" — glass overlay appears immediately, ThinkingBubble animates
- [x] All chat content and buttons behind the overlay are non-interactive while publishing
- [x] On success: redirects to availability settings, no flash
- [x] On error (simulate network fail): overlay disappears, error message appears in chat, button re-enables

🤖 Generated with [Claude Code](https://claude.com/claude-code)