### PR TITLE
feat(jupiter): add recurrence pattern as conversational step [PR-272]

### DIFF
--- a/src/api/jupiter/index.ts
+++ b/src/api/jupiter/index.ts
@@ -31,6 +31,7 @@ export const parseJupiterInput = async (
 };
 
 export interface JupiterPublishPayload {
+	recurrencePattern: RecurrencePattern;
 	sessionDuration: string;
 	sessionType: string;
 	timeRange: string;

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -587,17 +587,27 @@
 			"chip-both": "Both online and in person"
 		},
 		"timezone": {
-			"response": "One last thing — I’ll use your device’s timezone to schedule appointments accurately. This helps ensure your clients book at the right time for you. Sound good?",
+			"response": "Almost there! I’ll use your device’s timezone to schedule appointments accurately. This helps ensure your clients book at the right time for you. Sound good?",
 			"chip-yes": "Yes",
 			"chip-no": "No",
 			"follow-up": "No problem! Please select your timezone:",
 			"search-placeholder": "Search timezone..."
+		},
+		"recurrence-pattern": {
+			"response": "One last thing — how often would you like your availability to repeat?",
+			"chip-weekly": "Weekly (until end of month)",
+			"chip-monthly": "Monthly (until end of year)",
+			"summary-weekly": "Got it! Your slots will repeat every week until the end of this month. You can always extend from your dashboard.",
+			"summary-monthly": "Perfect! Your availability will repeat monthly until the end of the year — giving you full-year scheduling coverage.",
+			"value-weekly": "Weekly (until end of month)",
+			"value-monthly": "Monthly (until end of year)"
 		},
 		"preview": {
 			"title": "Your Availability Preview",
 			"label-days": "Working days:",
 			"label-hours": "Hours:",
 			"label-duration": "Duration:",
+			"label-recurrence": "Repeat:",
 			"label-session-type": "Session type:",
 			"label-timezone": "Timezone:",
 			"footer": "You can edit your availability anytime from your dashboard.",

--- a/src/assets/locales/pt/translation.json
+++ b/src/assets/locales/pt/translation.json
@@ -588,17 +588,27 @@
 			"chip-both": "Online e presencial"
 		},
 		"timezone": {
-			"response": "Uma última coisa — vou usar o fuso horário do seu dispositivo para agendar consultas com precisão. Assim, seus clientes sempre vão agendar no horário certo. Tudo bem?",
+			"response": "Quase lá! Vou usar o fuso horário do seu dispositivo para agendar consultas com precisão. Assim, seus clientes sempre vão agendar no horário certo. Tudo bem?",
 			"chip-yes": "Sim",
 			"chip-no": "Não",
 			"follow-up": "Sem problema! Selecione seu fuso horário:",
 			"search-placeholder": "Buscar fuso horário..."
+		},
+		"recurrence-pattern": {
+			"response": "Última pergunta — com qual frequência você quer que sua disponibilidade se repita?",
+			"chip-weekly": "Semanal (até o fim do mês)",
+			"chip-monthly": "Mensal (até o fim do ano)",
+			"summary-weekly": "Entendido! Seus horários vão se repetir toda semana até o fim deste mês. Você pode estender a qualquer momento pelo painel.",
+			"summary-monthly": "Perfeito! Sua disponibilidade vai se repetir mensalmente até o fim do ano — cobrindo todo o seu calendário anual.",
+			"value-weekly": "Semanal (até o fim do mês)",
+			"value-monthly": "Mensal (até o fim do ano)"
 		},
 		"preview": {
 			"title": "Resumo da sua Disponibilidade",
 			"label-days": "Dias de atendimento:",
 			"label-hours": "Horário:",
 			"label-duration": "Duração:",
+			"label-recurrence": "Repetição:",
 			"label-session-type": "Tipo de sessão:",
 			"label-timezone": "Fuso horário:",
 			"footer": "Você pode editar sua disponibilidade a qualquer momento no painel.",

--- a/src/pages/availability/availability-preview-card/AvailabilityPreviewCard.tsx
+++ b/src/pages/availability/availability-preview-card/AvailabilityPreviewCard.tsx
@@ -58,6 +58,13 @@ export const AvailabilityPreviewCard = ({
 				label: t('jupiter.preview.label-timezone'),
 				value: answers.timezone ?? detectedTimezone,
 			},
+			{
+				dotColor: palette.warning.main,
+				label: t('jupiter.preview.label-recurrence'),
+				value: answers.recurrencePattern
+					? t(`jupiter.recurrence-pattern.value-${answers.recurrencePattern.toLowerCase()}`)
+					: '—',
+			},
 		],
 		[answers, detectedTimezone, daysDisplay, t]
 	);

--- a/src/pages/availability/jupiter-conversation/JupiterConversation.tsx
+++ b/src/pages/availability/jupiter-conversation/JupiterConversation.tsx
@@ -51,19 +51,20 @@ export const JupiterConversation = () => {
 		detectedTimezone,
 		initFlow,
 		handleCalendarChoice,
+		handleGoogleBack,
+		handleGoogleContinue,
+		handleGooglePostConnect,
+		handlePublish,
+		handleRecurrencePattern,
+		handleReset,
+		handleSessionDuration,
+		handleSessionType,
+		handleTimeRange,
+		handleTimezone,
+		handleTimezoneSelect,
 		handleWorkingDays,
 		handleWorkingDaysFromText,
 		retryWorkingDays,
-		handleTimeRange,
-		handleSessionDuration,
-		handleSessionType,
-		handleTimezone,
-		handleTimezoneSelect,
-		handlePublish,
-		handleReset,
-		handleGoogleContinue,
-		handleGoogleBack,
-		handleGooglePostConnect,
 	} = useJupiterFlow();
 
 	const handleWorkingDaysOtherSubmit = useCallback(
@@ -144,6 +145,18 @@ export const JupiterConversation = () => {
 					key: 'chip-no',
 					label: t('jupiter.timezone.chip-no'),
 					variant: 'danger' as const,
+				},
+			] satisfies IChipOption[],
+			recurrencePattern: [
+				{
+					key: 'chip-weekly',
+					label: t('jupiter.recurrence-pattern.chip-weekly'),
+					variant: 'primary' as const,
+				},
+				{
+					key: 'chip-monthly',
+					label: t('jupiter.recurrence-pattern.chip-monthly'),
+					variant: 'secondary' as const,
 				},
 			] satisfies IChipOption[],
 		}),
@@ -330,6 +343,17 @@ export const JupiterConversation = () => {
 							key='timezone'
 							options={chipOptions.timezone}
 							onSelect={handleTimezone}
+						/>
+					</ChipsInline>
+				);
+
+			case 'recurrence-pattern':
+				return (
+					<ChipsInline>
+						<SingleSelectChips
+							key='recurrence-pattern'
+							options={chipOptions.recurrencePattern}
+							onSelect={handleRecurrencePattern}
 						/>
 					</ChipsInline>
 				);

--- a/src/pages/availability/jupiter-conversation/JupiterConversation.types.ts
+++ b/src/pages/availability/jupiter-conversation/JupiterConversation.types.ts
@@ -1,3 +1,5 @@
+import type { RecurrencePattern } from '@psycron/api/jupiter';
+
 export type JupiterStep =
 	| 'calendar-choice'
 	| 'working-days'
@@ -5,6 +7,7 @@ export type JupiterStep =
 	| 'session-duration'
 	| 'session-type'
 	| 'timezone'
+	| 'recurrence-pattern'
 	| 'preview'
 	| 'google-permissions'
 	| 'google-success'
@@ -12,6 +15,7 @@ export type JupiterStep =
 
 export interface JupiterAnswers {
 	calendarChoice?: 'google' | 'manual';
+	recurrencePattern?: RecurrencePattern;
 	sessionDuration?: string;
 	sessionType?: string;
 	timeRange?: string;

--- a/src/pages/availability/jupiter-conversation/useJupiterFlow.ts
+++ b/src/pages/availability/jupiter-conversation/useJupiterFlow.ts
@@ -6,6 +6,7 @@ import type { IAvailabilityRecord } from '@psycron/api/availability/index.types'
 import {
 	generateJupiterAvailability,
 	importGoogleCalendarSchedule,
+	type RecurrencePattern,
 } from '@psycron/api/jupiter';
 import { useAlert } from '@psycron/context/alert/AlertContext';
 import { AVAILABILITYGENERATE, AVAILABILITYPATH } from '@psycron/pages/urls';
@@ -53,6 +54,10 @@ const loadSaved = (): {
 			data.answers = { ...data.answers, sessionType: undefined };
 			if (data.step === 'preview') data.step = 'session-type';
 		}
+		// Migrate: if at preview but recurrencePattern not yet collected, redirect to that step
+		if (data.step === 'preview' && !data.answers?.recurrencePattern) {
+			data.step = 'recurrence-pattern';
+		}
 		return data;
 	} catch {
 		return null;
@@ -61,6 +66,7 @@ const loadSaved = (): {
 
 const STEP_QUESTION_KEY: Partial<Record<JupiterStep, string>> = {
 	'calendar-choice': 'jupiter.calendar-choice.msg2',
+	'recurrence-pattern': 'jupiter.recurrence-pattern.response',
 	'session-duration': 'jupiter.session-duration.response',
 	'session-type': 'jupiter.session-type.response',
 	'time-range': 'jupiter.time-range.response',
@@ -304,23 +310,36 @@ export const useJupiterFlow = (initialAnswers?: JupiterAnswers) => {
 					timezone: detectedTimezone,
 					timezoneConfirmed: true,
 				}));
-				setTimeout(() => setStep('preview'), 300);
+				advance('jupiter.recurrence-pattern.response', 'recurrence-pattern', 300);
 			} else {
 				addUserMessage(t('jupiter.timezone.chip-no'));
 				addBotMessage(t('jupiter.timezone.follow-up'));
 				setAnswers((prev) => ({ ...prev, timezoneConfirmed: false }));
 			}
 		},
-		[addBotMessage, addUserMessage, detectedTimezone, t]
+		[addBotMessage, addUserMessage, advance, detectedTimezone, t]
 	);
 
 	const handleTimezoneSelect = useCallback(
 		(tz: string) => {
 			addUserMessage(tz);
 			setAnswers((prev) => ({ ...prev, timezone: tz }));
-			setTimeout(() => setStep('preview'), 300);
+			advance('jupiter.recurrence-pattern.response', 'recurrence-pattern', 300);
 		},
-		[addUserMessage]
+		[addUserMessage, advance]
+	);
+
+	const handleRecurrencePattern = useCallback(
+		(key: string) => {
+			const value: RecurrencePattern = key === 'chip-weekly' ? 'WEEKLY' : 'MONTHLY';
+			const label = t(`jupiter.recurrence-pattern.${key}`);
+			const summaryKey =
+				key === 'chip-weekly'
+					? 'jupiter.recurrence-pattern.summary-weekly'
+					: 'jupiter.recurrence-pattern.summary-monthly';
+			commit(label, 'recurrencePattern', value, summaryKey, 'preview');
+		},
+		[commit, t]
 	);
 
 	// ─── Publish / Reset ───────────────────────────────────────────────────────
@@ -331,13 +350,15 @@ export const useJupiterFlow = (initialAnswers?: JupiterAnswers) => {
 			!answers.timeRange ||
 			!answers.sessionDuration ||
 			!answers.sessionType ||
-			!answers.timezone
+			!answers.timezone ||
+			!answers.recurrencePattern
 		)
 			return;
 
 		setIsPublishing(true);
 		try {
 			const { availabilityId } = await generateJupiterAvailability({
+				recurrencePattern: answers.recurrencePattern,
 				workingDays: answers.workingDays,
 				timeRange: answers.timeRange,
 				sessionDuration: answers.sessionDuration,
@@ -348,6 +369,7 @@ export const useJupiterFlow = (initialAnswers?: JupiterAnswers) => {
 			localStorage.setItem(ONBOARDING_KEY, 'true');
 			const record: IAvailabilityRecord = {
 				availabilityId,
+				recurrencePattern: answers.recurrencePattern,
 				sessionDuration: answers.sessionDuration!,
 				sessionType: answers.sessionType!,
 				timeRange: answers.timeRange!,
@@ -446,18 +468,19 @@ export const useJupiterFlow = (initialAnswers?: JupiterAnswers) => {
 		detectedTimezone,
 		initFlow,
 		handleCalendarChoice,
+		handleGoogleBack,
+		handleGoogleContinue,
+		handleGooglePostConnect,
+		handlePublish,
+		handleRecurrencePattern,
+		handleReset,
+		handleSessionDuration,
+		handleSessionType,
+		handleTimeRange,
+		handleTimezone,
+		handleTimezoneSelect,
 		handleWorkingDays,
 		handleWorkingDaysFromText,
 		retryWorkingDays,
-		handleTimeRange,
-		handleSessionDuration,
-		handleSessionType,
-		handleTimezone,
-		handleTimezoneSelect,
-		handlePublish,
-		handleReset,
-		handleGoogleContinue,
-		handleGoogleBack,
-		handleGooglePostConnect,
 	};
 };


### PR DESCRIPTION
## Summary
- Inserts a dedicated `recurrence-pattern` step between `timezone` and `preview` in the Jupiter generator flow
- User picks **Weekly (until end of month)** or **Monthly (until end of year)** via chips; Jupiter responds with a human-readable implication summary
- `recurrencePattern` is now included in the generate payload sent to the BE
- Preview card shows the selected recurrence in the summary
- Migrates saved draft sessions at `preview` that lack `recurrencePattern` back to the new step

## Test plan
- [ ] Start Jupiter generator fresh — recurrence step appears after timezone confirmation
- [ ] Select WEEKLY — bot responds with monthly implication summary, advances to preview
- [ ] Select MONTHLY — bot responds with yearly implication summary, advances to preview
- [ ] Preview card shows "Repeat:" row with selected value
- [ ] Publish — payload includes `recurrencePattern`
- [ ] Restore saved session at old `preview` step (no recurrencePattern) — redirects to recurrence step
- [ ] EN and PT translations render correctly

Closes [PR-272](https://psycron.atlassian.net/browse/PR-272)

🤖 Generated with [Claude Code](https://claude.com/claude-code)