### PR TITLE
feat(booking): public booking pages with branding, i18n and ux improvements

### DIFF
--- a/.github/workflows/SETUP.md
+++ b/.github/workflows/SETUP.md
@@ -1,0 +1,189 @@
+# Psycron — GitHub Automation & Version Tracking Setup Guide
+
+## Overview
+
+This package contains two GitHub Actions workflows that automate changelog generation and version management for Psycron's `psycron-fe` and `psycron-be` repositories.
+
+### What you get
+
+| Workflow | Trigger | What it does |
+|----------|---------|-------------|
+| `dev-changelog.yml` | Every push to `dev` | Generates a diff summary (main↔dev), posts to a pinned GitHub Issue, comments on any open dev→main PR |
+| `release.yml` | PR merge from `dev` to `main` | Auto-determines semver bump, creates Git tag, generates categorized GitHub Release |
+
+---
+
+## Installation (both repos)
+
+### Step 1: Copy workflow files
+
+For **each** repository (`psycron-fe` and `psycron-be`):
+
+```bash
+# From your local clone
+cd psycron-fe   # or psycron-be
+mkdir -p .github/workflows
+cp path/to/dev-changelog.yml .github/workflows/
+cp path/to/release.yml .github/workflows/
+git add .github/workflows/
+git commit -m "ci: add dev changelog and release automation"
+git push origin dev
+```
+
+### Step 2: Create the `changelog` label
+
+In each repo, go to **Settings → Labels** and create:
+- Name: `changelog`
+- Color: `#0075ca`
+- Description: "Auto-updated dev branch changelog"
+
+### Step 3: Verify permissions
+
+Go to **Settings → Actions → General → Workflow permissions** and ensure:
+- [x] Read and write permissions
+- [x] Allow GitHub Actions to create and approve pull requests
+
+---
+
+## Versioning Strategy
+
+### Semantic Versioning (SemVer)
+
+```
+v{MAJOR}.{MINOR}.{PATCH}
+
+MAJOR = breaking changes (API contracts change)
+MINOR = new features (additive, non-breaking)
+PATCH = bug fixes, security patches, refactors
+```
+
+### Version Phases
+
+| Phase | Version Range | When |
+|-------|--------------|------|
+| Pre-launch development | `v0.x.x` | Now → March 31, 2026 |
+| **MVP Launch** | **`v1.0.0`** | **April 1, 2026** |
+| Post-launch iteration | `v1.x.x` | April 2+ |
+| Major redesign/breaking | `v2.0.0` | When API contracts change |
+
+### Launch Day: Creating v1.0.0
+
+On April 1, when you merge `dev` → `main` for launch, use the manual trigger:
+
+1. Go to **Actions → 🚀 Release & Version Tag**
+2. Click **Run workflow**
+3. Set:
+   - `version_override`: `1.0.0`
+   - `release_title`: `Psycron MVP Launch — v1.0.0`
+4. Click **Run workflow**
+
+This creates the `v1.0.0` tag and a full GitHub Release.
+
+### Post-Launch: Automatic Versioning
+
+After v1.0.0, every merge from `dev` → `main` auto-determines the version:
+
+```
+feat(jupiter): add enhancement mode    → v1.1.0 (MINOR)
+fix(booking): timezone offset bug      → v1.0.1 (PATCH)
+sec(auth): rate limit hardening        → v1.0.2 (PATCH)
+feat!: new availability data model     → v2.0.0 (MAJOR — breaking)
+```
+
+---
+
+## Commit Convention (Required)
+
+For the automation to categorize changes correctly, follow **Conventional Commits**:
+
+```
+<type>(<scope>): <description>
+
+Types:
+  feat     → New feature
+  fix      → Bug fix
+  sec      → Security improvement
+  refactor → Code refactor (no behavior change)
+  docs     → Documentation
+  chore    → Tooling, deps, config
+  test     → Tests
+  ci       → CI/CD changes
+
+Scopes (suggested):
+  auth, booking, jupiter, availability, notifications,
+  payments, dashboard, i18n, calendar, patient
+
+Breaking changes:
+  feat!: ...           → Major version bump
+  BREAKING CHANGE:     → In commit body → Major version bump
+```
+
+### Examples
+
+```bash
+git commit -m "feat(jupiter): add recurrence pattern to conversational flow"
+git commit -m "fix(booking): patient address not persisting after step 3"
+git commit -m "sec(auth): enforce httpOnly on refresh token cookie"
+git commit -m "refactor(availability): extract slot generation to service"
+```
+
+---
+
+## What the Dev Changelog Shows
+
+Every push to `dev` updates a pinned GitHub Issue with:
+
+1. **Branch status** — how many commits `dev` is ahead/behind `main`
+2. **Commit table** — all commits since last merge to main
+3. **Category breakdown** — features, fixes, security, refactors
+4. **File change stats** — which directories/files changed
+5. **Key areas impacted** — grouped by module
+
+This gives you (and Eduardo, and investors looking at GitHub) a real-time view of what's in staging vs production.
+
+---
+
+## Confluence Integration
+
+The Confluence "Version Tracking" page should be updated when:
+1. A new release is created (version tag on main)
+2. Major feature work completes on dev
+
+For now, this is a manual step (update Confluence after each release).
+
+**Future automation option:** Add a Confluence API step to `release.yml` that auto-updates the version tracking page. This requires:
+- Storing `CONFLUENCE_API_TOKEN` as a GitHub Secret
+- Adding an API call step to the release workflow
+
+Template for that step (add when ready):
+
+```yaml
+- name: Update Confluence version tracking
+  run: |
+    curl -X PUT \
+      "https://psycron.atlassian.net/wiki/api/v2/pages/${CONFLUENCE_PAGE_ID}" \
+      -H "Authorization: Basic ${CONFLUENCE_AUTH}" \
+      -H "Content-Type: application/json" \
+      -d '{...}'
+  env:
+    CONFLUENCE_AUTH: ${{ secrets.CONFLUENCE_API_TOKEN }}
+    CONFLUENCE_PAGE_ID: "<page-id-here>"
+```
+
+---
+
+## File Structure
+
+```
+.github/
+└── workflows/
+    ├── dev-changelog.yml    # Dev branch diff generator
+    └── release.yml          # Release & version tagging
+```
+
+Both files go in **both** `psycron-fe` and `psycron-be` repos. Each repo tracks its own version independently:
+
+- `psycron-fe` → `v1.0.0`, `v1.1.0`, ...
+- `psycron-be` → `v1.0.0`, `v1.1.0`, ...
+
+This is standard for separate frontend/backend repos and allows independent deployment cadences.

--- a/.github/workflows/dev-changelog.yml
+++ b/.github/workflows/dev-changelog.yml
@@ -1,0 +1,188 @@
+# .github/workflows/dev-changelog.yml
+# ─────────────────────────────────────────────────────────────
+# Psycron — Dev Branch Changelog Generator
+# ─────────────────────────────────────────────────────────────
+# Runs on every push to `dev`. Generates a diff summary showing
+# all commits and file changes between `main` and `dev`.
+# Posts the summary as a PR comment (if a dev→main PR exists)
+# and updates a pinned GitHub Issue for visibility.
+#
+# Setup: No secrets needed beyond default GITHUB_TOKEN.
+# ─────────────────────────────────────────────────────────────
+
+name: "📋 Dev Changelog"
+
+on:
+  push:
+    branches: [dev]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  changelog:
+    name: Generate dev↔main diff
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate changelog
+        id: diff
+        run: |
+          echo "## 🔀 Dev vs Main — $(date -u '+%Y-%m-%d %H:%M UTC')" > changelog.md
+          echo "" >> changelog.md
+
+          # Count commits ahead
+          AHEAD=$(git rev-list --count main..dev 2>/dev/null || echo "0")
+          BEHIND=$(git rev-list --count dev..main 2>/dev/null || echo "0")
+          echo "**Branch status:** \`dev\` is **${AHEAD} commits ahead**, ${BEHIND} commits behind \`main\`" >> changelog.md
+          echo "" >> changelog.md
+
+          # List commits (grouped by conventional commit type)
+          echo "### Commits since last release" >> changelog.md
+          echo "" >> changelog.md
+          echo "| Hash | Author | Message | Date |" >> changelog.md
+          echo "|------|--------|---------|------|" >> changelog.md
+          git log main..dev --pretty=format="| \`%.7h\` | %an | %s | %ad |" --date=short >> changelog.md
+          echo "" >> changelog.md
+          echo "" >> changelog.md
+
+          # Categorize by conventional commits
+          echo "### Changes by category" >> changelog.md
+          echo "" >> changelog.md
+
+          FEATS=$(git log main..dev --pretty=format:"%s" | grep -c "^feat" || true)
+          FIXES=$(git log main..dev --pretty=format:"%s" | grep -c "^fix" || true)
+          SECS=$(git log main..dev --pretty=format:"%s" | grep -c "^sec" || true)
+          REFACTORS=$(git log main..dev --pretty=format:"%s" | grep -c "^refactor" || true)
+          DOCS=$(git log main..dev --pretty=format:"%s" | grep -c "^docs" || true)
+          CHORES=$(git log main..dev --pretty=format:"%s" | grep -c "^chore" || true)
+
+          echo "| Category | Count |" >> changelog.md
+          echo "|----------|-------|" >> changelog.md
+          echo "| ✨ Features (\`feat\`) | ${FEATS} |" >> changelog.md
+          echo "| 🐛 Fixes (\`fix\`) | ${FIXES} |" >> changelog.md
+          echo "| 🔒 Security (\`sec\`) | ${SECS} |" >> changelog.md
+          echo "| ♻️ Refactors (\`refactor\`) | ${REFACTORS} |" >> changelog.md
+          echo "| 📝 Docs (\`docs\`) | ${DOCS} |" >> changelog.md
+          echo "| 🔧 Chores (\`chore\`) | ${CHORES} |" >> changelog.md
+          echo "" >> changelog.md
+
+          # File change summary
+          echo "### Files changed" >> changelog.md
+          echo "" >> changelog.md
+          echo "\`\`\`" >> changelog.md
+          git diff --stat main..dev >> changelog.md
+          echo "\`\`\`" >> changelog.md
+          echo "" >> changelog.md
+
+          # Key directories impacted
+          echo "### Key areas impacted" >> changelog.md
+          echo "" >> changelog.md
+          git diff --name-only main..dev | sed 's|/[^/]*$||' | sort -u | head -20 | while read dir; do
+            COUNT=$(git diff --name-only main..dev | grep "^${dir}/" | wc -l)
+            echo "- \`${dir}/\` — ${COUNT} files" >> changelog.md
+          done
+          echo "" >> changelog.md
+
+          # Store for next step
+          echo "ahead=${AHEAD}" >> $GITHUB_OUTPUT
+
+      - name: Find or create tracking issue
+        id: issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = '📋 Dev Branch Changelog (Auto-Updated)';
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'changelog',
+              per_page: 1
+            });
+
+            let issueNumber;
+            if (issues.length > 0) {
+              issueNumber = issues[0].number;
+            } else {
+              // Create the tracking issue
+              const { data: newIssue } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                labels: ['changelog'],
+                body: 'This issue is auto-updated by the Dev Changelog workflow.'
+              });
+              issueNumber = newIssue.number;
+              // Pin it
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                state: 'open'
+              });
+            }
+            core.setOutput('number', issueNumber);
+
+      - name: Update tracking issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const changelog = fs.readFileSync('changelog.md', 'utf8');
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.issue.outputs.number }},
+              body: changelog
+            });
+
+      - name: Comment on open dev→main PR (if exists)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const changelog = fs.readFileSync('changelog.md', 'utf8');
+
+            // Find open PRs from dev to main
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:dev`,
+              base: 'main'
+            });
+
+            for (const pr of prs) {
+              // Delete previous bot comment if exists
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100
+              });
+              const botComment = comments.find(c =>
+                c.user.type === 'Bot' && c.body.includes('Dev vs Main')
+              );
+              if (botComment) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: botComment.id
+                });
+              }
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: changelog
+              });
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,199 @@
+# .github/workflows/release.yml
+# ─────────────────────────────────────────────────────────────
+# Psycron — Automated Release & Version Tagging
+# ─────────────────────────────────────────────────────────────
+# Triggers when a PR from `dev` is merged into `main`.
+# Automatically:
+#   1. Determines the next semantic version (based on commits)
+#   2. Creates a Git tag
+#   3. Generates a GitHub Release with categorized changelog
+#   4. Updates package.json version (optional)
+#
+# Version strategy:
+#   - feat(...)  → MINOR bump (0.x.0)
+#   - fix(...)   → PATCH bump (0.0.x)
+#   - BREAKING CHANGE or feat!(...) → MAJOR bump (x.0.0)
+#   - sec(...)   → PATCH bump
+#   - chore/docs → no bump (unless forced)
+#
+# Pre-launch: v0.x.x
+# April 1 launch: v1.0.0 (set manually via workflow_dispatch)
+# ─────────────────────────────────────────────────────────────
+
+name: "🚀 Release & Version Tag"
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version_override:
+        description: "Force a specific version (e.g., 1.0.0 for launch)"
+        required: false
+        type: string
+      release_title:
+        description: "Custom release title (e.g., 'Psycron MVP Launch')"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    # Only run on merged PRs from dev, or manual trigger
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'dev')
+
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get latest tag
+        id: latest_tag
+        run: |
+          LATEST=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "tag=${LATEST}" >> $GITHUB_OUTPUT
+          echo "Latest tag: ${LATEST}"
+
+      - name: Determine next version
+        id: version
+        run: |
+          LATEST="${{ steps.latest_tag.outputs.tag }}"
+          OVERRIDE="${{ inputs.version_override }}"
+
+          if [ -n "${OVERRIDE}" ]; then
+            NEXT="v${OVERRIDE#v}"
+            echo "version=${NEXT}" >> $GITHUB_OUTPUT
+            echo "Forced version: ${NEXT}"
+            exit 0
+          fi
+
+          # Parse current version
+          VERSION="${LATEST#v}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+          # Analyze commits since last tag
+          HAS_BREAKING=$(git log ${LATEST}..HEAD --pretty=format:"%s%n%b" | grep -c "BREAKING CHANGE\|^feat!(" || true)
+          HAS_FEAT=$(git log ${LATEST}..HEAD --pretty=format:"%s" | grep -c "^feat" || true)
+          HAS_FIX=$(git log ${LATEST}..HEAD --pretty=format:"%s" | grep -c "^fix\|^sec" || true)
+
+          if [ "$HAS_BREAKING" -gt 0 ]; then
+            MAJOR=$((MAJOR + 1))
+            MINOR=0
+            PATCH=0
+          elif [ "$HAS_FEAT" -gt 0 ]; then
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          elif [ "$HAS_FIX" -gt 0 ]; then
+            PATCH=$((PATCH + 1))
+          else
+            # Default: patch bump for any merge
+            PATCH=$((PATCH + 1))
+          fi
+
+          NEXT="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "version=${NEXT}" >> $GITHUB_OUTPUT
+          echo "Next version: ${NEXT} (from ${LATEST})"
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          LATEST="${{ steps.latest_tag.outputs.tag }}"
+          NEXT="${{ steps.version.outputs.version }}"
+          CUSTOM_TITLE="${{ inputs.release_title }}"
+
+          if [ -n "${CUSTOM_TITLE}" ]; then
+            TITLE="${CUSTOM_TITLE}"
+          else
+            TITLE="Release ${NEXT}"
+          fi
+
+          cat > release_notes.md << 'HEADER'
+          ## What's Changed
+          HEADER
+
+          # Features
+          FEATS=$(git log ${LATEST}..HEAD --pretty=format:"- %s (\`%.7h\`)" | grep "^- feat" || true)
+          if [ -n "$FEATS" ]; then
+            echo "" >> release_notes.md
+            echo "### ✨ Features" >> release_notes.md
+            echo "$FEATS" >> release_notes.md
+          fi
+
+          # Fixes
+          FIXES=$(git log ${LATEST}..HEAD --pretty=format:"- %s (\`%.7h\`)" | grep "^- fix" || true)
+          if [ -n "$FIXES" ]; then
+            echo "" >> release_notes.md
+            echo "### 🐛 Bug Fixes" >> release_notes.md
+            echo "$FIXES" >> release_notes.md
+          fi
+
+          # Security
+          SECS=$(git log ${LATEST}..HEAD --pretty=format:"- %s (\`%.7h\`)" | grep "^- sec" || true)
+          if [ -n "$SECS" ]; then
+            echo "" >> release_notes.md
+            echo "### 🔒 Security" >> release_notes.md
+            echo "$SECS" >> release_notes.md
+          fi
+
+          # Refactors
+          REFS=$(git log ${LATEST}..HEAD --pretty=format:"- %s (\`%.7h\`)" | grep "^- refactor" || true)
+          if [ -n "$REFS" ]; then
+            echo "" >> release_notes.md
+            echo "### ♻️ Refactors" >> release_notes.md
+            echo "$REFS" >> release_notes.md
+          fi
+
+          # Other
+          OTHERS=$(git log ${LATEST}..HEAD --pretty=format:"- %s (\`%.7h\`)" | grep -v "^- feat\|^- fix\|^- sec\|^- refactor\|^- Merge" || true)
+          if [ -n "$OTHERS" ]; then
+            echo "" >> release_notes.md
+            echo "### 🔧 Other Changes" >> release_notes.md
+            echo "$OTHERS" >> release_notes.md
+          fi
+
+          # Stats
+          echo "" >> release_notes.md
+          echo "---" >> release_notes.md
+          echo "" >> release_notes.md
+          COMMIT_COUNT=$(git rev-list --count ${LATEST}..HEAD)
+          FILE_COUNT=$(git diff --name-only ${LATEST}..HEAD | wc -l)
+          echo "**${COMMIT_COUNT} commits** | **${FILE_COUNT} files changed** | \`${LATEST}\` → \`${NEXT}\`" >> release_notes.md
+
+          echo "title=${TITLE}" >> $GITHUB_OUTPUT
+
+      - name: Create Git tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.version.outputs.version }}"
+
+      - name: Create GitHub Release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const notes = fs.readFileSync('release_notes.md', 'utf8');
+            const version = '${{ steps.version.outputs.version }}';
+            const title = '${{ steps.notes.outputs.title }}';
+
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: version,
+              name: `${title}`,
+              body: notes,
+              draft: false,
+              prerelease: version.startsWith('v0.')
+            });

--- a/src/api/patient/index.ts
+++ b/src/api/patient/index.ts
@@ -10,6 +10,7 @@ import type {
 	IEditPatientDetailsById,
 	IEditPatientDetailsByIdResponse,
 	IPatientByIdResponse,
+	IPublicPatientSessionsResponse,
 } from './index.types';
 
 export const bookAppointmentFromLink = async ({
@@ -44,6 +45,15 @@ export const updatePatientDetailsById = async ({
 		patient
 	);
 
+	return response.data;
+};
+
+export const getPublicPatientSessions = async (
+	patientId: string
+): Promise<IPublicPatientSessionsResponse> => {
+	const response = await apiClient.get<IPublicPatientSessionsResponse>(
+		`/patient/${patientId}/sessions`
+	);
 	return response.data;
 };
 

--- a/src/api/patient/index.types.ts
+++ b/src/api/patient/index.types.ts
@@ -2,6 +2,7 @@ import type {
 	IBookSessionWithLink,
 	IContactInfo,
 	IPatient,
+	ISlotAddress,
 } from '@psycron/context/user/auth/UserAuthenticationContext.types';
 
 import type { IResponse } from '../user/index.types';
@@ -73,6 +74,45 @@ export interface ICreatePatientForm {
 	recurrencePattern?: RecurrencePattern;
 	timeZone?: string;
 	whatsapp?: string;
+}
+
+export interface IPublicSessionSlot {
+	_id: string;
+	address?: ISlotAddress | null;
+	canceledAt?: string | null;
+	endTime: string;
+	letPatientChooseAddress?: boolean;
+	patientId?: string;
+	startTime: string;
+	status: string;
+}
+
+export interface IPublicSessionDate {
+	_id: string;
+	date: string;
+	slots: IPublicSessionSlot[];
+}
+
+export interface IPublicPatientSessionsResponse {
+	patient: {
+		_id: string;
+		cancelledAppointments: Array<{
+			cancelledAt: string;
+			customReason?: string;
+			date: string;
+			endTime: string;
+			reasonCode?: number;
+			slotId: string;
+			startTime: string;
+			triggeredBy: 'PATIENT' | 'THERAPIST';
+		}>;
+		firstName: string;
+		lastName: string;
+		sessionDates: IPublicSessionDate[];
+		therapistId: string;
+		timeZone?: string;
+	};
+	status: string;
 }
 
 export enum RecurrencePattern {

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -1,10 +1,106 @@
 {
+  "public": {
+    "powered-by": "Powered by Psycron"
+  },
+  "booking": {
+    "page": {
+      "title": "Book a Session"
+    },
+    "filter": {
+      "from": "From",
+      "label-date-range": "Date range",
+      "label-time-of-day": "Time of day",
+      "time-all": "Any time",
+      "time-morning": "Morning (before noon)",
+      "time-afternoon": "Afternoon (12–17h)",
+      "time-evening": "Evening (after 17h)",
+      "time-of-day": "Time of day",
+      "to": "To",
+      "weeks-1": "Next week",
+      "weeks-2": "Next 2 weeks",
+      "weeks-4": "Next month",
+      "weeks-12": "Next 3 months",
+      "weeks-all": "All available"
+    },
+    "slot": {
+      "booked": "Booked",
+      "taken": "Taken"
+    },
+    "drawer": {
+      "aria-label": "Book appointment",
+      "title": "Confirm your booking"
+    },
+    "confirm": "Confirm",
+    "error": "Something went wrong. Please try again.",
+    "no-slots": "No available slots match your filters.",
+    "form": {
+      "address-fallback": "Address will appear here after you enter it above.",
+      "email": "Email",
+      "first-name": "First name",
+      "last-name": "Last name",
+      "notify-email": "Notify me by email",
+      "notify-fallback": "Provide your contact details above to enable notifications.",
+      "notify-whatsapp": "Notify me by WhatsApp",
+      "section-notifications": "Notifications",
+      "section-personal": "Your details",
+      "section-recurrence": "Recurrence",
+      "your-address": "Session address"
+    },
+    "notifications": {
+      "description": "We'll send you a reminder before each session.",
+      "email": "Notify me by email",
+      "fallback-note": "Add your contact details above to enable reminders.",
+      "title": "Reminders",
+      "whatsapp": "Notify me by WhatsApp"
+    },
+    "recurrence": {
+      "biweekly": "Every 2 weeks",
+      "monthly": "Every month",
+      "not-yet": "Not yet — decide later",
+      "single": "One-time session",
+      "title": "How often would you like to meet?",
+      "weekly": "Every week"
+    },
+    "confirmation": {
+      "title": "You're booked!",
+      "subtitle": "Great, {{name}}! Your session has been confirmed.",
+      "date": "Date",
+      "time": "Time",
+      "your-agenda": "Your personal agenda",
+      "agenda-description": "Use this link to view and manage your upcoming appointments.",
+      "copy-link": "Copy link"
+    },
+    "appointments": {
+      "title": "Your appointments",
+      "subtitle": "View and manage your scheduled sessions.",
+      "upcoming": "Upcoming",
+      "past": "Past",
+      "no-upcoming": "You have no upcoming appointments."
+    },
+    "cancel": {
+      "button": "Cancel appointment",
+      "reason-prompt": "Please let us know why you need to cancel.",
+      "reason-label": "Reason",
+      "reason": {
+        "emergency": "Personal emergency",
+        "schedule-conflict": "Schedule conflict",
+        "financial": "Financial reasons",
+        "mental-health": "Not feeling ready",
+        "other": "Other"
+      },
+      "custom-reason": "Tell us more (optional)",
+      "confirm": "Confirm cancellation",
+      "success": "Your appointment has been cancelled.",
+      "error": "Something went wrong. Please try again."
+    }
+  },
   "common": {
     "close": "Close",
     "today": "Today",
     "save": "Save",
     "saving": "Saving...",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "loading": "Loading..."
   },
   "auth": {
     "error": {

--- a/src/assets/locales/pt/translation.json
+++ b/src/assets/locales/pt/translation.json
@@ -1,10 +1,106 @@
 {
+  "public": {
+    "powered-by": "Desenvolvido por Psycron"
+  },
+  "booking": {
+    "page": {
+      "title": "Agendar Sessão"
+    },
+    "filter": {
+      "from": "De",
+      "label-date-range": "Período",
+      "label-time-of-day": "Período do dia",
+      "time-all": "Qualquer horário",
+      "time-morning": "Manhã (antes do meio-dia)",
+      "time-afternoon": "Tarde (12–17h)",
+      "time-evening": "Noite (após 17h)",
+      "time-of-day": "Período do dia",
+      "to": "Até",
+      "weeks-1": "Próxima semana",
+      "weeks-2": "Próximas 2 semanas",
+      "weeks-4": "Próximo mês",
+      "weeks-12": "Próximos 3 meses",
+      "weeks-all": "Todos disponíveis"
+    },
+    "slot": {
+      "booked": "Reservado",
+      "taken": "Ocupado"
+    },
+    "drawer": {
+      "aria-label": "Agendar consulta",
+      "title": "Confirmar agendamento"
+    },
+    "confirm": "Confirmar",
+    "error": "Algo deu errado. Por favor, tente novamente.",
+    "no-slots": "Nenhum horário disponível corresponde aos seus filtros.",
+    "form": {
+      "address-fallback": "O endereço aparecerá aqui após você preenchê-lo acima.",
+      "email": "E-mail",
+      "first-name": "Nome",
+      "last-name": "Sobrenome",
+      "notify-email": "Notificar por e-mail",
+      "notify-fallback": "Preencha seus dados de contato acima para ativar as notificações.",
+      "notify-whatsapp": "Notificar por WhatsApp",
+      "section-notifications": "Notificações",
+      "section-personal": "Seus dados",
+      "section-recurrence": "Recorrência",
+      "your-address": "Endereço da sessão"
+    },
+    "notifications": {
+      "description": "Enviaremos um lembrete antes de cada sessão.",
+      "email": "Notificar por e-mail",
+      "fallback-note": "Adicione seus dados de contato acima para ativar os lembretes.",
+      "title": "Lembretes",
+      "whatsapp": "Notificar por WhatsApp"
+    },
+    "recurrence": {
+      "biweekly": "A cada 2 semanas",
+      "monthly": "Todo mês",
+      "not-yet": "Ainda não — decidir depois",
+      "single": "Sessão única",
+      "title": "Com que frequência você gostaria de se encontrar?",
+      "weekly": "Toda semana"
+    },
+    "confirmation": {
+      "title": "Agendamento confirmado!",
+      "subtitle": "Ótimo, {{name}}! Sua sessão foi confirmada.",
+      "date": "Data",
+      "time": "Horário",
+      "your-agenda": "Sua agenda pessoal",
+      "agenda-description": "Use este link para ver e gerenciar seus próximos agendamentos.",
+      "copy-link": "Copiar link"
+    },
+    "appointments": {
+      "title": "Seus agendamentos",
+      "subtitle": "Veja e gerencie suas sessões agendadas.",
+      "upcoming": "Próximas",
+      "past": "Anteriores",
+      "no-upcoming": "Você não possui agendamentos futuros."
+    },
+    "cancel": {
+      "button": "Cancelar agendamento",
+      "reason-prompt": "Por favor, informe o motivo do cancelamento.",
+      "reason-label": "Motivo",
+      "reason": {
+        "emergency": "Emergência pessoal",
+        "schedule-conflict": "Conflito de agenda",
+        "financial": "Motivos financeiros",
+        "mental-health": "Não me sinto pronto(a)",
+        "other": "Outro"
+      },
+      "custom-reason": "Conte mais (opcional)",
+      "confirm": "Confirmar cancelamento",
+      "success": "Seu agendamento foi cancelado.",
+      "error": "Algo deu errado. Por favor, tente novamente."
+    }
+  },
   "common": {
     "close": "Fechar",
     "today": "Hoje",
     "save": "Salvar",
     "saving": "Salvando...",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "loading": "Carregando..."
   },
   "auth": {
     "error": {

--- a/src/context/user/auth/UserAuthenticationContext.types.ts
+++ b/src/context/user/auth/UserAuthenticationContext.types.ts
@@ -186,7 +186,11 @@ export interface IPatient extends IBaseUser {
 
 export interface IBookSessionWithLink {
 	availabilityDayId: string;
+	notifyByEmail?: boolean;
+	notifyByWhatsapp?: boolean;
 	patient: Partial<IPatient>;
+	patientAddress?: ISlotAddress;
+	recurrencePattern?: string;
 	shareAddress?: boolean;
 	shouldReplicate?: boolean;
 	slotId: string;

--- a/src/layouts/public-booking/PublicBookingShell.styles.tsx
+++ b/src/layouts/public-booking/PublicBookingShell.styles.tsx
@@ -1,0 +1,69 @@
+import styled from '@emotion/styled';
+import { Box } from '@mui/material';
+import { isMobileMedia } from '@psycron/theme/media-queries/mediaQueries';
+import { palette } from '@psycron/theme/palette/palette.theme';
+import { shadowSmall } from '@psycron/theme/shadow/shadow.theme';
+import { spacing } from '@psycron/theme/spacing/spacing.theme';
+import { zIndexHover } from '@psycron/theme/zIndex';
+
+// spacing.medium (24px top offset) + padding xs*2 (16px) + logo height (50px)
+export const PUBLIC_TOP_BAR_BOTTOM = '110px';
+
+export const ShellWrapper = styled(Box)`
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
+	padding: 0 ${spacing.medium};
+	margin-top: ${spacing.medium};
+
+	${isMobileMedia} {
+		padding: 0 ${spacing.xs};
+	}
+`;
+
+export const TopBar = styled(Box)`
+	align-items: center;
+
+	display: flex;
+
+	backdrop-filter: blur(10px);
+	border: 2px solid rgba(233, 214, 255, 0.1);
+
+	border-radius: ${spacing.mediumSmall};
+	justify-content: space-between;
+	padding: ${spacing.xs} ${spacing.medium};
+	position: sticky;
+	top: ${spacing.medium};
+	z-index: ${zIndexHover};
+	box-shadow: ${shadowSmall};
+`;
+
+export const LogoMark = styled(Box)`
+	align-items: center;
+	display: flex;
+	gap: ${spacing.xs};
+
+	& > svg {
+		height: 3.125rem;
+		width: auto;
+	}
+`;
+
+export const Content = styled(Box)`
+	flex: 1;
+`;
+
+export const FooterBar = styled(Box)`
+	align-items: center;
+	border-top: 1px solid ${palette.gray['01']};
+	display: flex;
+	justify-content: center;
+	gap: ${spacing.xs};
+	padding: ${spacing.small} ${spacing.medium};
+
+	& > svg {
+		height: 20px;
+		width: auto;
+	}
+`;

--- a/src/layouts/public-booking/PublicBookingShell.tsx
+++ b/src/layouts/public-booking/PublicBookingShell.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Divider } from '@psycron/components/divider/Divider';
+import { LogoColor } from '@psycron/components/icons/brand/LogoColor';
+import { Localization } from '@psycron/components/localization/Localization';
+import { Text } from '@psycron/components/text/Text';
+
+import {
+	Content,
+	FooterBar,
+	LogoMark,
+	ShellWrapper,
+	TopBar,
+} from './PublicBookingShell.styles';
+
+interface IPublicBookingShellProps {
+	children: ReactNode;
+}
+
+export const PublicBookingShell = ({ children }: IPublicBookingShellProps) => {
+	const { t } = useTranslation();
+
+	return (
+		<ShellWrapper>
+			<TopBar>
+				<LogoMark>
+					<LogoColor />
+					<Text
+						color='text.primary'
+						fontWeight={700}
+						variant='body1'
+						fontSize={'1.4rem'}
+					>
+						Psycron
+					</Text>
+				</LogoMark>
+				<Localization />
+			</TopBar>
+
+			<Content>{children}</Content>
+
+			<Divider />
+			<FooterBar>
+				<LogoColor />
+				<Text color='text.disabled' variant='caption'>
+					{t('public.powered-by')}
+				</Text>
+			</FooterBar>
+		</ShellWrapper>
+	);
+};

--- a/src/pages/availability/week/drawer/AvailabilityWeekDrawer.tsx
+++ b/src/pages/availability/week/drawer/AvailabilityWeekDrawer.tsx
@@ -354,9 +354,7 @@ export const AvailabilityWeekDrawer = ({
 									icon: <MapPin color={palette.brand.purple} />,
 									key: 'appointment-address',
 									label: t('availability.week.drawer.appointment-address'),
-									value: t(
-										'availability.week.drawer.patient-provides-address'
-									),
+									value: t('availability.week.drawer.patient-provides-address'),
 								},
 							]
 						: []),

--- a/src/pages/user/appointment/booking/BookAppointment.styles.tsx
+++ b/src/pages/user/appointment/booking/BookAppointment.styles.tsx
@@ -1,0 +1,155 @@
+import styled from '@emotion/styled';
+import { Box, Chip, TextField } from '@mui/material';
+import { PUBLIC_TOP_BAR_BOTTOM } from '@psycron/layouts/public-booking/PublicBookingShell.styles';
+import {
+	isBiggerThanTabletMedia,
+	isSmallerThanTabletMedia,
+} from '@psycron/theme/media-queries/mediaQueries';
+import { palette } from '@psycron/theme/palette/palette.theme';
+import { spacing } from '@psycron/theme/spacing/spacing.theme';
+import { zIndexSticky } from '@psycron/theme/zIndex';
+
+export const PageWrapper = styled(Box)`
+	max-width: 800px;
+	margin: 0 auto;
+	padding: ${spacing.medium} ${spacing.small};
+`;
+
+export const FiltersRow = styled(Box)`
+	display: flex;
+	flex-wrap: wrap;
+	gap: ${spacing.small};
+	margin-bottom: ${spacing.mediumSmall};
+	justify-content: center;
+
+	${isSmallerThanTabletMedia} {
+		gap: 0;
+		flex-direction: row;
+		justify-content: space-between;
+	}
+`;
+
+export const Datepiker = styled(TextField)`
+	width: 150px;
+
+	${isBiggerThanTabletMedia} {
+		width: auto;
+	}
+`;
+
+export const FilterTimeRow = styled(Box)`
+	display: flex;
+	flex-wrap: wrap;
+	gap: ${spacing.xs};
+	margin-bottom: ${spacing.medium};
+`;
+
+export const TimeFilterChip = styled(Box, {
+	shouldForwardProp: (prop) => prop !== 'isActive',
+})<{ isActive: boolean }>`
+	background: ${({ isActive }) =>
+		isActive ? palette.primary.main : palette.white};
+	border: 1.5px solid
+		${({ isActive }) => (isActive ? palette.primary.main : palette.gray['02'])};
+	border-radius: 20px;
+	color: ${({ isActive }) =>
+		isActive ? palette.primary.dark : palette.text.secondary};
+	cursor: pointer;
+	font-size: 0.8125rem;
+	font-weight: ${({ isActive }) => (isActive ? 600 : 400)};
+	padding: ${spacing.xxs} ${spacing.extraSmall};
+	transition:
+		background 0.15s,
+		border-color 0.15s,
+		color 0.15s;
+	user-select: none;
+
+	&:hover {
+		border-color: ${palette.primary.main};
+		color: ${palette.primary.dark};
+	}
+`;
+
+export const DaySection = styled(Box)`
+	margin-bottom: ${spacing.medium};
+	position: relative;
+`;
+
+export const DayLabel = styled(Box)`
+	height: 50px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: ${palette.background.default};
+	color: ${palette.brand.dark};
+	font-size: 1rem;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	margin-bottom: ${spacing.xs};
+	padding: ${spacing.xxs} 0;
+	position: sticky;
+	text-transform: uppercase;
+	top: ${PUBLIC_TOP_BAR_BOTTOM};
+	z-index: ${zIndexSticky};
+`;
+
+export const SlotsRow = styled(Box)`
+	display: flex;
+	flex-wrap: wrap;
+	gap: ${spacing.xs};
+	justify-content: center;
+`;
+
+export const SlotChip = styled(Chip, {
+	shouldForwardProp: (prop) => prop !== 'isBooked',
+})<{ isBooked?: boolean }>`
+	background: ${({ isBooked }) =>
+		isBooked ? palette.gray['01'] : palette.white};
+	border: 1.5px solid
+		${({ isBooked }) => (isBooked ? 'transparent' : palette.primary.main)};
+	border-radius: 20px;
+	color: ${({ isBooked }) =>
+		isBooked ? palette.text.disabled : palette.primary.dark};
+	cursor: ${({ isBooked }) => (isBooked ? 'not-allowed' : 'pointer')};
+	font-size: 0.875rem;
+	font-weight: 500;
+	height: 40px;
+	opacity: ${({ isBooked }) => (isBooked ? 0.55 : 1)};
+	text-decoration: ${({ isBooked }) => (isBooked ? 'line-through' : 'none')};
+	transition:
+		background 0.12s,
+		box-shadow 0.12s;
+
+	&:hover {
+		background: ${({ isBooked }) =>
+			isBooked ? palette.gray['01'] : palette.primary.light};
+		box-shadow: ${({ isBooked }) =>
+			isBooked ? 'none' : '0 0 0 3px rgba(169,222,249,0.35)'};
+	}
+
+	.MuiChip-label {
+		padding: 0 ${spacing.extraSmall};
+	}
+`;
+
+export const EmptyState = styled(Box)`
+	align-items: center;
+	border: 1px dashed ${palette.gray['02']};
+	border-radius: 12px;
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.xs};
+	padding: ${spacing.largeXl} ${spacing.small};
+	text-align: center;
+`;
+
+export const SkeletonDay = styled(Box)`
+	margin-bottom: ${spacing.medium};
+`;
+
+export const SkeletonRow = styled(Box)`
+	display: flex;
+	flex-wrap: wrap;
+	gap: ${spacing.xs};
+	margin-top: ${spacing.xs};
+`;

--- a/src/pages/user/appointment/booking/BookAppointment.tsx
+++ b/src/pages/user/appointment/booking/BookAppointment.tsx
@@ -1,0 +1,347 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Skeleton } from '@mui/material';
+import { bookAppointmentFromLink } from '@psycron/api/patient';
+import { getAvailabilityCalendar, getUserById } from '@psycron/api/user';
+import { Button } from '@psycron/components/button/Button';
+import { Drawer } from '@psycron/components/drawer/Drawer';
+import { Text } from '@psycron/components/text/Text';
+import { useAlert } from '@psycron/context/alert/AlertContext';
+import { PublicBookingShell } from '@psycron/layouts/public-booking/PublicBookingShell';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { addWeeks, format, isAfter, parseISO, startOfDay } from 'date-fns';
+
+import { PublicBookingForm } from './components/PublicBookingForm';
+import { TherapistCard } from './components/TherapistCard';
+import {
+	Datepiker,
+	DayLabel,
+	DaySection,
+	EmptyState,
+	FiltersRow,
+	FilterTimeRow,
+	PageWrapper,
+	SkeletonDay,
+	SkeletonRow,
+	SlotChip,
+	SlotsRow,
+	TimeFilterChip,
+} from './BookAppointment.styles';
+import type {
+	IBookingFilters,
+	IBookingFormValues,
+	IPublicSlot,
+	TimeOfDay,
+} from './BookAppointment.types';
+
+const TIME_OF_DAY_OPTIONS: { label: string; value: TimeOfDay }[] = [
+	{ label: 'booking.filter.time-all', value: 'all' },
+	{ label: 'booking.filter.time-morning', value: 'morning' },
+	{ label: 'booking.filter.time-afternoon', value: 'afternoon' },
+	{ label: 'booking.filter.time-evening', value: 'evening' },
+];
+
+const matchesTimeOfDay = (startTime: string, tod: TimeOfDay): boolean => {
+	if (tod === 'all') return true;
+	const [h] = startTime.split(':').map(Number);
+	if (tod === 'morning') return h < 12;
+	if (tod === 'afternoon') return h >= 12 && h < 17;
+	return h >= 17;
+};
+
+export const BookAppointment = () => {
+	const { t } = useTranslation();
+	const { userId: therapistId } = useParams<{ userId: string }>();
+	const navigate = useNavigate();
+	const { showAlert } = useAlert();
+
+	const today = startOfDay(new Date());
+	const defaultTo = format(addWeeks(today, 4), 'yyyy-MM-dd');
+	const defaultFrom = format(today, 'yyyy-MM-dd');
+
+	const [filters, setFilters] = useState<IBookingFilters>({
+		dateFrom: defaultFrom,
+		dateTo: defaultTo,
+		timeOfDay: 'all',
+	});
+	const [selectedSlot, setSelectedSlot] = useState<IPublicSlot | null>(null);
+
+	const methods = useForm<IBookingFormValues>({
+		defaultValues: {
+			countryCode: '',
+			email: '',
+			firstName: '',
+			lastName: '',
+			notifyByEmail: true,
+			notifyByWhatsapp: true,
+			phone: '',
+			recurrencePattern: 'SINGLE',
+		},
+		mode: 'onChange',
+	});
+
+	const { data, isLoading } = useQuery({
+		enabled: Boolean(therapistId),
+		queryFn: () => getAvailabilityCalendar(therapistId ?? ''),
+		queryKey: ['publicAvailability', therapistId],
+	});
+
+	const { data: therapist } = useQuery({
+		enabled: Boolean(therapistId),
+		queryFn: () => getUserById(therapistId ?? ''),
+		queryKey: ['publicTherapist', therapistId],
+	});
+
+	const slots = useMemo<IPublicSlot[]>(() => {
+		if (!data?.dates) return [];
+		const fromDate = parseISO(filters.dateFrom);
+		const toDate = parseISO(filters.dateTo);
+
+		return data.dates
+			.filter((d) => {
+				const date = parseISO(d.date);
+				return (
+					isAfter(date, today) &&
+					!isAfter(fromDate, date) &&
+					!isAfter(date, toDate)
+				);
+			})
+			.flatMap((d) =>
+				(d.slots ?? [])
+					.filter(
+						(s) =>
+							(s.status === 'AVAILABLE' || s.status === 'BOOKED') &&
+							matchesTimeOfDay(s.startTime, filters.timeOfDay)
+					)
+					.map(
+						(s): IPublicSlot => ({
+							availabilityDayId: String(d.dateId),
+							date: d.date,
+							endTime: s.endTime,
+							isBooked: s.status === 'BOOKED',
+							letPatientChooseAddress: s.letPatientChooseAddress ?? false,
+							slotId: s._id,
+							startTime: s.startTime,
+						})
+					)
+			);
+	}, [data, filters, today]);
+
+	const slotsByDay = useMemo(() => {
+		const map = new Map<string, IPublicSlot[]>();
+		for (const slot of slots) {
+			const day = slot.date.slice(0, 10);
+			if (!map.has(day)) map.set(day, []);
+			map.get(day)!.push(slot);
+		}
+		return map;
+	}, [slots]);
+
+	const bookingMutation = useMutation({
+		mutationFn: (values: IBookingFormValues) => {
+			if (!therapistId || !selectedSlot) throw new Error('Missing context');
+			const {
+				address,
+				countryCode,
+				email,
+				firstName,
+				lastName,
+				phone,
+				recurrencePattern,
+				whatsapp,
+			} = values;
+			const fullPhone = countryCode ? `${countryCode}${phone}` : phone;
+			const fullWhatsapp = whatsapp
+				? countryCode
+					? `${countryCode}${whatsapp}`
+					: whatsapp
+				: undefined;
+
+			return bookAppointmentFromLink({
+				therapistId,
+				data: {
+					availabilityDayId: selectedSlot.availabilityDayId,
+					...(address ? { patientAddress: address } : {}),
+					patient: {
+						contacts: {
+							email,
+							phone: fullPhone,
+							...(fullWhatsapp ? { whatsapp: fullWhatsapp } : {}),
+						},
+						firstName,
+						lastName,
+					},
+					recurrencePattern,
+					shouldReplicate:
+						recurrencePattern !== 'SINGLE' && recurrencePattern !== 'NOT_YET',
+					slotId: selectedSlot.slotId,
+					timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+				},
+			});
+		},
+		onError: () => {
+			showAlert({ message: t('booking.error'), severity: 'error' });
+		},
+		onSuccess: (res) => {
+			const patientId = res.patient._id;
+			navigate(`../${therapistId}/${patientId}/appointment-confirmation`, {
+				replace: true,
+			});
+		},
+	});
+
+	const handleSlotClick = useCallback((slot: IPublicSlot) => {
+		if (slot.isBooked) return;
+		setSelectedSlot(slot);
+	}, []);
+
+	const handleClose = useCallback(() => {
+		setSelectedSlot(null);
+		methods.reset();
+	}, [methods]);
+
+	const handleSubmit = methods.handleSubmit((values) => {
+		bookingMutation.mutate(values);
+	});
+
+	if (isLoading) {
+		return (
+			<PublicBookingShell>
+				<PageWrapper>
+				<Skeleton
+					height={80}
+					sx={{ borderRadius: '14px', mb: 3 }}
+					variant='rectangular'
+				/>
+				<SkeletonDay>
+					<Skeleton height={18} variant='text' width={140} />
+					<SkeletonRow>
+						{Array.from({ length: 6 }).map((_, i) => (
+							<Skeleton
+								height={36}
+								key={i}
+								sx={{ borderRadius: '20px' }}
+								variant='rectangular'
+								width={68}
+							/>
+						))}
+					</SkeletonRow>
+				</SkeletonDay>
+				<SkeletonDay>
+					<Skeleton height={18} variant='text' width={120} />
+					<SkeletonRow>
+						{Array.from({ length: 8 }).map((_, i) => (
+							<Skeleton
+								height={36}
+								key={i}
+								sx={{ borderRadius: '20px' }}
+								variant='rectangular'
+								width={68}
+							/>
+						))}
+					</SkeletonRow>
+				</SkeletonDay>
+				</PageWrapper>
+			</PublicBookingShell>
+		);
+	}
+
+	return (
+		<PublicBookingShell>
+			<PageWrapper>
+			{therapist && <TherapistCard therapist={therapist} />}
+			<Text mb={3} variant='h4' fontWeight={600}>
+				{t('booking.page.title')}
+			</Text>
+			<FiltersRow>
+				<Datepiker
+					InputLabelProps={{ shrink: true }}
+					inputProps={{ min: defaultFrom }}
+					label={t('booking.filter.from')}
+					onChange={(e) =>
+						setFilters((f) => ({ ...f, dateFrom: e.target.value }))
+					}
+					size='small'
+					type='date'
+					value={filters.dateFrom}
+				/>
+				<Datepiker
+					InputLabelProps={{ shrink: true }}
+					inputProps={{ min: filters.dateFrom }}
+					label={t('booking.filter.to')}
+					onChange={(e) =>
+						setFilters((f) => ({ ...f, dateTo: e.target.value }))
+					}
+					size='small'
+					type='date'
+					value={filters.dateTo}
+				/>
+			</FiltersRow>
+
+			<FilterTimeRow>
+				{TIME_OF_DAY_OPTIONS.map(({ label, value }) => (
+					<TimeFilterChip
+						isActive={filters.timeOfDay === value}
+						key={value}
+						onClick={() => setFilters((f) => ({ ...f, timeOfDay: value }))}
+					>
+						{t(label)}
+					</TimeFilterChip>
+				))}
+			</FilterTimeRow>
+
+			{slotsByDay.size === 0 ? (
+				<EmptyState>
+					<Text color='text.secondary' variant='body2'>
+						{t('booking.no-slots')}
+					</Text>
+				</EmptyState>
+			) : (
+				Array.from(slotsByDay.entries()).map(([day, daySlots]) => (
+					<DaySection key={day}>
+						<DayLabel>{format(parseISO(day), 'EEEE, MMMM d')}</DayLabel>
+						<SlotsRow>
+							{daySlots.map((slot) => (
+								<SlotChip
+									isBooked={slot.isBooked}
+									key={slot.slotId}
+									label={
+										slot.isBooked ? t('booking.slot.taken') : slot.startTime
+									}
+									onClick={() => handleSlotClick(slot)}
+								/>
+							))}
+						</SlotsRow>
+					</DaySection>
+				))
+			)}
+
+			{selectedSlot && (
+				<Drawer
+					actions={
+						<Button
+							disabled={bookingMutation.isPending}
+							onClick={handleSubmit}
+							variant='contained'
+						>
+							{t('booking.confirm')}
+						</Button>
+					}
+					ariaLabel={t('booking.drawer.aria-label')}
+					onClose={handleClose}
+					title={`${selectedSlot.startTime} · ${format(parseISO(selectedSlot.date), 'MMM d')}`}
+				>
+					<PublicBookingForm
+						letPatientChooseAddress={
+							selectedSlot.letPatientChooseAddress ?? false
+						}
+						methods={methods}
+					/>
+				</Drawer>
+			)}
+		</PageWrapper>
+		</PublicBookingShell>
+	);
+};

--- a/src/pages/user/appointment/booking/BookAppointment.types.ts
+++ b/src/pages/user/appointment/booking/BookAppointment.types.ts
@@ -1,0 +1,34 @@
+import type { ISlotAddress } from '@psycron/context/user/auth/UserAuthenticationContext.types';
+
+export type TimeOfDay = 'all' | 'morning' | 'afternoon' | 'evening';
+
+export interface IPublicSlot {
+	availabilityDayId: string;
+	date: string;
+	endTime: string;
+	isBooked: boolean;
+	letPatientChooseAddress?: boolean;
+	slotId: string;
+	startTime: string;
+}
+
+export interface IBookingFilters {
+	dateFrom: string;
+	dateTo: string;
+	timeOfDay: TimeOfDay;
+}
+
+export interface IBookingFormValues {
+	address?: ISlotAddress;
+	countryCode: string;
+	email: string;
+	firstName: string;
+	hasWhatsApp?: boolean;
+	isPhoneWpp?: boolean;
+	lastName: string;
+	notifyByEmail: boolean;
+	notifyByWhatsapp: boolean;
+	phone: string;
+	recurrencePattern: string;
+	whatsapp?: string;
+}

--- a/src/pages/user/appointment/booking/components/PublicBookingForm.styles.tsx
+++ b/src/pages/user/appointment/booking/components/PublicBookingForm.styles.tsx
@@ -1,0 +1,63 @@
+import styled from '@emotion/styled';
+import { Box } from '@mui/material';
+import { palette } from '@psycron/theme/palette/palette.theme';
+import { shadowPress, shadowSmall } from '@psycron/theme/shadow/shadow.theme';
+import { spacing } from '@psycron/theme/spacing/spacing.theme';
+
+export const FormSection = styled(Box)`
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.mediumSmall};
+`;
+
+export const SectionTitle = styled(Box)`
+	color: ${palette.text.secondary};
+	font-size: 0.875rem;
+	font-weight: 600;
+	letter-spacing: 0.05em;
+	margin-bottom: ${spacing.xs};
+	text-transform: uppercase;
+`;
+
+export const RecurrenceOption = styled(Box, {
+	shouldForwardProp: (prop) => prop !== 'isSelected',
+})<{ isSelected: boolean }>`
+	align-items: center;
+	border: 1.5px solid
+		${({ isSelected }) =>
+			isSelected ? palette.brand.purple : palette.gray['02']};
+	border-radius: ${spacing.small};
+	cursor: pointer;
+	display: flex;
+	gap: ${spacing.extraSmall};
+	padding: ${spacing.extraSmall} ${spacing.small};
+	transition: border-color 0.15s;
+
+	box-shadow: ${({ isSelected }) => (isSelected ? shadowSmall : shadowPress)};
+	background-color: ${({ isSelected }) =>
+		isSelected ? palette.brand.light : palette.background.paper};
+
+	&:hover {
+		border-color: ${palette.brand.dark};
+		box-shadow: ${({ isSelected }) =>
+			!isSelected ? shadowSmall : shadowPress};
+
+		background-color: ${({ isSelected }) =>
+			isSelected ? palette.brand.dark : palette.brand.light};
+		color: ${({ isSelected }) =>
+			isSelected ? palette.white : palette.text.primary};
+	}
+`;
+
+export const NotifyBox = styled(Box)`
+	background: ${palette.gray['01']};
+	border-radius: ${spacing.small};
+	padding: ${spacing.small};
+	box-shadow: ${shadowSmall};
+`;
+
+export const NotifyCheckboxWrapper = styled(Box)`
+	display: flex;
+	flex-direction: column;
+	padding-left: ${spacing.small};
+`;

--- a/src/pages/user/appointment/booking/components/PublicBookingForm.tsx
+++ b/src/pages/user/appointment/booking/components/PublicBookingForm.tsx
@@ -1,0 +1,152 @@
+import { Controller, FormProvider } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { Checkbox, FormControlLabel, Radio } from '@mui/material';
+import { Divider } from '@psycron/components/divider/Divider';
+import { AddressForm } from '@psycron/components/form/components/address/AddressForm';
+import { ContactsForm } from '@psycron/components/form/components/contacts/ContactsForm';
+import { NameForm } from '@psycron/components/form/components/name/NameForm';
+import { Text } from '@psycron/components/text/Text';
+
+import type { IBookingFormValues } from '../BookAppointment.types';
+
+import {
+	FormSection,
+	NotifyBox,
+	NotifyCheckboxWrapper,
+	RecurrenceOption,
+	SectionTitle,
+} from './PublicBookingForm.styles';
+import type { IPublicBookingFormProps } from './PublicBookingForm.types';
+
+const RECURRENCE_OPTIONS = [
+	{ label: 'booking.recurrence.single', value: 'SINGLE' },
+	{ label: 'booking.recurrence.weekly', value: 'WEEKLY' },
+	{ label: 'booking.recurrence.biweekly', value: 'BIWEEKLY' },
+	{ label: 'booking.recurrence.monthly', value: 'MONTHLY' },
+	{ label: 'booking.recurrence.not-yet', value: 'NOT_YET' },
+] as const;
+
+export const PublicBookingForm = ({
+	letPatientChooseAddress,
+	methods,
+}: IPublicBookingFormProps) => {
+	const { t } = useTranslation();
+	const { control, watch } = methods;
+	const recurrence = watch('recurrencePattern');
+
+	return (
+		<FormProvider {...methods}>
+			<FormSection>
+				<NameForm<IBookingFormValues>
+					required
+					fields={{ firstName: 'firstName', lastName: 'lastName' }}
+					labelFirstName={t('booking.form.first-name')}
+					labelLastName={t('booking.form.last-name')}
+					placeholderFirstName={t('booking.form.first-name')}
+					placeholderLastName={t('booking.form.last-name')}
+				/>
+
+				<ContactsForm<IBookingFormValues>
+					atLeastOneContact
+					fullWidth
+					fields={{
+						email: 'email',
+						hasWhatsApp: 'hasWhatsApp',
+						isPhoneWpp: 'isPhoneWpp',
+						phone: 'phone',
+						whatsapp: 'whatsapp',
+					}}
+					labelEmail={t('booking.form.email')}
+					placeholderEmail={t('booking.form.email')}
+				/>
+
+				{letPatientChooseAddress && (
+					<>
+						<Divider />
+						<SectionTitle>{t('booking.form.your-address')}</SectionTitle>
+						<AddressForm<IBookingFormValues>
+							fields={{
+								city: 'address.city',
+								country: 'address.country',
+								postcode: 'address.postcode',
+								street: 'address.street',
+							}}
+							showGoogleAddressSearch
+						/>
+					</>
+				)}
+
+				<Divider />
+
+				<SectionTitle>{t('booking.recurrence.title')}</SectionTitle>
+				<Controller
+					control={control}
+					name='recurrencePattern'
+					render={({ field }) => (
+						<>
+							{RECURRENCE_OPTIONS.map(({ label, value }) => (
+								<RecurrenceOption
+									isSelected={recurrence === value}
+									key={value}
+									onClick={() => field.onChange(value)}
+								>
+									<Radio
+										checked={recurrence === value}
+										onChange={() => field.onChange(value)}
+										size='small'
+										value={value}
+									/>
+									<Text variant='body2'>{t(label)}</Text>
+								</RecurrenceOption>
+							))}
+						</>
+					)}
+				/>
+
+				<Divider />
+
+				<NotifyBox>
+					<SectionTitle>{t('booking.notifications.title')}</SectionTitle>
+					<Text color='text.secondary' mb={2} variant='body2'>
+						{t('booking.notifications.description')}
+					</Text>
+					<NotifyCheckboxWrapper>
+						<Controller
+							control={control}
+							name='notifyByEmail'
+							render={({ field }) => (
+								<FormControlLabel
+									control={
+										<Checkbox
+											checked={field.value}
+											onChange={(e) => field.onChange(e.target.checked)}
+										/>
+									}
+									label={t('booking.notifications.email')}
+								/>
+							)}
+						/>
+						<Controller
+							control={control}
+							name='notifyByWhatsapp'
+							render={({ field }) => (
+								<FormControlLabel
+									control={
+										<Checkbox
+											checked={field.value}
+											onChange={(e) => field.onChange(e.target.checked)}
+										/>
+									}
+									label={t('booking.notifications.whatsapp')}
+								/>
+							)}
+						/>
+					</NotifyCheckboxWrapper>
+					<Text color='text.secondary' mt={1} variant='caption'>
+						{t('booking.notifications.fallback-note')}
+					</Text>
+				</NotifyBox>
+			</FormSection>
+		</FormProvider>
+	);
+};

--- a/src/pages/user/appointment/booking/components/PublicBookingForm.types.ts
+++ b/src/pages/user/appointment/booking/components/PublicBookingForm.types.ts
@@ -1,0 +1,8 @@
+import type { UseFormReturn } from 'react-hook-form';
+
+import type { IBookingFormValues } from '../BookAppointment.types';
+
+export interface IPublicBookingFormProps {
+	letPatientChooseAddress: boolean;
+	methods: UseFormReturn<IBookingFormValues>;
+}

--- a/src/pages/user/appointment/booking/components/TherapistCard.styles.tsx
+++ b/src/pages/user/appointment/booking/components/TherapistCard.styles.tsx
@@ -1,0 +1,43 @@
+import styled from '@emotion/styled';
+import { Box } from '@mui/material';
+import { palette } from '@psycron/theme/palette/palette.theme';
+import { shadowSmall } from '@psycron/theme/shadow/shadow.theme';
+import { spacing } from '@psycron/theme/spacing/spacing.theme';
+
+export const CardWrapper = styled(Box)`
+	align-items: center;
+	background: ${palette.background.paper};
+	border: 1px solid ${palette.brand.purple};
+	border-radius: ${spacing.mediumSmall};
+	display: flex;
+	gap: ${spacing.medium};
+	margin-bottom: ${spacing.large};
+	padding: ${spacing.medium};
+	box-shadow: ${shadowSmall};
+`;
+
+export const InfoBlock = styled(Box)`
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.xxs};
+	min-width: 0;
+`;
+
+export const SpecialityRow = styled(Box)`
+	display: flex;
+	flex-wrap: wrap;
+	gap: ${spacing.xxs};
+	margin-top: ${spacing.xxs};
+`;
+
+export const SpecialityChip = styled(Box)`
+	background: ${palette.brand.light};
+	border-radius: ${spacing.mediumSmall};
+	color: ${palette.brand.dark};
+	font-size: 0.7rem;
+	font-weight: 500;
+	padding: 2px ${spacing.xs};
+	text-transform: capitalize;
+	white-space: nowrap;
+	box-shadow: ${shadowSmall};
+`;

--- a/src/pages/user/appointment/booking/components/TherapistCard.tsx
+++ b/src/pages/user/appointment/booking/components/TherapistCard.tsx
@@ -1,0 +1,40 @@
+import { Avatar } from '@psycron/components/avatar/Avatar';
+import { Text } from '@psycron/components/text/Text';
+import type { ITherapist } from '@psycron/context/user/auth/UserAuthenticationContext.types';
+
+import {
+	CardWrapper,
+	InfoBlock,
+	SpecialityChip,
+	SpecialityRow,
+} from './TherapistCard.styles';
+
+interface ITherapistCardProps {
+	therapist: Pick<
+		ITherapist,
+		'firstName' | 'lastName' | 'picture' | 'specialities'
+	>;
+}
+
+export const TherapistCard = ({ therapist }: ITherapistCardProps) => {
+	const { firstName, lastName, picture, specialities } = therapist;
+	const visibleSpecialities = (specialities ?? []).slice(0, 3);
+
+	return (
+		<CardWrapper>
+			<Avatar firstName={firstName} lastName={lastName} src={picture} />
+			<InfoBlock>
+				<Text fontWeight={600} variant='subtitle1'>
+					{firstName} {lastName}
+				</Text>
+				{visibleSpecialities.length > 0 && (
+					<SpecialityRow>
+						{visibleSpecialities.map((s) => (
+							<SpecialityChip key={s}>{s}</SpecialityChip>
+						))}
+					</SpecialityRow>
+				)}
+			</InfoBlock>
+		</CardWrapper>
+	);
+};

--- a/src/pages/user/appointment/confirmation/AppointmentConfirmation.styles.tsx
+++ b/src/pages/user/appointment/confirmation/AppointmentConfirmation.styles.tsx
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+import { Box } from '@mui/material';
+import { palette } from '@psycron/theme/palette/palette.theme';
+import { spacing } from '@psycron/theme/spacing/spacing.theme';
+
+export const PageWrapper = styled(Box)`
+	max-width: 560px;
+	margin: 0 auto;
+	padding: ${spacing.large} ${spacing.small};
+`;
+
+export const ConfirmationCard = styled(Box)`
+	background: ${palette.white};
+	border: 1px solid ${palette.gray['02']};
+	border-radius: 12px;
+	padding: ${spacing.medium};
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.small};
+`;
+
+export const DetailRow = styled(Box)`
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.xxs};
+`;
+
+export const AgendaLinkBox = styled(Box)`
+	background: ${palette.primary.light};
+	border-radius: 8px;
+	margin-top: ${spacing.small};
+	padding: ${spacing.small};
+	word-break: break-all;
+`;

--- a/src/pages/user/appointment/confirmation/AppointmentConfirmation.tsx
+++ b/src/pages/user/appointment/confirmation/AppointmentConfirmation.tsx
@@ -1,0 +1,106 @@
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import { Divider, Typography } from '@mui/material';
+import { getPatientById } from '@psycron/api/patient';
+import { Button } from '@psycron/components/button/Button';
+import { PublicBookingShell } from '@psycron/layouts/public-booking/PublicBookingShell';
+import { useQuery } from '@tanstack/react-query';
+import { format, parseISO } from 'date-fns';
+
+import {
+	AgendaLinkBox,
+	ConfirmationCard,
+	DetailRow,
+	PageWrapper,
+} from './AppointmentConfirmation.styles';
+
+export const AppointmentConfirmation = () => {
+	const { t } = useTranslation();
+	const { therapistId, patientId } = useParams<{
+		patientId: string;
+		therapistId: string;
+	}>();
+
+	const { data: patient, isLoading } = useQuery({
+		enabled: Boolean(therapistId) && Boolean(patientId),
+		queryFn: () => getPatientById(therapistId!, patientId!),
+		queryKey: ['publicPatient', therapistId, patientId],
+	});
+
+	const agendaUrl = `${window.location.origin}/${window.location.pathname.split('/')[1]}/${patientId}/appointments`;
+
+	const latestSession =
+		patient?.sessionDates?.[patient.sessionDates.length - 1];
+	const latestSlot = latestSession?.slots?.[0];
+
+	if (isLoading) {
+		return (
+			<PublicBookingShell>
+				<PageWrapper>
+					<Typography color='text.secondary'>{t('common.loading')}</Typography>
+				</PageWrapper>
+			</PublicBookingShell>
+		);
+	}
+
+	return (
+		<PublicBookingShell>
+			<PageWrapper>
+				<Typography mb={2} variant='h5'>
+					{t('booking.confirmation.title')}
+				</Typography>
+				<Typography color='text.secondary' mb={4} variant='body2'>
+					{t('booking.confirmation.subtitle', {
+						name: patient?.firstName ?? '',
+					})}
+				</Typography>
+
+				<ConfirmationCard>
+					{latestSession && (
+						<>
+							<DetailRow>
+								<Typography color='text.secondary' variant='caption'>
+									{t('booking.confirmation.date')}
+								</Typography>
+								<Typography variant='body1'>
+									{format(parseISO(latestSession.date), 'EEEE, MMMM d, yyyy')}
+								</Typography>
+							</DetailRow>
+
+							{latestSlot && (
+								<DetailRow>
+									<Typography color='text.secondary' variant='caption'>
+										{t('booking.confirmation.time')}
+									</Typography>
+									<Typography variant='body1'>
+										{latestSlot.startTime} — {latestSlot.endTime}
+									</Typography>
+								</DetailRow>
+							)}
+						</>
+					)}
+
+					<Divider />
+
+					<DetailRow>
+						<Typography color='text.secondary' variant='caption'>
+							{t('booking.confirmation.your-agenda')}
+						</Typography>
+						<Typography color='text.secondary' mb={2} variant='body2'>
+							{t('booking.confirmation.agenda-description')}
+						</Typography>
+						<AgendaLinkBox>
+							<Typography variant='body2'>{agendaUrl}</Typography>
+						</AgendaLinkBox>
+						<Button
+							onClick={() => navigator.clipboard.writeText(agendaUrl)}
+							variant='outlined'
+						>
+							{t('booking.confirmation.copy-link')}
+						</Button>
+					</DetailRow>
+				</ConfirmationCard>
+			</PageWrapper>
+		</PublicBookingShell>
+	);
+};

--- a/src/pages/user/appointment/list/patient/AppointmentsList.styles.tsx
+++ b/src/pages/user/appointment/list/patient/AppointmentsList.styles.tsx
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled';
+import { Box } from '@mui/material';
+import { palette } from '@psycron/theme/palette/palette.theme';
+import { spacing } from '@psycron/theme/spacing/spacing.theme';
+
+export const PageWrapper = styled(Box)`
+	max-width: 720px;
+	margin: 0 auto;
+	padding: ${spacing.medium} ${spacing.small};
+`;
+
+export const SessionCard = styled(Box, {
+	shouldForwardProp: (prop) => prop !== 'isPast',
+})<{ isPast?: boolean }>`
+	background: ${({ isPast }) => (isPast ? palette.gray['01'] : palette.white)};
+	border: 1px solid ${({ isPast }) => (isPast ? palette.gray['02'] : palette.primary.light)};
+	border-radius: 10px;
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.extraSmall};
+	margin-bottom: ${spacing.small};
+	opacity: ${({ isPast }) => (isPast ? 0.7 : 1)};
+	padding: ${spacing.small} ${spacing.mediumSmall};
+`;
+
+export const SessionHeader = styled(Box)`
+	align-items: center;
+	display: flex;
+	justify-content: space-between;
+`;
+
+export const CancelForm = styled(Box)`
+	background: ${palette.error.access};
+	border-radius: 8px;
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.extraSmall};
+	margin-top: ${spacing.xs};
+	padding: ${spacing.small};
+`;
+
+export const SectionLabel = styled(Box)`
+	color: ${palette.text.secondary};
+	font-size: 0.75rem;
+	font-weight: 600;
+	letter-spacing: 0.06em;
+	margin-bottom: ${spacing.xs};
+	text-transform: uppercase;
+`;

--- a/src/pages/user/appointment/list/patient/AppointmentsList.tsx
+++ b/src/pages/user/appointment/list/patient/AppointmentsList.tsx
@@ -1,0 +1,220 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import {
+	Divider,
+	MenuItem,
+	TextField,
+	Typography,
+} from '@mui/material';
+import { getPublicPatientSessions } from '@psycron/api/patient';
+import type { IPublicSessionDate, IPublicSessionSlot } from '@psycron/api/patient/index.types';
+import { cancelAppointmentByPatient } from '@psycron/api/user/availability';
+import type { CancellationReasonEnum } from '@psycron/api/user/availability/index.types';
+import { Button } from '@psycron/components/button/Button';
+import { useAlert } from '@psycron/context/alert/AlertContext';
+import { PublicBookingShell } from '@psycron/layouts/public-booking/PublicBookingShell';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { format, isPast, parseISO } from 'date-fns';
+
+import {
+	CancelForm,
+	PageWrapper,
+	SectionLabel,
+	SessionCard,
+	SessionHeader,
+} from './AppointmentsList.styles';
+
+const CANCEL_REASONS = [
+	{ label: 'booking.cancel.reason.emergency', value: 1 },
+	{ label: 'booking.cancel.reason.schedule-conflict', value: 2 },
+	{ label: 'booking.cancel.reason.financial', value: 3 },
+	{ label: 'booking.cancel.reason.mental-health', value: 4 },
+	{ label: 'booking.cancel.reason.other', value: 6 },
+] as const;
+
+interface ISessionRow {
+	date: string;
+	dateId: string;
+	isPast: boolean;
+	slot: IPublicSessionSlot;
+	therapistId: string;
+}
+
+export const AppointmentsList = () => {
+	const { t } = useTranslation();
+	const { patientId } = useParams<{ patientId: string }>();
+	const { showAlert } = useAlert();
+	const queryClient = useQueryClient();
+
+	const [cancellingSlotId, setCancellingSlotId] = useState<string | null>(null);
+	const [reasonCode, setReasonCode] = useState<number | ''>('');
+	const [customReason, setCustomReason] = useState('');
+
+	const { data, isLoading } = useQuery({
+		enabled: Boolean(patientId),
+		queryFn: () => getPublicPatientSessions(patientId!),
+		queryKey: ['publicPatientSessions', patientId],
+	});
+
+	const cancelMutation = useMutation({
+		mutationFn: ({ slotId, therapistId }: { slotId: string; therapistId: string }) =>
+			cancelAppointmentByPatient({
+				...(customReason ? { customReason } : {}),
+				patientId: patientId!,
+				reasonCode: reasonCode as CancellationReasonEnum,
+				slotId,
+				therapistId,
+				triggeredBy: 'PATIENT',
+			}),
+		onError: () => {
+			showAlert({ message: t('booking.cancel.error'), severity: 'error' });
+		},
+		onSuccess: () => {
+			showAlert({ message: t('booking.cancel.success'), severity: 'success' });
+			setCancellingSlotId(null);
+			setReasonCode('');
+			setCustomReason('');
+			queryClient.invalidateQueries({ queryKey: ['publicPatientSessions', patientId] });
+		},
+	});
+
+	const sessions: ISessionRow[] = (data?.patient?.sessionDates ?? []).flatMap(
+		(group: IPublicSessionDate) =>
+			group.slots.map((slot) => ({
+				date: group.date,
+				dateId: group._id,
+				isPast: isPast(parseISO(group.date)),
+				slot,
+				therapistId: data!.patient.therapistId,
+			}))
+	);
+
+	const upcoming = sessions.filter((s) => !s.isPast);
+	const past = sessions.filter((s) => s.isPast);
+
+	const renderSession = ({ date, isPast: sessionIsPast, slot, therapistId }: ISessionRow) => {
+		const isCancelling = cancellingSlotId === slot._id;
+
+		return (
+			<SessionCard isPast={sessionIsPast} key={slot._id}>
+				<SessionHeader>
+					<Typography variant='subtitle2'>
+						{format(parseISO(date), 'EEEE, MMM d, yyyy')}
+					</Typography>
+					<Typography color='text.secondary' variant='body2'>
+						{slot.startTime} — {slot.endTime}
+					</Typography>
+				</SessionHeader>
+
+				{!sessionIsPast && slot.status !== 'CANCELLED' && (
+					<>
+						{isCancelling ? (
+							<CancelForm>
+								<Typography variant='body2'>
+									{t('booking.cancel.reason-prompt')}
+								</Typography>
+								<TextField
+									fullWidth
+									label={t('booking.cancel.reason-label')}
+									onChange={(e) => setReasonCode(Number(e.target.value))}
+									select
+									size='small'
+									value={reasonCode}
+								>
+									{CANCEL_REASONS.map(({ label, value }) => (
+										<MenuItem key={value} value={value}>
+											{t(label)}
+										</MenuItem>
+									))}
+								</TextField>
+								{reasonCode === 6 && (
+									<TextField
+										fullWidth
+										label={t('booking.cancel.custom-reason')}
+										multiline
+										onChange={(e) => setCustomReason(e.target.value)}
+										rows={2}
+										size='small'
+										value={customReason}
+									/>
+								)}
+								<Button
+									disabled={!reasonCode || cancelMutation.isPending}
+									onClick={() =>
+										cancelMutation.mutate({ slotId: slot._id, therapistId })
+									}
+									variant='contained'
+								>
+									{t('booking.cancel.confirm')}
+								</Button>
+								<Button
+									onClick={() => {
+										setCancellingSlotId(null);
+										setReasonCode('');
+										setCustomReason('');
+									}}
+									variant='text'
+								>
+									{t('common.cancel')}
+								</Button>
+							</CancelForm>
+						) : (
+							<Button
+								onClick={() => setCancellingSlotId(slot._id)}
+								variant='outlined'
+							>
+								{t('booking.cancel.button')}
+							</Button>
+						)}
+					</>
+				)}
+			</SessionCard>
+		);
+	};
+
+	if (isLoading) {
+		return (
+			<PublicBookingShell>
+				<PageWrapper>
+					<Typography color='text.secondary'>{t('common.loading')}</Typography>
+				</PageWrapper>
+			</PublicBookingShell>
+		);
+	}
+
+	return (
+		<PublicBookingShell>
+			<PageWrapper>
+				<Typography mb={1} variant='h5'>
+					{t('booking.appointments.title')}
+					{data?.patient?.firstName ? `, ${data.patient.firstName}` : ''}
+				</Typography>
+				<Typography color='text.secondary' mb={5} variant='body2'>
+					{t('booking.appointments.subtitle')}
+				</Typography>
+
+				{upcoming.length > 0 && (
+					<>
+						<SectionLabel>{t('booking.appointments.upcoming')}</SectionLabel>
+						{upcoming.map(renderSession)}
+					</>
+				)}
+
+				{upcoming.length === 0 && (
+					<Typography color='text.secondary' mb={4} variant='body2'>
+						{t('booking.appointments.no-upcoming')}
+					</Typography>
+				)}
+
+				{past.length > 0 && (
+					<>
+						<Divider sx={{ my: 4 }} />
+						<SectionLabel>{t('booking.appointments.past')}</SectionLabel>
+						{past.map(renderSession)}
+					</>
+				)}
+			</PageWrapper>
+		</PublicBookingShell>
+	);
+};

--- a/src/routes/PublicRoutes.tsx
+++ b/src/routes/PublicRoutes.tsx
@@ -6,22 +6,21 @@ import { VerifyEmail } from '@psycron/pages/auth/verification/email/VerifyEmail'
 import { TestHomePage } from '@psycron/pages/back-office/home/TestHomePage';
 import { Unsubscribe } from '@psycron/pages/unsubscribe/Unsubscribe';
 import {
-	// APPOINTMENTCONFIRMATIONPATH,
-	// BOOKAPPOINTMENT,
+	APPOINTMENTCONFIRMATIONPATH,
 	AUTHCALLBACK,
+	BOOKAPPOINTMENT,
 	HOMEPAGE,
 	PASSRESET,
-	// PATIENTAPPOINTMENTSLIST,
-	// PATIENTEDITAPPOINTMENT,
+	PATIENTAPPOINTMENTSLIST,
 	REQPASSRESET,
 	SIGNIN,
 	SIGNUP,
 	UNSUBSCRIBE,
 	VERIFYEMAIL,
 } from '@psycron/pages/urls';
-// import { BookAppointment } from '@psycron/pages/user/appointment/booking/BookAppointment';
-// import { AppointmentConfirmation } from '@psycron/pages/user/appointment/confirmation/AppointmentConfirmation';
-// import { AppointmentsList } from '@psycron/pages/user/appointment/list/patient/AppointmentsList';
+import { BookAppointment } from '@psycron/pages/user/appointment/booking/BookAppointment';
+import { AppointmentConfirmation } from '@psycron/pages/user/appointment/confirmation/AppointmentConfirmation';
+import { AppointmentsList } from '@psycron/pages/user/appointment/list/patient/AppointmentsList';
 
 const publicRoutes = [
 	{ path: HOMEPAGE, element: <TestHomePage /> },
@@ -32,13 +31,9 @@ const publicRoutes = [
 	{ path: VERIFYEMAIL, element: <VerifyEmail /> },
 	{ path: REQPASSRESET, element: <ResetPassword /> },
 	{ path: PASSRESET, element: <ChangePassword /> },
-	// { path: BOOKAPPOINTMENT, element: <BookAppointment /> },
-	// { path: APPOINTMENTCONFIRMATIONPATH, element: <AppointmentConfirmation /> },
-	// { path: PATIENTAPPOINTMENTSLIST, element: <AppointmentsList /> },
-	// {
-	// 	path: `:userId/${PATIENTEDITAPPOINTMENT}/edit/:availabilityDayId`,
-	// 	element: <BookAppointment />,
-	// },
+	{ path: BOOKAPPOINTMENT, element: <BookAppointment /> },
+	{ path: APPOINTMENTCONFIRMATIONPATH, element: <AppointmentConfirmation /> },
+	{ path: PATIENTAPPOINTMENTSLIST, element: <AppointmentsList /> },
 ];
 
 export default publicRoutes;


### PR DESCRIPTION
## Summary

- **PublicBookingShell** — new layout with Psycron logo + name, EN/PT language toggle (`Localization`), and "Powered by Psycron" footer; wraps all 3 public pages
- **BookAppointment** — rebuilt with therapist card (avatar + specialties), time-of-day filter chips (any/morning/afternoon/evening), redesigned available/booked slot chips, sticky day headers that stop below the TopBar (`PUBLIC_TOP_BAR_BOTTOM = 90px`), and skeleton loading state
- **AppointmentConfirmation** — booking success page with session details and copyable personal agenda link
- **AppointmentsList** — patient-facing session list with full cancel flow (reason picker + optional custom reason)
- **Routes** — wired `BOOKAPPOINTMENT`, `APPOINTMENTCONFIRMATIONPATH`, `PATIENTAPPOINTMENTSLIST` in `PublicRoutes`
- **API** — `getPublicPatientSessions` + `IPublicPatientSessionsResponse` / `IPublicSessionDate` / `IPublicSessionSlot` types
- **i18n** — full EN + PT coverage for booking, filters, confirmation, cancellation, and `common.loading`

## Test plan

- [ ] Visit `/:locale/:userId/book-appointment` — therapist card renders, date filters work, time-of-day chips filter correctly, slot chips show available/booked states
- [ ] Select an available slot — drawer opens with booking form; confirm books and redirects to confirmation page
- [ ] Confirmation page shows correct date/time and copyable agenda URL
- [ ] Visit `/:locale/:patientId/appointments` — upcoming and past sessions listed; cancel flow works end-to-end
- [ ] Switch language via toggle — all booking strings update to PT/EN
- [ ] Scroll the booking page — day labels stick below the TopBar (not behind it)
- [ ] Loading state renders skeletons while availability data fetches

Closes PPD-270

🤖 Generated with [Claude Code](https://claude.com/claude-code)