### PR TITLE
fix(env): remove staging runtime env and overly strict prod-only validation

### DIFF
--- a/src/utils/env/validateEnv.ts
+++ b/src/utils/env/validateEnv.ts
@@ -55,7 +55,7 @@ const OPTIONAL_ENV_VARS: Record<string, string> = {
 	VITE_TEST_MODE: 'Optional testing mode override',
 };
 
-const VALID_RUNTIME_ENVS = ['dev', 'staging', 'prod'] as const;
+const VALID_RUNTIME_ENVS = ['dev', 'prod'] as const;
 const VALID_TEST_MODE_VALUES = ['true', 'false', '1', '0', 'test', 'app'] as const;
 
 const DEPRECATED_ENV_ALIASES = [
@@ -164,13 +164,6 @@ export const validateEnv = (): ValidationResult => {
 	) {
 		errors.push(
 			`VITE_RUNTIME_ENV must be one of: ${VALID_RUNTIME_ENVS.join(', ')}`
-		);
-	}
-
-	// In production builds, force runtime classification to production.
-	if (!isDev && runtimeEnv && runtimeEnv !== 'prod') {
-		errors.push(
-			`VITE_RUNTIME_ENV must be "prod" in production mode. Current value: "${runtimeEnv}"`
 		);
 	}
 


### PR DESCRIPTION
## Summary
- Removes `staging` from valid `VITE_RUNTIME_ENV` values — only `dev` and `prod` are used
- Drops the `!isDev` guard that blocked all non-localhost builds with non-`prod` values (`import.meta.env.DEV` is `false` for any Vite build artifact, not just production)

## Root cause
The validation was crashing any Vercel preview/dev deployment that had `VITE_RUNTIME_ENV=staging` set, showing a "Configuration Error" on the app.

## Test plan
- [ ] Vercel preview deployment with `VITE_RUNTIME_ENV=dev` loads without config error
- [ ] Production deployment with `VITE_RUNTIME_ENV=prod` loads correctly
- [ ] Setting an invalid value (e.g. `staging`) correctly fails validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)