### PR TITLE
feat(jupiter): T7 — specialty confirmation + delivery mode defaults

### DIFF
--- a/src/api/jupiter/index.ts
+++ b/src/api/jupiter/index.ts
@@ -12,9 +12,12 @@ export interface IGetWeekSlotsResponse {
 	days: IWeekSlotDay[];
 }
 
-export type ParseField = 'working-days' | 'time-range' | 'session-duration';
+export type ParseField = 'working-days' | 'time-range' | 'session-duration' | 'specialty';
+
+export type ParseSpecialtyFlag = 'accepted' | 'rejected' | 'rephrase';
 
 export type ParseInputResult =
+	| { flag: ParseSpecialtyFlag; parsed: string[]; valid: true }
 	| { parsed: string[], valid: true; }
 	| { parsed: string, valid: true; }
 	| { valid: false };

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -545,6 +545,21 @@
 			"subtitle": "I’ll help you set up your availability in just a few moments. Let’s make scheduling feel effortless.",
 			"cta": "Set up my schedule"
 		},
+		"specialty": {
+			"response": "What do you practice? Use the professional name for your work.",
+			"chip-occupational-therapist": "Occupational Therapist",
+			"chip-nutritionist": "Nutritionist",
+			"chip-other": "Other",
+			"chip-physiotherapist": "Physiotherapist",
+			"chip-psychiatrist": "Psychiatrist",
+			"chip-psychologist": "Psychologist",
+			"chip-speech-therapist": "Speech Therapist",
+			"continue": "Continue",
+			"other-placeholder": "Your specialty or professional title",
+			"acknowledged": "Got it! I'll set things up with that in mind.",
+			"error-rephrase": "I couldn't quite catch that — try using the professional name for what you practice.",
+			"error-rejected": "I'm not able to set up scheduling for that. If you have another specialty, I'd love to help you get started."
+		},
 		"calendar-choice": {
 			"msg1": "Hi! I’m Júpiter, your scheduling assistant. I’m here to help you set up your availability in a way that feels natural and effortless.",
 			"msg2": "Let’s start by setting up your calendar. How would you like to begin?",
@@ -582,6 +597,7 @@
 		},
 		"session-type": {
 			"response": "How do you usually conduct your sessions?",
+			"response-with-suggestion": "How do you usually conduct your sessions? I have a suggestion based on your specialty — pick what works best for you.",
 			"chip-online": "Online only",
 			"chip-in-person": "In person only",
 			"chip-both": "Both online and in person"

--- a/src/assets/locales/pt/translation.json
+++ b/src/assets/locales/pt/translation.json
@@ -546,6 +546,21 @@
 			"subtitle": "Vou te ajudar a configurar sua disponibilidade em poucos momentos. Vamos tornar o agendamento simples e rápido.",
 			"cta": "Configurar minha agenda"
 		},
+		"specialty": {
+			"response": "Qual é a sua área de atuação? Use o nome profissional do que você pratica.",
+			"chip-occupational-therapist": "Terapeuta Ocupacional",
+			"chip-nutritionist": "Nutricionista",
+			"chip-other": "Outro",
+			"chip-physiotherapist": "Fisioterapeuta",
+			"chip-psychiatrist": "Psiquiatra",
+			"chip-psychologist": "Psicólogo(a)",
+			"chip-speech-therapist": "Fonoaudiólogo(a)",
+			"continue": "Continuar",
+			"other-placeholder": "Sua especialidade ou título profissional",
+			"acknowledged": "Entendido! Vou configurar tudo levando isso em conta.",
+			"error-rephrase": "Não consegui identificar bem — tente usar o nome profissional do que você pratica.",
+			"error-rejected": "Não consigo configurar agendamentos para isso. Se você tem outra especialidade, adoraria te ajudar a começar."
+		},
 		"calendar-choice": {
 			"msg1": "Olá! Eu sou a Júpiter, sua assistente de agendamento via IA. Estou aqui para te ajudar a configurar sua disponibilidade de forma simples e natural.",
 			"msg2": "Vamos começar configurando sua agenda. Como você prefere?",
@@ -583,6 +598,7 @@
 		},
 		"session-type": {
 			"response": "Como você costuma realizar suas sessões?",
+			"response-with-suggestion": "Como você costuma realizar suas sessões? Tenho uma sugestão com base na sua especialidade — escolha o que funciona melhor para você.",
 			"chip-online": "Apenas online",
 			"chip-in-person": "Apenas presencial",
 			"chip-both": "Online e presencial"

--- a/src/context/user/auth/UserAuthenticationContext.types.ts
+++ b/src/context/user/auth/UserAuthenticationContext.types.ts
@@ -98,6 +98,7 @@ export interface ITherapist extends IBaseUser {
 	patients: MongoId[];
 	picture?: string;
 	role: TherapistRole;
+	specialities?: string[];
 	stripeCustomerID?: string;
 	timeZone: string;
 }

--- a/src/pages/availability/jupiter-conversation/JupiterConversation.tsx
+++ b/src/pages/availability/jupiter-conversation/JupiterConversation.tsx
@@ -7,6 +7,7 @@ import { MultiSelectChips } from '@psycron/components/chat/chips/MultiSelectChip
 import { SingleSelectChips } from '@psycron/components/chat/chips/SingleSelectChips';
 import { Divider } from '@psycron/components/divider/Divider';
 import { ChevronLeft, Jupiter, Send } from '@psycron/components/icons';
+import { useUserDetails } from '@psycron/context/user/details/UserDetailsContext';
 
 import { AvailabilityPreviewCard } from '../availability-preview-card/AvailabilityPreviewCard';
 import { GoogleCalendarPermissions } from '../google-calendar-path/GoogleCalendarPermissions';
@@ -41,12 +42,15 @@ export const JupiterConversation = () => {
 	const [customValue, setCustomValue] = useState('');
 	const [isParsing, setIsParsing] = useState(false);
 
+	const { therapistId, userDetails } = useUserDetails();
+
 	const {
 		step,
 		answers,
 		messages,
 		isImporting,
 		isPublishing,
+		specialityKey,
 		workingDaysKey,
 		detectedTimezone,
 		initFlow,
@@ -59,13 +63,41 @@ export const JupiterConversation = () => {
 		handleReset,
 		handleSessionDuration,
 		handleSessionType,
+		handleSpecialty,
+		handleSpecialtyFromText,
 		handleTimeRange,
 		handleTimezone,
 		handleTimezoneSelect,
 		handleWorkingDays,
 		handleWorkingDaysFromText,
+		retrySpeciality,
 		retryWorkingDays,
-	} = useJupiterFlow();
+	} = useJupiterFlow({
+		therapistId,
+		userSpecialities: userDetails?.specialities,
+	});
+
+	const handleSpecialtyOtherSubmit = useCallback(
+		async (raw: string) => {
+			setIsParsing(true);
+			const result = await parseJupiterInput('specialty', raw);
+			setIsParsing(false);
+
+			if (result.valid && Array.isArray(result.parsed)) {
+				const flag = 'flag' in result ? result.flag : 'accepted';
+				if (flag === 'rejected') {
+					retrySpeciality(true);
+				} else if (flag === 'rephrase') {
+					retrySpeciality(false);
+				} else {
+					handleSpecialtyFromText(result.parsed);
+				}
+			} else {
+				retrySpeciality(false);
+			}
+		},
+		[handleSpecialtyFromText, retrySpeciality]
+	);
 
 	const handleWorkingDaysOtherSubmit = useCallback(
 		async (raw: string) => {
@@ -145,6 +177,22 @@ export const JupiterConversation = () => {
 					key: 'chip-no',
 					label: t('jupiter.timezone.chip-no'),
 					variant: 'danger' as const,
+				},
+			] satisfies IChipOption[],
+			specialty: [
+				{ key: 'chip-psychologist', label: t('jupiter.specialty.chip-psychologist') },
+				{ key: 'chip-physiotherapist', label: t('jupiter.specialty.chip-physiotherapist') },
+				{ key: 'chip-nutritionist', label: t('jupiter.specialty.chip-nutritionist') },
+				{ key: 'chip-psychiatrist', label: t('jupiter.specialty.chip-psychiatrist') },
+				{ key: 'chip-speech-therapist', label: t('jupiter.specialty.chip-speech-therapist') },
+				{
+					key: 'chip-occupational-therapist',
+					label: t('jupiter.specialty.chip-occupational-therapist'),
+				},
+				{
+					key: 'chip-other',
+					label: t('jupiter.specialty.chip-other'),
+					variant: 'outline' as const,
 				},
 			] satisfies IChipOption[],
 			recurrencePattern: [
@@ -249,6 +297,21 @@ export const JupiterConversation = () => {
 
 	const renderStepChips = () => {
 		switch (step) {
+			case 'specialty':
+				return (
+					<ChipsInline>
+						<MultiSelectChips
+							key={specialityKey}
+							options={chipOptions.specialty}
+							onConfirm={handleSpecialty}
+							confirmLabel={t('jupiter.specialty.continue')}
+							otherPlaceholder={t('jupiter.specialty.other-placeholder')}
+							onOtherSubmit={handleSpecialtyOtherSubmit}
+						/>
+						{isParsing && <JupiterThinking />}
+					</ChipsInline>
+				);
+
 			case 'calendar-choice':
 				return (
 					<ChipsInline>

--- a/src/pages/availability/jupiter-conversation/JupiterConversation.types.ts
+++ b/src/pages/availability/jupiter-conversation/JupiterConversation.types.ts
@@ -1,6 +1,7 @@
 import type { RecurrencePattern } from '@psycron/api/jupiter';
 
 export type JupiterStep =
+	| 'specialty'
 	| 'calendar-choice'
 	| 'working-days'
 	| 'time-range'
@@ -18,6 +19,7 @@ export interface JupiterAnswers {
 	recurrencePattern?: RecurrencePattern;
 	sessionDuration?: string;
 	sessionType?: string;
+	specialities?: string[];
 	timeRange?: string;
 	timezone?: string;
 	timezoneConfirmed?: boolean;

--- a/src/pages/availability/jupiter-conversation/jupiterSpecialtyDefaults.ts
+++ b/src/pages/availability/jupiter-conversation/jupiterSpecialtyDefaults.ts
@@ -1,0 +1,79 @@
+// ─── Chip key → canonical speciality name ─────────────────────────────────────
+
+export const SPECIALTY_CHIP_KEY_MAP: Record<string, string> = {
+	'chip-occupational-therapist': 'occupational-therapist',
+	'chip-nutritionist': 'nutritionist',
+	'chip-physiotherapist': 'physiotherapist',
+	'chip-psychiatrist': 'psychiatrist',
+	'chip-psychologist': 'psychologist',
+	'chip-speech-therapist': 'speech-therapist',
+};
+
+// ─── Canonical speciality name → default sessionType chip key ─────────────────
+// Configurable — not hardcoded in component logic.
+// Drives the session-type suggestion in the Jupiter flow; always overridable.
+
+export const SPECIALTY_SESSION_TYPE_DEFAULTS: Record<string, string> = {
+	// Healthcare
+	'occupational-therapist': 'chip-in-person',
+	nutritionist: 'chip-both',
+	physiotherapist: 'chip-in-person',
+	psychiatrist: 'chip-both',
+	psychologist: 'chip-both',
+	'speech-therapist': 'chip-in-person',
+	nurse: 'chip-in-person',
+	// Wellness
+	acupuncture: 'chip-in-person',
+	'drainage-massage': 'chip-in-person',
+	'massage-therapist': 'chip-in-person',
+	meditation: 'chip-both',
+	reiki: 'chip-in-person',
+	'tantric-massage': 'chip-in-person',
+	yoga: 'chip-both',
+	// Alternative
+	astrology: 'chip-both',
+	'card-reading': 'chip-both',
+	medium: 'chip-both',
+	// Aesthetics
+	'aesthetic-nurse': 'chip-in-person',
+	'tattoo-artist': 'chip-in-person',
+	// Movement
+	'dance-instructor': 'chip-in-person',
+	pilates: 'chip-in-person',
+	'personal-trainer': 'chip-in-person',
+};
+
+export const SPECIALTY_SESSION_TYPE_FALLBACK = 'chip-both';
+
+// ─── Category lookup (FE only — not stored in DB) ────────────────────────────
+// Used for calendar filtering. Derivable at any time from canonical name.
+
+export const SPECIALTY_CATEGORIES: Record<string, string> = {
+	// Healthcare
+	'occupational-therapist': 'healthcare',
+	nutritionist: 'healthcare',
+	physiotherapist: 'healthcare',
+	psychiatrist: 'healthcare',
+	psychologist: 'healthcare',
+	'speech-therapist': 'healthcare',
+	nurse: 'healthcare',
+	// Wellness
+	acupuncture: 'wellness',
+	'drainage-massage': 'wellness',
+	'massage-therapist': 'wellness',
+	meditation: 'wellness',
+	reiki: 'wellness',
+	'tantric-massage': 'wellness',
+	yoga: 'wellness',
+	// Alternative
+	astrology: 'alternative',
+	'card-reading': 'alternative',
+	medium: 'alternative',
+	// Aesthetics
+	'aesthetic-nurse': 'aesthetics',
+	'tattoo-artist': 'aesthetics',
+	// Movement
+	'dance-instructor': 'movement',
+	pilates: 'movement',
+	'personal-trainer': 'movement',
+};

--- a/src/pages/availability/jupiter-conversation/useJupiterFlow.ts
+++ b/src/pages/availability/jupiter-conversation/useJupiterFlow.ts
@@ -8,6 +8,7 @@ import {
 	importGoogleCalendarSchedule,
 	type RecurrencePattern,
 } from '@psycron/api/jupiter';
+import { editUserById } from '@psycron/api/user';
 import { useAlert } from '@psycron/context/alert/AlertContext';
 import { AVAILABILITYGENERATE, AVAILABILITYPATH } from '@psycron/pages/urls';
 import { useQueryClient } from '@tanstack/react-query';
@@ -17,6 +18,11 @@ import type {
 	JupiterMessage,
 	JupiterStep,
 } from './JupiterConversation.types';
+import {
+	SPECIALTY_CHIP_KEY_MAP,
+	SPECIALTY_SESSION_TYPE_DEFAULTS,
+	SPECIALTY_SESSION_TYPE_FALLBACK,
+} from './jupiterSpecialtyDefaults';
 
 export const STORAGE_KEY = '_psy_jd';
 export const ONBOARDING_KEY = '_psy_ob';
@@ -69,6 +75,7 @@ const STEP_QUESTION_KEY: Partial<Record<JupiterStep, string>> = {
 	'recurrence-pattern': 'jupiter.recurrence-pattern.response',
 	'session-duration': 'jupiter.session-duration.response',
 	'session-type': 'jupiter.session-type.response',
+	specialty: 'jupiter.specialty.response',
 	'time-range': 'jupiter.time-range.response',
 	timezone: 'jupiter.timezone.response',
 	'working-days': 'jupiter.working-days.response',
@@ -94,7 +101,17 @@ const CANONICAL_TO_CHIP: Record<string, string> = {
 	WEDNESDAY: 'chip-wed',
 };
 
-export const useJupiterFlow = (initialAnswers?: JupiterAnswers) => {
+interface UseJupiterFlowOptions {
+	initialAnswers?: JupiterAnswers;
+	therapistId?: string;
+	userSpecialities?: string[];
+}
+
+export const useJupiterFlow = ({
+	initialAnswers,
+	therapistId,
+	userSpecialities,
+}: UseJupiterFlowOptions = {}) => {
 	const { t, i18n } = useTranslation();
 	const navigate = useNavigate();
 	const { showAlert } = useAlert();
@@ -107,15 +124,19 @@ export const useJupiterFlow = (initialAnswers?: JupiterAnswers) => {
 		return params.get('calendar') === 'connected';
 	}, []);
 
-	const [step, setStep] = useState<JupiterStep>(
-		isCalendarConnected ? 'google-success' : (saved?.step ?? 'calendar-choice')
-	);
+	const [step, setStep] = useState<JupiterStep>(() => {
+		if (isCalendarConnected) return 'google-success';
+		if (saved) return saved.step;
+		if (!userSpecialities?.length) return 'specialty';
+		return 'calendar-choice';
+	});
 	const [answers, setAnswers] = useState<JupiterAnswers>(
 		initialAnswers ?? saved?.answers ?? {}
 	);
 	const [messages, setMessages] = useState<JupiterMessage[]>([]);
 	const [isPublishing, setIsPublishing] = useState(false);
 	const [isImporting, setIsImporting] = useState(false);
+	const [specialityKey, setSpecialityKey] = useState(0);
 	const [workingDaysKey, setWorkingDaysKey] = useState(0);
 
 	const hasInitialized = useRef(false);
@@ -193,10 +214,18 @@ export const useJupiterFlow = (initialAnswers?: JupiterAnswers) => {
 
 		addBotMessage(t('jupiter.calendar-choice.msg1'));
 		setTimeout(
-			() => addBotMessage(t('jupiter.calendar-choice.msg2'), false),
+			() =>
+				addBotMessage(
+					t(
+						!userSpecialities?.length
+							? 'jupiter.specialty.response'
+							: 'jupiter.calendar-choice.msg2'
+					),
+					false
+				),
 			500
 		);
-	}, [addBotMessage, saved, t]);
+	}, [addBotMessage, saved, t, userSpecialities?.length]);
 
 	// ─── Step handlers ─────────────────────────────────────────────────────────
 
@@ -261,6 +290,67 @@ export const useJupiterFlow = (initialAnswers?: JupiterAnswers) => {
 		setWorkingDaysKey((k) => k + 1);
 	}, [addBotMessage, t]);
 
+	// ─── Specialty handlers ────────────────────────────────────────────────────
+
+	const commitSpecialities = useCallback(
+		async (canonicals: string[]) => {
+			const label = canonicals.join(', ');
+			addUserMessage(label);
+			setAnswers((prev) => ({ ...prev, specialities: canonicals }));
+
+			if (therapistId) {
+				try {
+					await editUserById({ data: { specialities: canonicals }, userId: therapistId });
+				} catch {
+					// Non-critical — flow continues regardless
+				}
+			}
+
+			const defaultSessionType =
+				SPECIALTY_SESSION_TYPE_DEFAULTS[canonicals[0]] ??
+				SPECIALTY_SESSION_TYPE_FALLBACK;
+			setAnswers((prev) => ({ ...prev, sessionType: defaultSessionType }));
+
+			addBotMessage(t('jupiter.specialty.acknowledged'));
+			setTimeout(() => {
+				addBotMessage(t('jupiter.calendar-choice.msg2'), false);
+				setStep('calendar-choice');
+			}, 500);
+		},
+		[addBotMessage, addUserMessage, therapistId, t]
+	);
+
+	const handleSpecialty = useCallback(
+		(selectedKeys: string[]) => {
+			const canonicals = selectedKeys.map(
+				(k) => SPECIALTY_CHIP_KEY_MAP[k] ?? k.replace('chip-', '')
+			);
+			commitSpecialities(canonicals);
+		},
+		[commitSpecialities]
+	);
+
+	const handleSpecialtyFromText = useCallback(
+		(canonicals: string[]) => {
+			commitSpecialities(canonicals);
+		},
+		[commitSpecialities]
+	);
+
+	const retrySpeciality = useCallback(
+		(isRejected = false) => {
+			addBotMessage(
+				t(
+					isRejected
+						? 'jupiter.specialty.error-rejected'
+						: 'jupiter.specialty.error-rephrase'
+				)
+			);
+			setSpecialityKey((k) => k + 1);
+		},
+		[addBotMessage, t]
+	);
+
 	// Receives the resolved display label (from chip option or free text input)
 	const handleTimeRange = useCallback(
 		(label: string) =>
@@ -276,15 +366,16 @@ export const useJupiterFlow = (initialAnswers?: JupiterAnswers) => {
 
 	// Receives the resolved display label (from chip option or free text input)
 	const handleSessionDuration = useCallback(
-		(label: string) =>
-			commit(
-				label,
-				'sessionDuration',
-				label,
-				'jupiter.session-type.response',
-				'session-type'
-			),
-		[commit]
+		(label: string) => {
+			const hasSpecialityDefault =
+				answers.specialities?.length &&
+				SPECIALTY_SESSION_TYPE_DEFAULTS[answers.specialities[0]];
+			const sessionTypeResponseKey = hasSpecialityDefault
+				? 'jupiter.session-type.response-with-suggestion'
+				: 'jupiter.session-type.response';
+			commit(label, 'sessionDuration', label, sessionTypeResponseKey, 'session-type');
+		},
+		[answers.specialities, commit]
 	);
 
 	const handleSessionType = useCallback(
@@ -464,6 +555,7 @@ export const useJupiterFlow = (initialAnswers?: JupiterAnswers) => {
 		messages,
 		isImporting,
 		isPublishing,
+		specialityKey,
 		workingDaysKey,
 		detectedTimezone,
 		initFlow,
@@ -476,11 +568,14 @@ export const useJupiterFlow = (initialAnswers?: JupiterAnswers) => {
 		handleReset,
 		handleSessionDuration,
 		handleSessionType,
+		handleSpecialty,
+		handleSpecialtyFromText,
 		handleTimeRange,
 		handleTimezone,
 		handleTimezoneSelect,
 		handleWorkingDays,
 		handleWorkingDaysFromText,
+		retrySpeciality,
 		retryWorkingDays,
 	};
 };


### PR DESCRIPTION
## Summary

- Adds `specialty` as the first conversational step in the Jupiter flow for new users (skipped if specialities already set on profile)
- Chip selection + free-text "Other" path backed by `parseJupiterInput('specialty', ...)` with `accepted` / `rephrase` / `rejected` routing
- Multi-specialty supported — all selections saved to therapist profile via `editUserById`
- Session-type default pre-filled based on first specialty (e.g. physiotherapist → in-person), overridable by user
- `specialities: string[]` added to `ITherapist` FE type

## BE changes (separate PR)

- `specialities: [String]` added to Mongoose `Therapist` schema
- `parse-input` endpoint extended to handle `specialty` field with AI normalization and flag routing

## Test plan

- [ ] New user (no specialities): Jupiter starts at specialty step
- [ ] Returning user (specialities set): specialty step is skipped, flow starts at calendar-choice
- [ ] Chip selection (single + multi): canonicals saved to profile
- [ ] Free text "Other" → accepted path: advances to calendar-choice
- [ ] Free text "Other" → rephrase path: bot asks to rephrase, chips reset
- [ ] Free text "Other" → rejected path: bot shows rejection message, chips reset
- [ ] Session-type step shows specialty-aware suggestion when default exists
- [ ] Session-type step shows neutral message when no default

Jira: [PR-273](https://psycron-app.atlassian.net/browse/PR-273)

🤖 Generated with [Claude Code](https://claude.com/claude-code)