### PR TITLE
feat(availability): therapist-side booking with recurrence, timezone and contact link [PR-271]

### DIFF
--- a/src/api/patient/index.types.ts
+++ b/src/api/patient/index.types.ts
@@ -2,6 +2,7 @@ import type {
 	IBookSessionWithLink,
 	IContactInfo,
 	IPatient,
+	IPreferredContact,
 	ISlotAddress,
 } from '@psycron/context/user/auth/UserAuthenticationContext.types';
 
@@ -27,11 +28,12 @@ export interface IPatientByIdResponse {
 export interface PatientFormData {
 	_id?: string;
 	countryCode?: string;
-	email: string;
+	email?: string;
 	firstName: string;
 	lastName: string;
 	phone: string;
-	whatsapp: string;
+	preferredContact?: IPreferredContact;
+	whatsapp?: string;
 }
 export interface IEditPatientDetailsById {
 	patient: PatientFormData;
@@ -48,6 +50,7 @@ export interface PatientPartial {
 	contacts: IContactInfo;
 	firstName: string;
 	lastName: string;
+	preferredContact?: IPreferredContact;
 }
 
 export interface ICreatePatient {
@@ -63,15 +66,19 @@ export interface ICreatePatientResponse {
 	status: 'success' | 'error';
 }
 
+export type SessionDelivery = 'in_person' | 'online';
+
 export interface ICreatePatientForm {
 	countryCode: string;
-	email: string;
+	email?: string;
 	firstName: string;
 	hasWhatsApp?: boolean;
 	isPhoneWpp?: boolean;
 	lastName: string;
 	phone: string;
+	preferredContact?: IPreferredContact;
 	recurrencePattern?: RecurrencePattern;
+	sessionDelivery?: SessionDelivery;
 	timeZone?: string;
 	whatsapp?: string;
 }

--- a/src/api/user/availability/index.ts
+++ b/src/api/user/availability/index.ts
@@ -9,6 +9,8 @@ import type {
 	CancelAppointmentPayload,
 	CancelAppointmentResponse,
 	IAvailabilityData,
+	IBookSlotByTherapistPayload,
+	IBookSlotByTherapistResponse,
 	ICompleteSessionAvailabilityData,
 	ICompleteSessionAvailabilityResponse,
 	IEditSlotStatus,
@@ -104,6 +106,19 @@ export const getPublicSlotDetailsById = async (
 	slotId: string
 ): Promise<IPublicSlotDetailsResponse> => {
 	const response = await apiClient.get(`/users/${therapistId}/${slotId}`);
+	return response.data;
+};
+
+export const bookSlotByTherapist = async ({
+	therapistId,
+	availabilityDayId,
+	slotId,
+	...data
+}: IBookSlotByTherapistPayload): Promise<IBookSlotByTherapistResponse> => {
+	const response = await apiClient.post<IBookSlotByTherapistResponse>(
+		`/users/${therapistId}/availability/${availabilityDayId}/slot/${slotId}/book`,
+		data
+	);
 	return response.data;
 };
 

--- a/src/api/user/availability/index.types.ts
+++ b/src/api/user/availability/index.types.ts
@@ -180,3 +180,38 @@ export interface CancelAppointmentFormData {
 	reasonCode: string;
 	triggeredBy: string;
 }
+
+export interface IBookSlotByTherapistPayload {
+	availabilityDayId: string;
+	patient: {
+		contacts: {
+			email?: string;
+			phone?: string;
+			whatsapp?: string;
+		};
+		firstName: string;
+		lastName: string;
+		preferredContact?: {
+			type: string;
+			value: string;
+		};
+	};
+	patientAddress?: ISlotAddress;
+	recurrencePattern?: string;
+	shareAddress: boolean;
+	shouldReplicate: boolean;
+	slotId: string;
+	therapistId: string;
+	timeZone: string;
+}
+
+export interface IBookSlotByTherapistResponse {
+	appointmentInfo: {
+		date: string;
+		time: string;
+	};
+	message: string;
+	patient: Partial<IPatient>;
+	status: string;
+	therapistId: string;
+}

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -262,6 +262,18 @@
         "contact-via": "Contact via {{method}}?",
         "contact-via-same": "Is phone number the same as whatsapp?"
       },
+      "preferred-contact": {
+        "coming-soon": "Integration coming soon — paste your meeting link for now",
+        "label": "Preferred session platform",
+        "value-phone": "Phone number",
+        "value-url": "Meeting link (URL)",
+        "type": {
+          "google_meet": "Google Meet",
+          "phone": "Phone call",
+          "whatsapp": "WhatsApp",
+          "zoom": "Zoom"
+        }
+      },
       "consent": {
         "terms": "I agree to the <privacyLink>Privacy Policy</privacyLink> and <termsLink>Terms of Use.</termsLink>",
         "marketing": "I consent to receive <marketingLink>marketing communications.</marketingLink>",
@@ -883,6 +895,8 @@
         "date": "Date",
         "edit": "Edit",
         "edit-end-time": "End time",
+        "booking-error": "Failed to book appointment. Please try again.",
+        "booking-success": "Appointment booked successfully.",
         "edit-error": "Failed to save changes. Please try again.",
         "edit-note": "Notes",
         "edit-save": "Save changes",
@@ -893,6 +907,16 @@
         "location-choice-clinic": "Clinic",
         "location-choice-custom": "Custom",
         "location-choice-label": "Session location",
+        "session-delivery-in-person": "In person",
+        "session-delivery-in-person-subtitle": "At your clinic or the patient's location",
+        "session-delivery-label": "How will this session be held?",
+        "session-delivery-online": "Online",
+        "recurrence-all": "All future appointments",
+        "recurrence-end-month": "Until end of month",
+        "recurrence-end-year": "Until end of year",
+        "recurrence-label": "Repeat booking",
+        "recurrence-single": "This appointment only",
+        "session-delivery-online-subtitle": "Video call, phone, or messaging",
         "location-choice-patient": "Patient",
         "location-subtitle-clinic": "We will share your clinic address in the booking location",
         "location-subtitle-custom": "We will share the custom address in the booking location",
@@ -900,6 +924,8 @@
         "minutes": "minutes",
         "notes": "Notes",
         "patient-email": "Patient's email",
+        "patient-timezone": "Patient's timezone",
+        "patient-timezone-placeholder": "Search by city, e.g. Sao Paulo",
         "patient-first-name": "Patient's first name",
         "patient-last-name": "Patient's last name",
         "patient-time": "Patient time",
@@ -918,7 +944,11 @@
         "your-time": "Your time",
         "appointment-address": "Appointment address",
         "patient-phone": "Patient's phone",
-        "patient-provides-address": "Patient will provide the address"
+        "patient-provides-address": "Patient will provide the address",
+        "call-whatsapp": "Call on WhatsApp",
+        "call-phone": "Call patient",
+        "join-meet": "Join on Google Meet",
+        "join-zoom": "Join on Zoom"
       },
       "buffer-label": "Buffer",
       "legend-available": "Available",

--- a/src/assets/locales/pt/translation.json
+++ b/src/assets/locales/pt/translation.json
@@ -263,6 +263,18 @@
         "contact-via": "Entrar em contato via {{method}}?",
         "contact-via-same": "O número é o mesmo para o Whatsapp?"
       },
+      "preferred-contact": {
+        "coming-soon": "Integração em breve — cole o link da sessão por enquanto",
+        "label": "Plataforma preferida para sessão",
+        "value-phone": "Número de telefone",
+        "value-url": "Link da reunião (URL)",
+        "type": {
+          "google_meet": "Google Meet",
+          "phone": "Ligação",
+          "whatsapp": "WhatsApp",
+          "zoom": "Zoom"
+        }
+      },
       "consent": {
         "terms": "Eu concordo com a <privacyLink>Política de Privacidade</privacyLink> e os <termsLink>Termos de Uso</termsLink>",
         "marketing": "Eu concordo em receber <marketingLink>comunicações de marketing.</marketingLink>",
@@ -884,6 +896,8 @@
         "date": "Data",
         "edit": "Editar",
         "edit-end-time": "Horário de término",
+        "booking-error": "Falha ao agendar a consulta. Tente novamente.",
+        "booking-success": "Consulta agendada com sucesso.",
         "edit-error": "Falha ao salvar as alterações. Tente novamente.",
         "edit-note": "Notas",
         "edit-save": "Salvar alterações",
@@ -894,6 +908,16 @@
         "location-choice-clinic": "Consultório",
         "location-choice-custom": "Personalizado",
         "location-choice-label": "Local da sessão",
+        "session-delivery-in-person": "Presencial",
+        "session-delivery-in-person-subtitle": "No seu consultório ou endereço do paciente",
+        "session-delivery-label": "Como será realizada esta sessão?",
+        "session-delivery-online": "Online",
+        "recurrence-all": "Todos os agendamentos futuros",
+        "recurrence-end-month": "Até o fim do mês",
+        "recurrence-end-year": "Até o fim do ano",
+        "recurrence-label": "Repetir agendamento",
+        "recurrence-single": "Apenas este agendamento",
+        "session-delivery-online-subtitle": "Videochamada, telefone ou mensagens",
         "location-choice-patient": "Paciente",
         "location-subtitle-clinic": "Vamos partilhar o endereço do consultório na localização da consulta",
         "location-subtitle-custom": "Vamos partilhar o endereço personalizado na localização da consulta",
@@ -901,6 +925,8 @@
         "minutes": "minutos",
         "notes": "Notas",
         "patient-email": "Email do paciente",
+        "patient-timezone": "Fuso horário do paciente",
+        "patient-timezone-placeholder": "Pesquise por cidade, ex: Sao Paulo",
         "patient-first-name": "Nome do paciente",
         "patient-last-name": "Sobrenome do paciente",
         "patient-time": "Horário do paciente",
@@ -919,7 +945,11 @@
         "your-time": "Seu horário",
         "appointment-address": "Endereço da consulta",
         "patient-phone": "Telefone do paciente",
-        "patient-provides-address": "O paciente irá fornecer o endereço"
+        "patient-provides-address": "O paciente irá fornecer o endereço",
+        "call-whatsapp": "Ligar pelo WhatsApp",
+        "call-phone": "Ligar para o paciente",
+        "join-meet": "Entrar no Google Meet",
+        "join-zoom": "Entrar no Zoom"
       },
       "buffer-label": "Buffer",
       "legend-available": "Disponível",

--- a/src/components/form/components/contacts/ContactsForm.tsx
+++ b/src/components/form/components/contacts/ContactsForm.tsx
@@ -22,6 +22,7 @@ export const ContactsForm = <T extends FieldValues>({
 	disabled,
 	fields,
 	fullWidth,
+	hidePhone = false,
 	labelEmail,
 	placeholderEmail,
 	required = false,
@@ -84,89 +85,92 @@ export const ContactsForm = <T extends FieldValues>({
 					disabled={disabled}
 				/>
 
-				<InputWrapper>
-					<PhoneInputComponent<T>
-						name={phonePath}
-						required={atLeastOneContact ? false : required}
-						validateFn={
-							atLeastOneContact
-								? (v) => {
-										const email = getValues(emailPath) as string | undefined;
-										if (!v?.trim() && !email?.trim()) {
-											return t(
-												'components.form.validation.at-least-one-contact'
-											);
+			{!hidePhone && (
+					<InputWrapper>
+						<PhoneInputComponent<T>
+							name={phonePath}
+							required={atLeastOneContact ? false : required}
+							validateFn={
+								atLeastOneContact
+									? (v) => {
+											const email = getValues(emailPath) as string | undefined;
+											if (!v?.trim() && !email?.trim()) {
+												return t(
+													'components.form.validation.at-least-one-contact'
+												);
+											}
+											return true;
 										}
-										return true;
-									}
-								: undefined
-						}
-						disabled={disabled}
-						defaultValue={defaultValues?.phone ?? ''}
-						labelKey='globals.phone'
-					/>
-				</InputWrapper>
+									: undefined
+							}
+							disabled={disabled}
+							defaultValue={defaultValues?.phone ?? ''}
+							labelKey='globals.phone'
+						/>
+					</InputWrapper>
+				)}
 			</EmailPhoneWrapper>
-			<ContactsFormSwitchWrapper>
-				<Switch
-					small={isSmallerThanTablet}
-					checked={hasWhatsApp}
-					onChange={(_, next) => {
-						if (disabled) return;
-
-						setValue(hasWhatsAppPath, next as never, {
-							shouldDirty: true,
-							shouldTouch: true,
-						});
-
-						// If user turned WhatsApp off, reset dependent state
-						if (!next) {
-							setValue(isPhoneWppPath, false as never, {
-								shouldDirty: true,
-								shouldTouch: true,
-							});
-							setValue(whatsappPath, '' as never, {
-								shouldDirty: true,
-								shouldTouch: true,
-							});
-						}
-					}}
-					label={t('components.form.contacts-form.contact-via', {
-						method: 'Whatsapp',
-					})}
-					disabled={disabled}
-				/>
-
-				{hasWhatsApp ? (
+			{!hidePhone && (
+				<ContactsFormSwitchWrapper>
 					<Switch
 						small={isSmallerThanTablet}
-						checked={isPhoneWpp}
+						checked={hasWhatsApp}
 						onChange={(_, next) => {
 							if (disabled) return;
 
-							setValue(isPhoneWppPath, next as never, {
+							setValue(hasWhatsAppPath, next as never, {
 								shouldDirty: true,
 								shouldTouch: true,
 							});
 
-							if (next) {
+							if (!next) {
+								setValue(isPhoneWppPath, false as never, {
+									shouldDirty: true,
+									shouldTouch: true,
+								});
 								setValue(whatsappPath, '' as never, {
 									shouldDirty: true,
 									shouldTouch: true,
 								});
 							}
 						}}
-						label={t('components.form.contacts-form.contact-via-same')}
+						label={t('components.form.contacts-form.contact-via', {
+							method: 'Whatsapp',
+						})}
 						disabled={disabled}
 					/>
-				) : null}
-			</ContactsFormSwitchWrapper>
+
+					{hasWhatsApp ? (
+						<Switch
+							small={isSmallerThanTablet}
+							checked={isPhoneWpp}
+							onChange={(_, next) => {
+								if (disabled) return;
+
+								setValue(isPhoneWppPath, next as never, {
+									shouldDirty: true,
+									shouldTouch: true,
+								});
+
+								if (next) {
+									setValue(whatsappPath, '' as never, {
+										shouldDirty: true,
+										shouldTouch: true,
+									});
+								}
+							}}
+							label={t('components.form.contacts-form.contact-via-same')}
+							disabled={disabled}
+						/>
+					) : null}
+				</ContactsFormSwitchWrapper>
+			)}
 
 			<input type='hidden' {...register(hasWhatsAppPath)} />
 			<input type='hidden' {...register(isPhoneWppPath)} />
 
-			<ContactsFormWhatsAppWrapper isFullWidth={fullWidth}>
-				{hasWhatsApp && !isPhoneWpp ? (
+			{!hidePhone && hasWhatsApp && !isPhoneWpp ? (
+				<ContactsFormWhatsAppWrapper isFullWidth={fullWidth}>
 					<InputWrapper>
 						<PhoneInputComponent<T>
 							name={whatsappPath}
@@ -176,8 +180,8 @@ export const ContactsForm = <T extends FieldValues>({
 							labelKey='globals.whatsapp'
 						/>
 					</InputWrapper>
-				) : null}
-			</ContactsFormWhatsAppWrapper>
+				</ContactsFormWhatsAppWrapper>
+			) : null}
 		</ContactsFormWrapper>
 	);
 };

--- a/src/components/form/components/contacts/ContactsForm.types.ts
+++ b/src/components/form/components/contacts/ContactsForm.types.ts
@@ -16,6 +16,7 @@ export type ContactsFormProps<T extends FieldValues> = {
 	disabled?: boolean;
 	fields?: ContactsFormFields<T>;
 	fullWidth?: boolean;
+	hidePhone?: boolean;
 	labelEmail?: string;
 	placeholderEmail?: string;
 	required?: boolean;

--- a/src/components/form/components/name/NameForm.tsx
+++ b/src/components/form/components/name/NameForm.tsx
@@ -41,7 +41,13 @@ export const NameForm = <T extends FieldValues>({
 					placeholder={
 						placeholderFirstName ?? t('components.input.text.first-name')
 					}
-					{...register(firstNamePath)}
+					{...register(firstNamePath, {
+						required: required
+							? t('components.form.validation.required', {
+									name: labelFirstName ?? t('components.form.signup.first-name'),
+								})
+							: false,
+					})}
 					error={Boolean(firstNameError)}
 					helperText={
 						typeof firstNameError?.message === 'string'
@@ -62,7 +68,13 @@ export const NameForm = <T extends FieldValues>({
 					placeholder={
 						placeholderLastName ?? t('components.input.text.last-name')
 					}
-					{...register(lastNamePath)}
+					{...register(lastNamePath, {
+						required: required
+							? t('components.form.validation.required', {
+									name: labelLastName ?? t('components.form.signup.last-name'),
+								})
+							: false,
+					})}
 					error={Boolean(lastNameError)}
 					helperText={
 						typeof lastNameError?.message === 'string'

--- a/src/components/form/components/preferred-contact/PreferredContactForm.styles.tsx
+++ b/src/components/form/components/preferred-contact/PreferredContactForm.styles.tsx
@@ -1,0 +1,25 @@
+import styled from '@emotion/styled';
+import { Box, InputLabel, TextField } from '@mui/material';
+import { spacing } from '@psycron/theme/spacing/spacing.theme';
+
+export const PreferredContactWrapper = styled(Box)`
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	gap: ${spacing.small};
+`;
+
+export const PreferredContactFields = styled(Box)`
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.small};
+	width: 100%;
+`;
+
+export const PreferredContactTypeSelect = styled(TextField)`
+	margin-bottom: ${spacing.xs};
+`;
+
+export const PreferredContactUrlInputLabel = styled(InputLabel)`
+	margin-left: 0;
+`;

--- a/src/components/form/components/preferred-contact/PreferredContactForm.tsx
+++ b/src/components/form/components/preferred-contact/PreferredContactForm.tsx
@@ -1,0 +1,108 @@
+import { useEffect } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { FormControl, NativeSelect, OutlinedInput } from '@mui/material';
+import type { ICreatePatientForm } from '@psycron/api/patient/index.types';
+import type { PreferredContactType } from '@psycron/context/user/auth/UserAuthenticationContext.types';
+
+import {
+	PreferredContactFields,
+	PreferredContactTypeSelect,
+	PreferredContactUrlInputLabel,
+	PreferredContactWrapper,
+} from './PreferredContactForm.styles';
+import type { PreferredContactFormProps } from './PreferredContactForm.types';
+
+const PREFERRED_CONTACT_TYPES: PreferredContactType[] = [
+	'whatsapp',
+	'phone',
+	'google_meet',
+	'zoom',
+];
+
+const isUrlType = (type: PreferredContactType): boolean =>
+	type === 'google_meet' || type === 'zoom';
+
+export const PreferredContactForm = ({
+	disabled,
+}: PreferredContactFormProps) => {
+	const { t } = useTranslation();
+	const { register, control, setValue } = useFormContext<ICreatePatientForm>();
+
+	const isPhoneWpp = useWatch({ control, name: 'isPhoneWpp' });
+	const phone = useWatch({ control, name: 'phone' });
+	const whatsapp = useWatch({ control, name: 'whatsapp' });
+	const selectedType = useWatch({ control, name: 'preferredContact.type' });
+
+	// Sync preferredContact.value from ContactsForm phone/whatsapp fields
+	useEffect(() => {
+		if (selectedType === 'whatsapp') {
+			const whatsappValue = isPhoneWpp ? phone : whatsapp;
+			if (whatsappValue) {
+				setValue('preferredContact.value', whatsappValue, {
+					shouldDirty: true,
+				});
+			}
+		} else if (selectedType === 'phone' && phone) {
+			setValue('preferredContact.value', phone, { shouldDirty: true });
+		}
+	}, [isPhoneWpp, phone, whatsapp, selectedType, setValue]);
+
+	const handleTypeChange = (next: PreferredContactType) => {
+		setValue('preferredContact.type', next, { shouldDirty: true });
+		setValue('preferredContact.value', '', { shouldDirty: true });
+
+		if (next === 'whatsapp') {
+			// Signal ContactsForm to show WhatsApp input
+			setValue('hasWhatsApp', true, { shouldDirty: true });
+		} else {
+			setValue('hasWhatsApp', false, { shouldDirty: true });
+		}
+	};
+
+	const label = t('components.form.preferred-contact.label');
+
+	return (
+		<PreferredContactWrapper>
+			<PreferredContactFields>
+				<FormControl fullWidth>
+					<PreferredContactUrlInputLabel
+						htmlFor='preferred-contact-type'
+						shrink
+					>
+						{label}
+					</PreferredContactUrlInputLabel>
+					<NativeSelect
+						disabled={disabled}
+						input={<OutlinedInput label={label} notched />}
+						inputProps={{ id: 'preferred-contact-type' }}
+						value={selectedType ?? ''}
+						onChange={(e) =>
+							handleTypeChange(e.target.value as PreferredContactType)
+						}
+					>
+						<option value='' disabled>
+							–
+						</option>
+						{PREFERRED_CONTACT_TYPES.map((type) => (
+							<option key={type} value={type}>
+								{t(`components.form.preferred-contact.type.${type}`)}
+							</option>
+						))}
+					</NativeSelect>
+				</FormControl>
+
+				{selectedType && isUrlType(selectedType) && (
+					<PreferredContactTypeSelect
+						fullWidth
+						disabled={disabled}
+						label={t('components.form.preferred-contact.value-url')}
+						type='url'
+						helperText={t('components.form.preferred-contact.coming-soon')}
+						{...register('preferredContact.value')}
+					/>
+				)}
+			</PreferredContactFields>
+		</PreferredContactWrapper>
+	);
+};

--- a/src/components/form/components/preferred-contact/PreferredContactForm.types.ts
+++ b/src/components/form/components/preferred-contact/PreferredContactForm.types.ts
@@ -1,0 +1,3 @@
+export interface PreferredContactFormProps {
+	disabled?: boolean;
+}

--- a/src/components/form/components/timezone/GoogleTimezoneSearch.tsx
+++ b/src/components/form/components/timezone/GoogleTimezoneSearch.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CircularProgress, TextField } from '@mui/material';
+import { GoogleAutocompleteGlobalStyles } from '@psycron/components/form/components/address/GoogleAddressSearch/GoogleAddressSearch.styles';
+import {
+	GOOGLE_MAPS_API_KEY,
+	PSYCRON_BASE_API,
+} from '@psycron/utils/variables';
+import type { Libraries } from '@react-google-maps/api';
+import { Autocomplete, useLoadScript } from '@react-google-maps/api';
+
+import type { IGoogleTimezoneSearch } from './GoogleTimezoneSearch.types';
+
+const LIBRARIES: Libraries = ['places'];
+
+const AUTOCOMPLETE_OPTIONS: google.maps.places.AutocompleteOptions = {
+	types: ['(cities)'],
+};
+
+const fetchTimezoneId = async (
+	lat: number,
+	lng: number
+): Promise<{ id: string; name: string } | null> => {
+	try {
+		const res = await fetch(
+			`${PSYCRON_BASE_API}/utils/timezone?lat=${lat}&lng=${lng}`
+		);
+		const data = (await res.json()) as { id: string; name: string };
+		if (data.id) return data;
+	} catch {
+		// fall through
+	}
+	return null;
+};
+
+export const GoogleTimezoneSearch = ({
+	onTimezoneSelect,
+}: IGoogleTimezoneSearch) => {
+	const { t } = useTranslation();
+	const [inputValue, setInputValue] = useState('');
+	const [detectedTz, setDetectedTz] = useState<string | null>(null);
+	const [loading, setLoading] = useState(false);
+
+	const { isLoaded, loadError } = useLoadScript({
+		googleMapsApiKey: GOOGLE_MAPS_API_KEY,
+		libraries: LIBRARIES,
+	});
+
+	if (!isLoaded || loadError) return null;
+
+	return (
+		<>
+			<GoogleAutocompleteGlobalStyles />
+			<Autocomplete
+				onLoad={(ac) => {
+					ac.addListener('place_changed', async () => {
+						const place = ac.getPlace();
+						if (!place?.geometry?.location) return;
+
+						const lat = place.geometry.location.lat();
+						const lng = place.geometry.location.lng();
+
+						setLoading(true);
+						const tz = await fetchTimezoneId(lat, lng);
+						setLoading(false);
+
+						if (tz) {
+							setDetectedTz(tz.name);
+							setInputValue(place.name ?? place.formatted_address ?? '');
+							onTimezoneSelect(tz.id);
+						}
+					});
+				}}
+				options={AUTOCOMPLETE_OPTIONS}
+			>
+				<TextField
+					fullWidth
+					label={t('availability.week.drawer.patient-timezone')}
+					placeholder={t(
+						'availability.week.drawer.patient-timezone-placeholder'
+					)}
+					value={inputValue}
+					helperText={detectedTz ?? undefined}
+					onChange={(e) => {
+						setInputValue(e.target.value);
+						if (detectedTz) {
+							setDetectedTz(null);
+							onTimezoneSelect('');
+						}
+					}}
+					slotProps={{
+						input: {
+							endAdornment: loading ? (
+								<CircularProgress size={16} />
+							) : undefined,
+						},
+					}}
+				/>
+			</Autocomplete>
+		</>
+	);
+};

--- a/src/components/form/components/timezone/GoogleTimezoneSearch.types.ts
+++ b/src/components/form/components/timezone/GoogleTimezoneSearch.types.ts
@@ -1,0 +1,3 @@
+export interface IGoogleTimezoneSearch {
+	onTimezoneSelect: (timezoneId: string) => void;
+}

--- a/src/components/form/components/timezone/TimezoneSelect.tsx
+++ b/src/components/form/components/timezone/TimezoneSelect.tsx
@@ -1,0 +1,18 @@
+import { Controller, useFormContext } from 'react-hook-form';
+import type { ICreatePatientForm } from '@psycron/api/patient/index.types';
+
+import { GoogleTimezoneSearch } from './GoogleTimezoneSearch';
+
+export const TimezoneSelect = () => {
+	const { control } = useFormContext<ICreatePatientForm>();
+
+	return (
+		<Controller
+			control={control}
+			name='timeZone'
+			render={({ field }) => (
+				<GoogleTimezoneSearch onTimezoneSelect={field.onChange} />
+			)}
+		/>
+	);
+};

--- a/src/context/user/auth/UserAuthenticationContext.types.ts
+++ b/src/context/user/auth/UserAuthenticationContext.types.ts
@@ -42,7 +42,7 @@ export interface IClinicAddress {
 }
 
 export interface IContactInfo {
-	email: string;
+	email?: string;
 	hasWhatsApp?: boolean;
 	isPhoneWpp?: boolean;
 
@@ -174,10 +174,18 @@ export interface ISessionDatesGroup {
 	slots: ISlot[];
 }
 
+export type PreferredContactType = 'google_meet' | 'phone' | 'whatsapp' | 'zoom';
+
+export interface IPreferredContact {
+	type: PreferredContactType;
+	value: string;
+}
+
 export interface IPatient extends IBaseUser {
 	cancelledAppointments?: ICancelledAppointment[];
 	createdBy?: ITherapist | string;
 	notifications?: INotification[];
+	preferredContact?: IPreferredContact | null;
 
 	role: 'PATIENT';
 	sessionDates: ISessionDatesGroup[];

--- a/src/pages/availability/week/drawer/AvailabilityWeekDrawer.styles.tsx
+++ b/src/pages/availability/week/drawer/AvailabilityWeekDrawer.styles.tsx
@@ -190,6 +190,36 @@ export const CancelChoiceCardSub = styled(Text)`
 	color: ${palette.gray['05']};
 `;
 
+// ─── Contact link button ───────────────────────────────────────────────────────
+
+export const ContactLinkAnchor = styled('a')`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: ${spacing.small};
+	width: 100%;
+	padding: ${spacing.small} ${spacing.medium};
+	border: 1.5px solid ${hexToRgba(palette.brand.purple, 0.4)};
+	border-radius: ${spacing.extraSmall};
+	color: ${palette.brand.purple};
+	font-size: 14px;
+	font-weight: 500;
+	text-decoration: none;
+	transition:
+		background 0.15s ease,
+		border-color 0.15s ease;
+	cursor: pointer;
+	& svg {
+		width: 20px;
+		height: 20px;
+		flex-shrink: 0;
+	}
+	&:hover {
+		background: ${hexToRgba(palette.brand.purple, 0.06)};
+		border-color: ${palette.brand.purple};
+	}
+`;
+
 // ─── Reschedule slot picker ────────────────────────────────────────────────────
 
 export const SlotPickerList = styled(Box)`

--- a/src/pages/availability/week/drawer/AvailabilityWeekDrawer.tsx
+++ b/src/pages/availability/week/drawer/AvailabilityWeekDrawer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
 import { StatusEnum } from '@psycron/api/user/availability/index.types';
@@ -7,6 +7,7 @@ import {
 	Account,
 	Appointment,
 	Calendar,
+	Globe,
 	Google,
 	Jupiter,
 	Mail,
@@ -46,6 +47,7 @@ import {
 	CancelViewBody,
 	ConfirmedBadge,
 	ConfirmedBadgeText,
+	ContactLinkAnchor,
 	DrawerBadgeRow,
 	DrawerDetailLabel,
 	SourceBadge,
@@ -59,6 +61,7 @@ import type {
 	LocationChoice,
 } from './AvailabilityWeekDrawer.types';
 import {
+	buildContactLink,
 	computeEndTime,
 	computeTimeStrings,
 	STATUS_CONFIG,
@@ -86,6 +89,12 @@ export const AvailabilityWeekDrawer = ({
 		getInitialLocationChoice
 	);
 
+	useEffect(() => {
+		setLocationChoice(getInitialLocationChoice());
+		setOverrideAddress(!!slot.address);
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [slot.address, slot.letPatientChooseAddress]);
+
 	// ─── Slot flags ───────────────────────────────────────────────────────────
 	const isAvailable = slot.status === 'available';
 	const isBooked =
@@ -95,8 +104,6 @@ export const AvailabilityWeekDrawer = ({
 	const hasInPersonAddress = !!userDetails?.clinicAddress?.street;
 	const isInPersonSession =
 		sessionType === 'IN_PERSON' || sessionType === 'BOTH';
-	const showSessionLocation =
-		isAvailable && isInPersonSession && hasInPersonAddress;
 	const showAddressInEdit = isBooked && isInPersonSession && hasInPersonAddress;
 
 	// ─── Hooks ────────────────────────────────────────────────────────────────
@@ -110,7 +117,8 @@ export const AvailabilityWeekDrawer = ({
 		slot,
 		therapistId,
 		locationChoice,
-		slotAddress.address
+		slotAddress.address,
+		onClose
 	);
 
 	const editSlotForm = useEditSlotForm(
@@ -255,6 +263,21 @@ export const AvailabilityWeekDrawer = ({
 	const DASH = '—';
 	const apptPatient = appointmentDetailsBySlotId?.appointment?.patient;
 	const appt = appointmentDetailsBySlotId?.appointment;
+
+	// ─── Contact link ─────────────────────────────────────────────────────────
+	const contactLink = isBooked
+		? buildContactLink(apptPatient?.preferredContact)
+		: null;
+
+	const CONTACT_LINK_ICON: Record<
+		'google_meet' | 'phone' | 'whatsapp' | 'zoom',
+		JSX.Element
+	> = {
+		google_meet: <Google color={palette.brand.purple} />,
+		phone: <Phone color={palette.brand.purple} />,
+		whatsapp: <WhatsApp color={palette.brand.purple} />,
+		zoom: <Globe color={palette.brand.purple} />,
+	};
 
 	const details: IDrawerDetail[] = isAvailable
 		? [
@@ -424,7 +447,7 @@ export const AvailabilityWeekDrawer = ({
 								methods={methods}
 								onCustomAddressChange={handleCustomAddressChange}
 								onLocationChoiceChange={handleLocationChoiceChange}
-								showSessionLocation={showSessionLocation}
+								sessionType={sessionType}
 							/>
 						) : (
 							<Box></Box>
@@ -462,7 +485,21 @@ export const AvailabilityWeekDrawer = ({
 					? t('availability.week.drawer.book-slot')
 					: (patientName ?? '')
 			}
-			actions={<DrawerActions config={drawerActions} />}
+			actions={
+				<>
+					{contactLink && view === 'default' && (
+						<ContactLinkAnchor
+							href={contactLink.href}
+							rel='noopener noreferrer'
+							target='_blank'
+						>
+							{CONTACT_LINK_ICON[contactLink.type]}
+							{t(contactLink.labelKey)}
+						</ContactLinkAnchor>
+					)}
+					<DrawerActions config={drawerActions} />
+				</>
+			}
 			headerExtra={
 				<>
 					{!isAvailable && (

--- a/src/pages/availability/week/drawer/AvailabilityWeekDrawer.utils.ts
+++ b/src/pages/availability/week/drawer/AvailabilityWeekDrawer.utils.ts
@@ -1,9 +1,46 @@
+import type {
+	IPreferredContact,
+} from '@psycron/context/user/auth/UserAuthenticationContext.types';
 import { palette } from '@psycron/theme/palette/palette.theme';
 import type { Locale } from 'date-fns';
 import { format, parseISO } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 
 import type { IWeekSlot } from '../AvailabilityWeekPage.types';
+
+export interface IContactLink {
+	href: string;
+	labelKey: string;
+	type: IPreferredContact['type'];
+}
+
+const CONTACT_LINK_LABEL: Record<IPreferredContact['type'], string> = {
+	google_meet: 'availability.week.drawer.join-meet',
+	phone: 'availability.week.drawer.call-phone',
+	whatsapp: 'availability.week.drawer.call-whatsapp',
+	zoom: 'availability.week.drawer.join-zoom',
+};
+
+/**
+ * Builds the appropriate contact link for a booked patient.
+ * Uses preferredContact as the single source of truth.
+ */
+export const buildContactLink = (
+	preferredContact?: IPreferredContact | null
+): IContactLink | null => {
+	if (!preferredContact?.value) return null;
+
+	const { type, value } = preferredContact;
+
+	const href =
+		type === 'whatsapp'
+			? `https://wa.me/${value.replace(/\D/g, '')}`
+			: type === 'phone'
+				? `tel:${value}`
+				: value;
+
+	return { href, labelKey: CONTACT_LINK_LABEL[type], type };
+};
 
 export const STATUS_CONFIG: Record<
 	string,

--- a/src/pages/availability/week/drawer/hooks/useBookingForm.ts
+++ b/src/pages/availability/week/drawer/hooks/useBookingForm.ts
@@ -1,9 +1,15 @@
 import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { editSlot } from '@psycron/api/availability';
-import type { ICreatePatientForm } from '@psycron/api/patient/index.types';
-import { usePatient } from '@psycron/context/patient/PatientContext';
+import {
+	type ICreatePatientForm,
+	RecurrencePattern,
+} from '@psycron/api/patient/index.types';
+import { bookSlotByTherapist } from '@psycron/api/user/availability';
+import { useAlert } from '@psycron/context/alert/AlertContext';
 import type { ISlotAddress } from '@psycron/context/user/auth/UserAuthenticationContext.types';
 import { getFormattedContacts } from '@psycron/hooks/useFormattedContacts';
+import { useQueryClient } from '@tanstack/react-query';
 
 import type {
 	IAvailabilityWeekDrawerProps,
@@ -14,9 +20,12 @@ export const useBookingForm = (
 	slot: IAvailabilityWeekDrawerProps['slot'],
 	therapistId: string | null,
 	locationChoice: LocationChoice,
-	customAddress: ISlotAddress | null
+	customAddress: ISlotAddress | null,
+	onSuccess: () => void
 ) => {
-	const { bookAppointmentWithLink } = usePatient();
+	const { t } = useTranslation();
+	const { showAlert } = useAlert();
+	const queryClient = useQueryClient();
 	const methods = useForm<ICreatePatientForm>({ mode: 'onChange' });
 	const {
 		handleSubmit,
@@ -24,37 +33,75 @@ export const useBookingForm = (
 	} = methods;
 
 	const onSubmit = async (formData: ICreatePatientForm) => {
-		const { email, firstName, lastName } = formData;
-		const { fullPhone, fullWhatsapp } = getFormattedContacts(formData);
+		try {
+			const { email, firstName, lastName, preferredContact } = formData;
+			const { fullPhone: rawPhone, fullWhatsapp: rawWhatsapp } =
+				getFormattedContacts(formData);
 
-		if (locationChoice === 'custom' && customAddress) {
-			await editSlot({
-				address: customAddress,
+			const phoneFromPreferred =
+				preferredContact?.type === 'phone' ||
+				preferredContact?.type === 'whatsapp'
+					? preferredContact.value
+					: undefined;
+
+			const fullPhone = phoneFromPreferred || rawPhone;
+			const fullWhatsapp =
+				preferredContact?.type === 'whatsapp'
+					? preferredContact.value || rawWhatsapp
+					: rawWhatsapp;
+
+			if (locationChoice === 'custom' && customAddress) {
+				await editSlot({
+					address: customAddress,
+					availabilityDayId: slot.availabilityDayId ?? '',
+					slotId: slot._id ?? slot.id,
+					therapistId: therapistId ?? '',
+				});
+			}
+
+			const { recurrencePattern } = formData;
+
+			await bookSlotByTherapist({
+				therapistId: therapistId ?? '',
 				availabilityDayId: slot.availabilityDayId ?? '',
 				slotId: slot._id ?? slot.id,
-				therapistId: therapistId ?? '',
-			});
-		}
-
-		bookAppointmentWithLink({
-			therapistId,
-			data: {
-				availabilityDayId: slot.availabilityDayId ?? '',
 				patient: {
 					contacts: {
-						email,
-						phone: fullPhone,
+						...(email ? { email } : {}),
+						...(fullPhone ? { phone: fullPhone } : {}),
 						...(fullWhatsapp ? { whatsapp: fullWhatsapp } : {}),
 					},
 					firstName,
 					lastName,
+					...(preferredContact?.type && preferredContact?.value
+						? { preferredContact }
+						: {}),
 				},
-				shouldReplicate: false,
+				...(recurrencePattern ? { recurrencePattern } : {}),
+				shouldReplicate: recurrencePattern
+					? recurrencePattern !== RecurrencePattern.SINGLE
+					: false,
 				shareAddress: locationChoice === 'clinic',
-				slotId: slot._id ?? slot.id,
-				timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-			},
-		});
+				timeZone:
+					formData.timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
+			});
+
+			await queryClient.invalidateQueries({
+				queryKey: ['therapistAvailability'],
+			});
+
+			showAlert({
+				message: t('availability.week.drawer.booking-success'),
+				severity: 'success',
+			});
+
+			onSuccess();
+		} catch {
+			showAlert({
+				message: t('availability.week.drawer.booking-error'),
+				severity: 'error',
+			});
+		}
 	};
 
 	return { isSubmitting, methods, submitBooking: handleSubmit(onSubmit) };

--- a/src/pages/availability/week/drawer/hooks/useEditSlotForm.ts
+++ b/src/pages/availability/week/drawer/hooks/useEditSlotForm.ts
@@ -59,6 +59,9 @@ export const useEditSlotForm = (
 				severity: data.wasBooked ? 'warning' : 'success',
 			});
 			queryClient.invalidateQueries({ queryKey: ['therapistAvailability'] });
+			queryClient.invalidateQueries({
+				queryKey: ['slotAppointmentDetails', slot._id ?? slot.id],
+			});
 			onSaved();
 		},
 	});

--- a/src/pages/availability/week/drawer/views/slot-available-body/SlotAvailableBody.tsx
+++ b/src/pages/availability/week/drawer/views/slot-available-body/SlotAvailableBody.tsx
@@ -1,41 +1,77 @@
-import { FormProvider } from 'react-hook-form';
+import { useMemo } from 'react';
+import { FormProvider, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
 import type { ICreatePatientForm } from '@psycron/api/patient/index.types';
 import { ContactsForm } from '@psycron/components/form/components/contacts/ContactsForm';
 import { NameForm } from '@psycron/components/form/components/name/NameForm';
+import { PreferredContactForm } from '@psycron/components/form/components/preferred-contact/PreferredContactForm';
+import { TimezoneSelect } from '@psycron/components/form/components/timezone/TimezoneSelect';
 
 import { FormWrapper } from '../../AvailabilityWeekDrawer.styles';
 import { SlotLocationSection } from '../slot-location-section/SlotLocationSection';
+import { SlotRecurrenceSection } from '../slot-recurrence-section/SlotRecurrenceSection';
+import { SlotSessionDeliverySection } from '../slot-session-delivery/SlotSessionDeliverySection';
 
 import type { ISlotAvailableBodyProps } from './SlotAvailableBody.types';
 
 export const SlotAvailableBody = ({
 	methods,
-	showSessionLocation,
+	sessionType,
 	...locationProps
 }: ISlotAvailableBodyProps) => {
 	const { t } = useTranslation();
+	const { control } = methods;
+
+	const selectedPreferredType = useWatch({
+		control,
+		name: 'preferredContact.type',
+	});
+	const sessionDelivery = useWatch({ control, name: 'sessionDelivery' });
+
+	// For non-BOTH types, derive delivery from sessionType
+	const effectiveDelivery = useMemo(() => {
+		if (sessionType === 'ONLINE') return 'online' as const;
+		if (sessionType === 'IN_PERSON') return 'in_person' as const;
+		return sessionDelivery; // BOTH: follows user card choice
+	}, [sessionType, sessionDelivery]);
+
+	const isOnline = effectiveDelivery === 'online';
+	const isInPerson = effectiveDelivery === 'in_person';
+
+	// Show contacts form for all delivery modes once a choice is made
+	const showContactsForm = isInPerson || isOnline;
+
+	// Require at least one contact for in-person or when platform = phone/whatsapp
+	// Meet/Zoom contacts are optional extras
+	const requireContacts =
+		isInPerson ||
+		selectedPreferredType === 'phone' ||
+		selectedPreferredType === 'whatsapp';
 
 	return (
-		<>
-			<FormProvider {...methods}>
-				<Box component='form'>
-					<FormWrapper>
-						<NameForm<ICreatePatientForm>
-							required
-							fields={{ firstName: 'firstName', lastName: 'lastName' }}
-							labelFirstName={t('availability.week.drawer.patient-first-name')}
-							labelLastName={t('availability.week.drawer.patient-last-name')}
-							placeholderFirstName={t(
-								'availability.week.drawer.patient-first-name'
-							)}
-							placeholderLastName={t(
-								'availability.week.drawer.patient-last-name'
-							)}
-						/>
+		<FormProvider {...methods}>
+			<Box component='form'>
+				<FormWrapper>
+					<NameForm<ICreatePatientForm>
+						required
+						fields={{ firstName: 'firstName', lastName: 'lastName' }}
+						labelFirstName={t('availability.week.drawer.patient-first-name')}
+						labelLastName={t('availability.week.drawer.patient-last-name')}
+						placeholderFirstName={t(
+							'availability.week.drawer.patient-first-name'
+						)}
+						placeholderLastName={t(
+							'availability.week.drawer.patient-last-name'
+						)}
+					/>
+					{sessionType === 'BOTH' && <SlotSessionDeliverySection />}
+
+					{isOnline && <PreferredContactForm />}
+
+					{showContactsForm && (
 						<ContactsForm<ICreatePatientForm>
-							atLeastOneContact
+							atLeastOneContact={requireContacts}
 							fullWidth
 							fields={{
 								email: 'email',
@@ -47,10 +83,12 @@ export const SlotAvailableBody = ({
 							labelEmail={t('availability.week.drawer.patient-email')}
 							placeholderEmail={t('availability.week.drawer.patient-email')}
 						/>
-					</FormWrapper>
-				</Box>
-				{showSessionLocation && <SlotLocationSection {...locationProps} />}
-			</FormProvider>
-		</>
+					)}
+					{isInPerson && <SlotLocationSection {...locationProps} />}
+					<SlotRecurrenceSection />
+					<TimezoneSelect />
+				</FormWrapper>
+			</Box>
+		</FormProvider>
 	);
 };

--- a/src/pages/availability/week/drawer/views/slot-available-body/SlotAvailableBody.types.ts
+++ b/src/pages/availability/week/drawer/views/slot-available-body/SlotAvailableBody.types.ts
@@ -5,5 +5,5 @@ import type { ISlotLocationSectionProps } from '../slot-location-section/SlotLoc
 
 export interface ISlotAvailableBodyProps extends ISlotLocationSectionProps {
 	methods: UseFormReturn<ICreatePatientForm>;
-	showSessionLocation: boolean;
+	sessionType?: string;
 }

--- a/src/pages/availability/week/drawer/views/slot-recurrence-section/SlotRecurrenceSection.tsx
+++ b/src/pages/availability/week/drawer/views/slot-recurrence-section/SlotRecurrenceSection.tsx
@@ -1,0 +1,64 @@
+import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { type ICreatePatientForm,RecurrencePattern } from '@psycron/api/patient/index.types';
+
+import {
+	LocationChoiceCard,
+	LocationChoiceCardLabel,
+	LocationChoiceGrid,
+	LocationSection,
+	LocationSectionLabel,
+} from '../slot-location-section/SlotLocationSection.styles';
+
+interface IRecurrenceOption {
+	labelKey: string;
+	pattern: RecurrencePattern;
+}
+
+const RECURRENCE_OPTIONS: IRecurrenceOption[] = [
+	{
+		labelKey: 'availability.week.drawer.recurrence-single',
+		pattern: RecurrencePattern.SINGLE,
+	},
+	{
+		labelKey: 'availability.week.drawer.recurrence-end-month',
+		pattern: RecurrencePattern.UNTIL_END_OF_MONTH,
+	},
+	{
+		labelKey: 'availability.week.drawer.recurrence-end-year',
+		pattern: RecurrencePattern.UNTIL_END_OF_YEAR,
+	},
+	{
+		labelKey: 'availability.week.drawer.recurrence-all',
+		pattern: RecurrencePattern.ALL_APPOINTMENTS,
+	},
+];
+
+export const SlotRecurrenceSection = () => {
+	const { t } = useTranslation();
+	const { watch, setValue } = useFormContext<ICreatePatientForm>();
+	const selected = watch('recurrencePattern');
+
+	return (
+		<LocationSection>
+			<LocationSectionLabel>
+				{t('availability.week.drawer.recurrence-label')}
+			</LocationSectionLabel>
+
+			<LocationChoiceGrid style={{ flexWrap: 'wrap' }}>
+				{RECURRENCE_OPTIONS.map(({ pattern, labelKey }) => (
+					<LocationChoiceCard
+						key={pattern}
+						onClick={() =>
+							setValue('recurrencePattern', pattern, { shouldDirty: true })
+						}
+						tertiary
+						variant={selected === pattern ? 'contained' : 'outlined'}
+					>
+						<LocationChoiceCardLabel>{t(labelKey)}</LocationChoiceCardLabel>
+					</LocationChoiceCard>
+				))}
+			</LocationChoiceGrid>
+		</LocationSection>
+	);
+};

--- a/src/pages/availability/week/drawer/views/slot-session-delivery/SlotSessionDeliverySection.tsx
+++ b/src/pages/availability/week/drawer/views/slot-session-delivery/SlotSessionDeliverySection.tsx
@@ -1,0 +1,74 @@
+import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import type { ICreatePatientForm, SessionDelivery } from '@psycron/api/patient/index.types';
+import { Globe, MapPin } from '@psycron/components/icons';
+
+import {
+	LocationChoiceCard,
+	LocationChoiceCardLabel,
+	LocationChoiceGrid,
+	LocationChoiceSubtitle,
+	LocationSection,
+	LocationSectionLabel,
+} from '../slot-location-section/SlotLocationSection.styles';
+
+interface IDeliveryOption {
+	delivery: SessionDelivery;
+	icon: JSX.Element;
+	labelKey: string;
+	subtitleKey: string;
+}
+
+const DELIVERY_OPTIONS: IDeliveryOption[] = [
+	{
+		delivery: 'online',
+		icon: <Globe />,
+		labelKey: 'availability.week.drawer.session-delivery-online',
+		subtitleKey: 'availability.week.drawer.session-delivery-online-subtitle',
+	},
+	{
+		delivery: 'in_person',
+		icon: <MapPin />,
+		labelKey: 'availability.week.drawer.session-delivery-in-person',
+		subtitleKey:
+			'availability.week.drawer.session-delivery-in-person-subtitle',
+	},
+];
+
+export const SlotSessionDeliverySection = () => {
+	const { t } = useTranslation();
+	const { watch, setValue } = useFormContext<ICreatePatientForm>();
+	const selected = watch('sessionDelivery');
+
+	return (
+		<LocationSection>
+			<LocationSectionLabel>
+				{t('availability.week.drawer.session-delivery-label')}
+			</LocationSectionLabel>
+
+			<LocationChoiceGrid>
+				{DELIVERY_OPTIONS.map(({ delivery, icon, labelKey }) => (
+					<LocationChoiceCard
+						key={delivery}
+						onClick={() =>
+							setValue('sessionDelivery', delivery, { shouldDirty: true })
+						}
+						tertiary
+						variant={selected === delivery ? 'contained' : 'outlined'}
+					>
+						{icon}
+						<LocationChoiceCardLabel>{t(labelKey)}</LocationChoiceCardLabel>
+					</LocationChoiceCard>
+				))}
+			</LocationChoiceGrid>
+
+			<LocationChoiceGrid>
+				{DELIVERY_OPTIONS.map(({ delivery, subtitleKey }) => (
+					<LocationChoiceSubtitle key={`${delivery}-subtitle`}>
+						{selected === delivery && t(subtitleKey)}
+					</LocationChoiceSubtitle>
+				))}
+			</LocationChoiceGrid>
+		</LocationSection>
+	);
+};

--- a/src/theme/form/form-label/formLabel.theme.tsx
+++ b/src/theme/form/form-label/formLabel.theme.tsx
@@ -1,9 +1,9 @@
 import type { Theme } from '@mui/material/styles';
 import type { CSSObject } from '@mui/system';
-import type { Palette } from '@psycron/theme/palette/palette.types';
+import type { AppPalette } from '@psycron/theme/palette/palette.types';
 
 const formLabel = ({ palette }: Theme): Record<string, CSSObject> => {
-	const { secondary } = palette as unknown as Palette;
+	const { secondary } = palette as unknown as AppPalette;
 
 	return {
 		asterisk: {

--- a/src/theme/input/label/label.theme.tsx
+++ b/src/theme/input/label/label.theme.tsx
@@ -1,10 +1,10 @@
 import { inputLabelClasses } from '@mui/material';
 import type { Theme } from '@mui/material/styles';
 import type { CSSObject } from '@mui/system';
-import type { Palette } from '@psycron/theme/palette/palette.types';
+import type { AppPalette } from '@psycron/theme/palette/palette.types';
 
 const labelStyles = ({ palette }: Theme): Record<string, CSSObject> => {
-	const { text, tertiary, brand } = palette as unknown as Palette;
+	const { text, tertiary, brand } = palette as unknown as AppPalette;
 
 	return {
 		root: {


### PR DESCRIPTION
## Summary

- Dedicated `bookSlotByTherapist` endpoint replaces misused public patient booking path
- Recurrence pattern selector (single / end-of-month / end-of-year / all) in booking drawer
- Session delivery selector (online / in-person) for BOTH session types
- `TimezoneSelect` with Google Timezone API proxied through backend to avoid key restriction
- `PreferredContactForm` for online sessions (Google Meet, Zoom, phone, WhatsApp)
- WhatsApp/Meet/Zoom/phone call link rendered in booked slot drawer header via `buildContactLink`
- `shouldReplicate` derived from `recurrencePattern` (true unless SINGLE)
- `useEditSlotForm` invalidates `slotAppointmentDetails` cache on success
- `IContactInfo.email` made optional; `ContactsForm` email field no longer required
- i18n keys added for EN and PT (booking feedback, recurrence, session delivery, contact links)

## Test plan

- [x] Book a slot as therapist — confirm patient created/updated correctly
- [x] Select each recurrence pattern — verify `shouldReplicate` sent correctly
- [x] BOTH session type: select online → PreferredContactForm appears; select in-person → location section appears
- [x] Set timezone via address search — verify correct IANA timezone saved
- [x] Booked slot with WhatsApp PoC → "Call on WhatsApp" button links to `wa.me/{number}`
- [x] Booked slot with Google Meet / Zoom PoC → join link rendered
- [x] Edit slot → slot detail view refreshes immediately
- [x] No email provided → booking still succeeds (email optional)
- [x] EN and PT translations render correctly

## Jira

[PR-271](https://psycron.atlassian.net/browse/PR-271)

🤖 Generated with [Claude Code](https://claude.com/claude-code)