### PR TITLE
feat(observability): tester-friendly error tracking workflow

### DIFF
--- a/src/analytics/posthog/AppAnalytics.tsx
+++ b/src/analytics/posthog/AppAnalytics.tsx
@@ -1,6 +1,7 @@
 import { type FC, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { usePostHog } from '@posthog/react';
+import * as Sentry from '@sentry/react';
 import type { Properties } from 'posthog-js';
 
 import type { AppAnalyticsProps } from './AppAnalytics.types';
@@ -21,6 +22,14 @@ export const AppAnalytics: FC<AppAnalyticsProps> = ({
 		if (!isAuthenticated || !distinctId) return;
 
 		client.identify(distinctId, identifyProps);
+
+		const sessionReplayUrl = client.get_session_replay_url({
+			withTimestamp: true,
+		});
+
+		if (sessionReplayUrl) {
+			Sentry.setTag('posthog_session_url', sessionReplayUrl);
+		}
 	}, [client, isAuthenticated, distinctId]);
 
 	useEffect((): void => {

--- a/src/analytics/posthog/config.ts
+++ b/src/analytics/posthog/config.ts
@@ -50,6 +50,13 @@ export const initPostHog = (): void => {
 			maskInputOptions: {
 				password: true,
 			},
+			recordHeaders: false,
+			recordBody: false,
+			networkRecordOptions: {
+				recordHeaders: false,
+				recordBody: false,
+				recordInitiatorType: true,
+			},
 		},
 
 		// ✅ Performance & UX metrics

--- a/src/analytics/sentry/sentry.ts
+++ b/src/analytics/sentry/sentry.ts
@@ -120,6 +120,23 @@ export const initSentry = (): void => {
 		integrations: [
 			Sentry.replayIntegration(),
 			Sentry.browserTracingIntegration(),
+			Sentry.feedbackIntegration({
+				autoInject: true,
+				showBranding: false,
+				colorScheme: 'system',
+				triggerLabel: 'Report a Bug',
+				formTitle: 'Report a Bug',
+				nameLabel: 'Name',
+				namePlaceholder: 'Your name',
+				emailLabel: 'Email',
+				emailPlaceholder: 'your@email.com',
+				messageLabel: 'What happened?',
+				messagePlaceholder:
+					'Describe what you were doing and what went wrong.',
+				submitButtonLabel: 'Send Report',
+				cancelButtonLabel: 'Cancel',
+				successMessageText: 'Thank you! Your report has been sent.',
+			}),
 		],
 	});
 };

--- a/vercel.json
+++ b/vercel.json
@@ -26,6 +26,8 @@
     }
   ],
   "rewrites": [
-    { "source": "/:locale/:path*", "destination": "/index.html" }
+    { "source": "/api-docs",        "destination": "https://api.psycron.app/api-docs" },
+    { "source": "/api-docs/:path*", "destination": "https://api.psycron.app/api-docs/:path*" },
+    { "source": "/:locale/:path*",  "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- **PostHog network capture**: session replays now include API call URLs + status codes (no headers/bodies — LGPD safe)
- **Sentry ↔ PostHog link**: sets `posthog_session_url` tag on Sentry events so devs can jump from error → exact replay moment
- **Sentry Feedback widget**: in-app "Report a Bug" button for testers to annotate issues without dev tools or external dashboards
- **Vercel api-docs proxy**: rewrites `/api-docs` to the BE Swagger UI

## Workflow
```
Tester uses the app
  → Errors captured silently (Sentry + PostHog replay with network calls)
  → Tester notices something off → clicks "Report a Bug" → types a sentence
  → Dev opens Sentry → sees grouped errors + tester feedback
  → Clicks posthog_session_url tag → watches replay with API calls
  → Real bug? → one click → create Jira issue from Sentry UI
```

## Test plan
- [ ] Deploy to staging and verify "Report a Bug" button renders
- [ ] Submit a feedback report and confirm it appears in Sentry
- [ ] Trigger an error and verify `posthog_session_url` tag is set on the Sentry event
- [ ] Check PostHog session replay includes network requests (URL + status)
- [ ] Verify `/api-docs` proxies correctly to BE Swagger UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)