### PR TITLE
feat(notifications): pr-335-v2 whatsapp otp challenge, sms toggled off, auth context 2fa

### DIFF
--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -110,6 +110,24 @@ export const getGoogleCalendarStatus = async (): Promise<{
 	return response.data;
 };
 
+export type VerifyWhatsAppOtpResponse = {
+	refreshToken: string;
+	status: 'success';
+	token: string;
+	user: { _id: string; firstName: string; lastName: string; role: string };
+};
+
+export const verifyWhatsAppOtpFc = async (data: {
+	otp: string;
+	therapistId: string;
+}): Promise<VerifyWhatsAppOtpResponse> => {
+	const response = await apiClient.post<VerifyWhatsAppOtpResponse>(
+		'/users/whatsapp-otp/verify',
+		data
+	);
+	return response.data;
+};
+
 /**
  * @deprecated getEncryptionKey removed for security (P1.3)
  * The encryption key endpoint was removed from the backend.

--- a/src/api/dashboard/index.types.ts
+++ b/src/api/dashboard/index.types.ts
@@ -94,7 +94,7 @@ export interface DashboardBillingReadiness {
 	totalCount: number;
 }
 
-export type DashboardNotificationChannel = 'EMAIL' | 'ICALENDAR' | 'SMS' | 'WHATSAPP';
+export type DashboardNotificationChannel = 'EMAIL' | 'ICALENDAR' | 'WHATSAPP';
 
 export interface DashboardNotifications24h {
 	channels: Record<DashboardNotificationChannel, number>;

--- a/src/api/notifications/index.types.ts
+++ b/src/api/notifications/index.types.ts
@@ -1,4 +1,4 @@
-export type NotificationChannel = 'EMAIL' | 'ICALENDAR' | 'SMS' | 'WHATSAPP';
+export type NotificationChannel = 'EMAIL' | 'ICALENDAR' | 'WHATSAPP';
 
 export interface INotificationChannelPref {
 	email: boolean;
@@ -29,12 +29,13 @@ export interface IUpdateNotificationPreferencesResponse {
 export type NotificationStatus = 'DELIVERED' | 'FAILED' | 'PENDING' | 'SENT';
 
 export type NotificationMessageType =
+	| 'ACCOUNT_SETUP'
 	| 'APPOINTMENT_CONFIRMATION'
 	| 'APPOINTMENT_UPDATED'
-	| 'ACCOUNT_SETUP'
 	| 'CONFLICT'
 	| 'DAILY_SCHEDULE_SUMMARY'
 	| 'REMINDER'
+	| 'WHATSAPP_ACTION_REQUIRED'
 	| string;
 
 export interface INotificationPatient {

--- a/src/api/subs/index.ts
+++ b/src/api/subs/index.ts
@@ -30,3 +30,13 @@ export const unSubscribe = async (
 	);
 	return response.data;
 };
+
+export const unsubscribeByEmail = async (
+	email: string
+): Promise<UnsubscribeResponse> => {
+	const response = await apiClient.post<UnsubscribeResponse>(
+		'/subs/unsubscribe-email',
+		{ email }
+	);
+	return response.data;
+};

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -1270,6 +1270,14 @@
       "success-title": "You have been unsubscribed",
       "success-description": "If this email was on our list, it has been removed. You will no longer receive marketing emails from Psycron.",
       "back-home": "Back to homepage"
+    },
+    "auth": {
+      "whatsapp-otp": {
+        "title": "Two-step verification",
+        "description": "Enter the 6-digit code sent to your WhatsApp number.",
+        "label": "Verification code",
+        "submit": "Verify"
+      }
     }
   },
   "chat": {
@@ -2091,7 +2099,8 @@
       "conflict": "Conflict",
       "account_setup": "Account setup",
       "daily_schedule_summary": "Daily schedule summary",
-      "unknown": "Notification"
+      "unknown": "Notification",
+      "whatsapp_action_required": "WhatsApp follow-up required"
     },
     "bulk": {
       "resend-eligible": "Re-notify eligible",

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -1,2178 +1,2189 @@
 {
-	"public": {
-		"powered-by": "Powered by Psycron"
-	},
-	"booking": {
-		"page": {
-			"title": "Book a Session"
-		},
-		"calendar": {
-			"title": "Select a date and time",
-			"subtitle": "Pick a day first, then choose the time that works best for you.",
-			"booking-greeting": "Hello, choose your appointment.",
-			"detail-title": "Choose a date",
-			"view-month": "Month",
-			"view-week": "Week",
-			"pick-a-day": "Select a date on the calendar to see what is available.",
-			"no-date-title": "No date selected yet",
-			"no-date-body": "Start by choosing a highlighted day from the calendar.",
-			"no-times-title": "No times for this day",
-			"no-times-body": "Try another highlighted date or switch the time-of-day filter.",
-			"available-count": "available times",
-			"sidebar-description": "Choose the day and time that work best for you.",
-			"duration-heading": "Session length",
-			"duration-pending": "Select a time to preview the duration.",
-			"location-pending": "Choose a date and time to preview the session location.",
-			"date-heading": "Selected day",
-			"date-pending": "Pick a date from the calendar.",
-			"agenda-title": "Appointments",
-			"agenda-main-title": "Calendar",
-			"agenda-subtitle": "Tap a day to focus on just the appointments that matter on that date.",
-			"agenda-greeting": "Hello, {{name}}, check your appointments.",
-			"agenda-greeting-fallback": "Hello, check your appointments.",
-			"agenda-sidebar-description": "A view of your journey with quick access to upcoming, past, and cancelled sessions.",
-			"agenda-overview-title": "Overview",
-			"agenda-overview-fallback": "Overview",
-			"agenda-overview-heading": "Overview",
-			"agenda-overview-heading-fallback": "Overview",
-			"active-days": "Active days",
-			"day-appointments": "appointments on this day",
-			"selected-day-section": "Appointments of the day",
-			"next-appointments-section": "Next appointments",
-			"no-appointments-title": "Nothing scheduled for this day",
-			"no-appointments-body": "Choose another highlighted date to review your appointments.",
-			"no-next-appointments": "Your next confirmed appointments will appear here."
-		},
-		"filter": {
-			"from": "From",
-			"label-date-range": "Date range",
-			"label-time-of-day": "Time of day",
-			"time-all": "Any time",
-			"time-morning": "Morning (before noon)",
-			"time-afternoon": "Afternoon (12–17h)",
-			"time-evening": "Evening (after 17h)",
-			"time-of-day": "Time of day",
-			"to": "To",
-			"weeks-1": "Next week",
-			"weeks-2": "Next 2 weeks",
-			"weeks-4": "Next month",
-			"weeks-12": "Next 3 months",
-			"weeks-all": "All available"
-		},
-		"slot": {
-			"booked": "Booked",
-			"taken": "Taken"
-		},
-		"drawer": {
-			"aria-label": "Book appointment",
-			"title": "Confirm your booking"
-		},
-		"confirm": "Confirm",
-		"error": "Something went wrong. Please try again.",
-		"no-slots": "No available slots match your filters.",
-		"form": {
-			"address-fallback": "Address will appear here after you enter it above.",
-			"email": "Email",
-			"first-name": "First name",
-			"last-name": "Last name",
-			"notify-email": "Notify me by email",
-			"notify-fallback": "Provide your contact details above to enable notifications.",
-			"notify-whatsapp": "Notify me by WhatsApp",
-			"section-notifications": "Notifications",
-			"section-personal": "Your details",
-			"section-recurrence": "Recurrence",
-			"your-address": "Session address"
-		},
-		"notifications": {
-			"description": "We'll send you a reminder before each session.",
-			"email": "Notify me by email",
-			"fallback-note": "Add your contact details above to enable reminders.",
-			"title": "Reminders",
-			"whatsapp": "Notify me by WhatsApp"
-		},
-		"recurrence": {
-			"biweekly": "Every 2 weeks",
-			"monthly": "Every month",
-			"not-yet": "Not yet — decide later",
-			"single": "One-time session",
-			"title": "How often would you like to meet?",
-			"weekly": "Every week"
-		},
-		"confirmation": {
-			"title": "You're booked!",
-			"subtitle": "Great, {{name}}! Your session has been confirmed.",
-			"date": "Date",
-			"time": "Time",
-			"your-agenda": "Your personal agenda",
-			"agenda-description": "Use this link to view and manage your upcoming appointments.",
-			"copy-link": "Copy link"
-		},
-		"appointments": {
-			"title": "Your appointments",
-			"subtitle": "View and manage your scheduled sessions.",
-			"upcoming": "Upcoming",
-			"past": "Past",
-			"cancelled": "Cancelled",
-			"no-upcoming": "You have no upcoming appointments.",
-			"no-upcoming-title": "No upcoming sessions",
-			"no-past": "Completed appointments will appear here after your sessions.",
-			"no-past-title": "No past appointments yet",
-			"no-cancelled": "Cancelled appointments will stay here for your reference.",
-			"no-cancelled-title": "No cancelled appointments",
-			"therapist-fallback": "Your therapist"
-		},
-		"patient-drawer": {
-			"aria-label": "Patient appointment details",
-			"role": "Your appointment",
-			"available-title": "Confirm & book",
-			"available-subtitle": "Review this slot before completing your booking.",
-			"available-badge": "Available",
-			"confirmed-title": "Your appointment",
-			"confirmed-badge": "Confirmed",
-			"completed-title": "Completed appointment",
-			"completed-badge": "Completed",
-			"cancelled-title": "Cancelled appointment",
-			"cancelled-badge": "Cancelled",
-			"cancelled-notice": "This appointment was cancelled on {{date}}.",
-			"therapist-section": "Therapist",
-			"details-section": "Session details",
-			"contact-section": "Contact",
-			"reschedule-section": "Choose a new time",
-			"specialty-fallback": "Specialty details coming soon",
-			"when": "{{date}} at {{time}}",
-			"when-label": "When",
-			"duration": "{{minutes}} min",
-			"duration-label": "Duration",
-			"session-type-label": "Session type",
-			"session-online": "Online session",
-			"session-in-person": "In-person session",
-			"location-label": "Location",
-			"location-online": "Online session",
-			"location-in-person": "In-person location will be confirmed by your therapist.",
-			"location-address": "{{address}}",
-			"awaiting-address": "Waiting for the session address",
-			"call-therapist": "Call therapist",
-			"copy-phone": "Copy phone",
-			"cancel": "Cancel appointment",
-			"reschedule": "Reschedule",
-			"confirm-reschedule": "Confirm reschedule",
-			"reschedule-success": "Appointment rescheduled successfully.",
-			"reschedule-error": "We could not reschedule this appointment. Please try again.",
-			"no-reschedule-slots": "No other available slots were found right now.",
-			"book-new": "Book new appointment",
-			"session-completed": "Session completed"
-		},
-		"cancel": {
-			"button": "Cancel appointment",
-			"reason-prompt": "Please let us know why you need to cancel.",
-			"reason-label": "Reason",
-			"reason": {
-				"emergency": "Personal emergency",
-				"schedule-conflict": "Schedule conflict",
-				"financial": "Financial reasons",
-				"mental-health": "Not feeling ready",
-				"other": "Other"
-			},
-			"custom-reason": "Tell us more (optional)",
-			"confirm": "Confirm cancellation",
-			"success": "Your appointment has been cancelled.",
-			"error": "Something went wrong. Please try again."
-		}
-	},
-	"common": {
-		"back": "Back",
-		"cancel": "Cancel",
-		"close": "Close",
-		"layout": {
-			"collapse-queue": "Collapse",
-			"expand-queue": "Expand"
-		},
-		"loading": "Loading...",
-		"required": "Required",
-		"save": "Save",
-		"saving": "Saving...",
-		"today": "Today"
-	},
-	"patients": {
-		"list": {
-			"title": "Patient Center",
-			"subtitle": "Browse, search and manage your patients.",
-			"search-label": "Search",
-			"search-placeholder": "Search by name, email, or phone",
-			"status-label": "Status",
-			"status-all": "All patients",
-			"status-active": "Active",
-			"status-inactive": "Inactive",
-			"sort-label": "Sort by",
-			"sort-name": "Name (A-Z)",
-			"sort-name-desc": "Name (Z-A)",
-			"sort-last-appointment-asc": "Last appointment (oldest first)",
-			"sort-last-appointment": "Last appointment",
-			"sort-total-sessions-asc": "Total sessions (lowest first)",
-			"sort-total-sessions": "Total sessions",
-			"columns": {
-				"patient": "Patient",
-				"contact": "Contact",
-				"preferred-contact": "Preferred contact",
-				"timezone": "Timezone",
-				"billing": "Billing",
-				"recovery": "Recovery",
-				"last-appointment": "Last appointment",
-				"sessions": "Sessions",
-				"status": "Status"
-			},
-			"empty": {
-				"initial-title": "No patients yet",
-				"initial-body": "When you add or book your first patient, they will appear here and become part of your Patient Center.",
-				"filtered-title": "No patients match these filters",
-				"filtered-body": "Try adjusting your search or filters to find the patient you are looking for."
-			},
-			"clear-search": "Clear search",
-			"billing": {
-				"none": "Not set",
-				"per-session-short": "/ session",
-				"monthly-short": "/ month"
-			},
-			"not-available": "Not available",
-			"no-appointments": "No appointments yet",
-			"contact-method-not-set": "Not set",
-			"possible-duplicate": "Possible duplicate",
-			"cancellation-follow-up-needed": "{{count}} needs follow-up",
-			"cancellation-follow-up-needed_other": "{{count}} need follow-up",
-			"cancellation-follow-up-tooltip": "{{count}} cancelled session has no follow-up, rebook, archive, or reopen recorded.",
-			"cancellation-follow-up-tooltip_other": "{{count}} cancelled sessions have no follow-up, rebook, archive, or reopen recorded.",
-			"cancellation-follow-up-none": "No cancellations",
-			"cancellation-follow-up-resolved": "Resolved",
-			"cancelled-sessions-notice": "{{count}} cancelled session",
-			"cancelled-sessions-notice_other": "{{count}} cancelled sessions"
-		},
-		"profile": {
-			"subtitle": "Review contact details, care preferences, and session history.",
-			"member-since": "Patient since {{date}}",
-			"unknown-patient": "unknown patient",
-			"merged-note": "This patient record was merged into {{patientId}} and is kept for audit history.",
-			"not-found": "We could not load this patient. They may have been archived or merged into another record.",
-			"actions": {
-				"call": "Call",
-				"edit": "Edit patient",
-				"open-sessions": "Open sessions page",
-				"whatsapp": "WhatsApp",
-				"email": "Email"
-			},
-			"edit": {
-				"title": "Edit patient details",
-				"description": "Update contact details, care preferences, timezone, and address.",
-				"save": "Save changes"
-			},
-			"session-drawer": {
-				"title": "Session details",
-				"open-label": "Open session details for {{date}}",
-				"status": "Status",
-				"delivery": "Session format",
-				"cancelled-at": "Cancelled at",
-				"cancellation-reason": "Cancellation reason",
-				"cancelled-by": "Cancelled by",
-				"cancelled-by-patient": "Patient",
-				"cancelled-by-therapist": "Therapist",
-				"cancelled-by-unknown": "Not available",
-				"notification": "Notification",
-				"notification-sent": "Notification sent",
-				"notification-not-sent": "Notification not sent",
-				"cancel-confirm": "Confirm cancellation",
-				"cancel-custom-reason": "Please describe the reason",
-				"cancel-error": "We could not cancel this session. Please try again.",
-				"cancel-reason-prompt": "Why are you cancelling this session?",
-				"cancel-session": "Cancel session",
-				"cancel-success": "Session cancelled successfully.",
-				"cancelled-title": "Session cancelled",
-				"completed-title": "Session completed",
-				"notify": "Notify patient",
-				"notify-error": "We could not send the notification. Please try again.",
-				"notify-sending": "Sending notification…",
-				"notify-success": "Patient notified successfully.",
-				"read-only": "Cancelled sessions are available for review only.",
-				"reschedule": "Reschedule",
-				"reschedule-confirm": "Confirm reschedule",
-				"reschedule-error": "We could not reschedule this appointment. Please try again.",
-				"reschedule-no-slots": "No available slots to reschedule to. Try adjusting your working hours.",
-				"reschedule-prompt": "Select a new time slot for this appointment.",
-				"reschedule-success": "Appointment rescheduled successfully.",
-				"role": "Patient session",
-				"upcoming-title": "Upcoming session",
-				"update-error": "We could not update this session. Please try again.",
-				"update-no-change": "No changes were made — the session time is the same.",
-				"update-success": "Session updated successfully."
-			},
-			"status": {
-				"active": "Active",
-				"archived": "Archived",
-				"merged": "Merged"
-			},
-			"stats": {
-				"total": "Total sessions",
-				"upcoming": "Upcoming",
-				"completed": "Completed",
-				"cancelled": "Cancelled"
-			},
-			"notifications": {
-				"label": "Notifications",
-				"reminders-off": "Reminders off"
-			},
-			"sections": {
-				"billing": "Billing",
-				"details": "Patient details",
-				"timeline": "Session timeline"
-			},
-			"billing": {
-				"model": "Billing model",
-				"category": "Billing category",
-				"amount": "Price",
-				"currency": "Currency",
-				"models": {
-					"per-session": "Paid per session",
-					"monthly": "Paid monthly"
-				},
-				"categories": {
-					"standard": "Standard",
-					"social": "Social care",
-					"pro-bono": "Pro bono"
-				},
-				"category-descriptions": {
-					"standard": "Regular paid care at the agreed rate.",
-					"social": "Reduced-fee or socially supported care, tracked separately.",
-					"pro_bono": "Free care with no payment expected."
-				}
-			},
-			"share": {
-				"title": "Your sessions page",
-				"text": "Use this link to view and manage your scheduled sessions.",
-				"link-label": "Public sessions link"
-			},
-			"preferred-contact": {
-				"phone": "Phone",
-				"whatsapp": "WhatsApp",
-				"google-meet": "Google Meet",
-				"zoom": "Zoom",
-				"not-set": "Not set"
-			},
-			"next-session": "Next session",
-			"last-session": "Last completed session",
-			"no-upcoming-session": "No upcoming session scheduled",
-			"no-completed-session": "No completed sessions yet",
-			"no-sessions": "No sessions have been scheduled for this patient yet.",
-			"delivery": {
-				"online": "Online",
-				"in-person": "In person",
-				"not-set": "Delivery mode not set"
-			},
-			"sessions": {
-				"upcoming": "Upcoming",
-				"completed": "Completed",
-				"cancelled": "Cancelled"
-			}
-		}
-	},
-	"auth": {
-		"error": {
-			"login-failed": "Invalid email or password. Please check your credentials and try again.",
-			"registration-failed": "Unable to complete registration. Please check your information and try again.",
-			"password-reset-request": "If this email is registered, you will receive password reset instructions.",
-			"password-reset-failed": "Unable to reset password. The link may have expired. Please request a new one.",
-			"session-expired": "Your session has expired. Please sign in again.",
-			"rate-limited": "Too many attempts. Please wait a moment before trying again.",
-			"generic": "Something went wrong. Please try again later.",
-			"not-found": "User ID not found",
-			"not-allowed": "You can't delete this account."
-		},
-		"success": {
-			"password-reset-request": "If this email is registered, you will receive password reset instructions shortly.",
-			"password-reset": "Your password has been changed successfully. You can now sign in.",
-			"logout": "You have been signed out successfully."
-		},
-		"continue-google": "Continue with Google",
-		"continue-email": "Continue with email"
-	},
-	"globals": {
-		"email": "Email",
-		"name": "Name",
-		"password": "Password",
-		"phone": "Phone",
-		"whatsapp": "Whatsapp",
-		"address": "Address",
-		"patients": "Patients",
-		"patient": "Patient",
-		"registered-patients": "Registered patients",
-		"patients-manager": "Patients manager",
-		"billing-manager": "Billing manager",
-		"subscription-manager": "Subscription manager",
-		"appointments": "Appointments",
-		"appointments-manager": "Manage your appointments",
-		"change-language": "Change language",
-		"help": "Help center",
-		"logout": "Logout",
-		"plan": "Plan",
-		"cancel": "Cancel",
-		"delete": "Delete",
-		"edit": "Edit",
-		"date-time-format": "{{format}}",
-		"time-remaining": {
-			"days": "In {{count}} day(s)",
-			"hours": "In {{count}} hour(s)",
-			"minutes": "In {{count}} minute(s)",
-			"less-than-a-minute": "Session {{status}}"
-		},
-		"in-progress": "In progress",
-		"paused": "Paused",
-		"proceed": "Proceed",
-		"resume": "Resume",
-		"reason": "Reason",
-		"global-reason": "Global reason",
-		"custom-reason": "Describe the reason",
-		"select": "Select",
-		"unselect": "Unselect",
-		"error": {
-			"already-subscribed": "Your email is already subscribed",
-			"internal-server-error": "Something went wrong, please try again later",
-			"invalid-user": "Invalid email or password"
-		},
-		"success": {
-			"subscribed": "You were successfully subscribed. Please check your email!"
-		},
-		"date": "Date",
-		"time": "Time",
-		"at": "at",
-		"date-time": "Date and Time: ",
-		"therapist": "Therapist",
-		"appointment-status": {
-			"booked": "Booked",
-			"available": "Available",
-			"onhold": "on Hold",
-			"blocked": "Blocked",
-			"cancelled": "Cancelled"
-		},
-		"contacts": "Contacts",
-		"starts": "Starts",
-		"ends": "Ends",
-		"time-range": {
-			"time-from-to": "from {{start}} to {{end}}",
-			"time-range-date": "{{date}} from {{start}} to {{end}}",
-			"your-time": "Your local time",
-			"patient-time": "Patient's time",
-			"therapist-time": "Therapist's time"
-		},
-		"notification": {
-			"email": "Send email",
-			"phone": "Call patient",
-			"whatsapp": "Send WhatsApp message"
-		},
-		"cancellation-title": "Please choose the reason you are cancelling your appointment",
-		"cancellation-reason": {
-			"1": "Emergency (Personal/Health Issue)",
-			"2": "Schedule Conflict",
-			"3": "Financial Issues",
-			"4": "Mental Issues",
-			"5": "No-Show",
-			"6": "Other",
-			"7": "Other"
-		},
-		"cancellation-other-title": "Please specify the reason",
-		"status": "Status",
-		"close": "Close",
-		"read-only": "Read-only",
-		"auth-method": "Auth method",
-		"privacy-policy": "Privacy Policy",
-		"terms-of-service": "Terms of Use",
-		"privacy": "Privacy",
-		"previous": "Previous",
-		"next": "Next"
-	},
-	"components": {
-		"form": {
-			"confirm-password": "Confirm password",
-			"keep-loggedin": "Keep me logged in",
-			"not-valid": "Some fields are missing",
-			"signup": {
-				"sign-up": "Sign up",
-				"title-email": "Create your account",
-				"title": "Create your Psycron account",
-				"first-name": "First name",
-				"last-name": "Last name",
-				"already-have-acc": "Already have an account?",
-				"signin-here-link": "Sign in here"
-			},
-			"signin": {
-				"sign-in": "Sign in",
-				"title": "Welcome back",
-				"dont-have-acc": "Don't have an account?",
-				"signup-here-link": "Sign up here",
-				"forgot-password": "Forgot your password?"
-			},
-			"validation": {
-				"required": "{{name}} is required",
-				"invalid": "{{name}} is invalid",
-				"characters": "Password must be at least {{numChar}} characters",
-				"pass-rules": "Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character",
-				"at-least-one-contact": "Please provide an email or phone number",
-				"match": "{{name}} must match"
-			},
-			"address-form": {
-				"search": "Search the address here",
-				"search-note": "You can start searching for the address, or type it in the below fields.",
-				"street": "Street",
-				"number": "Nº",
-				"hood": "Neighbourhood",
-				"more-info": "Complementary info",
-				"city": "City",
-				"state": "State / Province",
-				"zip": "Zip Code",
-				"country": "Country",
-				"more-info-bttn": "Add more info"
-			},
-			"add-patient": {
-				"name": "Add patient"
-			},
-			"contacts-form": {
-				"contact-via": "Contact via {{method}}?",
-				"contact-via-same": "Is phone number the same as whatsapp?"
-			},
-			"preferred-contact": {
-				"coming-soon": "Integration coming soon — paste your meeting link for now",
-				"label": "Preferred session platform",
-				"value-phone": "Phone number",
-				"value-url": "Meeting link (URL)",
-				"type": {
-					"google_meet": "Google Meet",
-					"phone": "Phone call",
-					"whatsapp": "WhatsApp",
-					"zoom": "Zoom"
-				}
-			},
-			"consent": {
-				"terms": "I agree to the <privacyLink>Privacy Policy</privacyLink> and <termsLink>Terms of Use.</termsLink>",
-				"marketing": "I consent to receive <marketingLink>marketing communications.</marketingLink>",
-				"info": "By continuing, you agree to Psycron's <privacyLink>Privacy Policy</privacyLink> and <termsLink>Terms of Use.</termsLink>"
-			}
-		},
-		"input": {
-			"phone-input": {
-				"select-label": "Country",
-				"phone-num-label": "{{registerName}} number here",
-				"phone-number-guide": "Please provide a phone number including the city code if applicable.",
-				"invalid": "Invalid phone number",
-				"valid": "Valid phone number"
-			},
-			"text": {
-				"first-name": "Your first name here",
-				"last-name": "Your last name here",
-				"email": "Your email here"
-			}
-		},
-		"navbar": {
-			"action-center": "Action center",
-			"dashboard": "Dashboard",
-			"conflicts": "Conflicts",
-			"notifications": "Notifications",
-			"user-settings": "User settings",
-			"test": "Tests"
-		},
-		"user-details": {
-			"edit": "Edit details",
-			"edit-contacts": "Edit contacts",
-			"edit-success": "Details updated",
-			"add-contacts": "Add your {{contactValue}} number",
-			"change": "Change {{name}}",
-			"save": "Save details",
-			"address-not-found": "Address not found. Please add your info.",
-			"detail-not-found": "{{detail}} is not registered yet",
-			"no-changes": "Select a section to edit before saving.",
-			"delete": {
-				"title": "Delete account",
-				"description": "Your account will be deactivated and your personal data anonymised within 30 days. You can contact support to cancel this request.",
-				"confirmation": "Delete permanently"
-			},
-			"section": {
-				"title": {
-					"account": "Account",
-					"clinic": "Clinic Address",
-					"contact": "Contact",
-					"patients": "Patients",
-					"security": "Security & Privacy",
-					"subscription": "Subscription"
-				},
-				"local": "Email & Password",
-				"security": {
-					"google-mgmt": "Managed by Google - Your password is securely handled through Google's authentication system.",
-					"accepted": "By creating your Psycron account, you agreed to our <privacyLink>Privacy Policy</privacyLink> and <termsLink>Terms of Use.</termsLink>",
-					"accepted-info": "You can review these documents at any time.",
-					"marketing": "Receive marketing communications"
-				},
-				"clinic": {
-					"add-address": "Add clinic address",
-					"address-label": "Address",
-					"edit-address": "Edit address",
-					"title-empty": "Add your clinic address so patients can receive it in their booking confirmation."
-				},
-				"contact": {
-					"title-empty": "Add your phone number to enable SMS or WhatsApp notifications."
-				}
-			}
-		},
-		"dashboard": {
-			"card": {
-				"delay-notification": "Pausing the timer will delay all your remaining appointments for today by the duration of this pause.",
-				"delay-confirmation": "Are you sure you want to pause the timer?",
-				"pause": "Sause timer",
-				"session-progress": "Session progress:"
-			},
-			"availability-card": {
-				"first-availability": "Please create your first availability here"
-			}
-		},
-		"appointments": {
-			"card-title": "Appointments of the day",
-			"manager": "Appointments manager"
-		},
-		"patients-table": {
-			"name": "Patient name",
-			"next-session": "Next session",
-			"payment-status": "Payment status",
-			"sessions-month": "Sessions per Month",
-			"value": "Value per session",
-			"discount": "Discount?",
-			"discount-val": "Discount value",
-			"amount": "Full amount",
-			"currency": "Currency",
-			"latest-payment": "Latest payment",
-			"manage": "Manage patient"
-		},
-		"progress": {
-			"received": "You have already received {{progress}}% of your payments 🥳",
-			"missing": "You are missing {{progress}}% of your payments",
-			"not-received": "You haven't received any payments yet",
-			"received-all": "You have received 100% of your payments for this period 🥳 😎"
-		},
-		"c2-action": {
-			"join-waitlist": "Join our <strong>waitlist</strong> today to streamline your therapy practice and focus more on your patients.",
-			"email": "Your email",
-			"join-now": "Join now"
-		},
-		"hero": {
-			"heading": "Revolutionize your therapy practice with a seamless all-in-one solution",
-			"helper": "Easily manage your appointments, payments, patient records, billing, and more."
-		},
-		"header": {
-			"join": "Join now",
-			"benefits": "Benefits",
-			"contact": "Contact",
-			"language": "Language"
-		},
-		"link": {
-			"navigate": {
-				"back": "Back",
-				"next": "Proceed",
-				"finish": "Finish",
-				"confirm": "Confirm",
-				"cancel": "Cancel"
-			}
-		},
-		"footer": {
-			"contact": "Would you like to get in touch? <a>Find us here</a>",
-			"find-me": "Find us here",
-			"credit": {
-				"illustration": "Illustrations by <owner>Icons 8</owner> from <page>Ouch!</page>"
-			}
-		},
-		"share-button": {
-			"alert": {
-				"success": "Shared successfully!",
-				"success-copy": "Link copied successfully!",
-				"error": "Someting went wrong, please try again later.",
-				"error-copy": "We couldn't copy the link, please try again later."
-			},
-			"tooltip-tile": "Share with {{with}}",
-			"share-with-name": "with {{name}}",
-			"share-with-patients": "with your patients",
-			"share-infos": {
-				"availability": {
-					"title": "{{therapistName}} shared with you their availability",
-					"text": "Enter here to book an appointment"
-				}
-			}
-		},
-		"agenda": {
-			"modal": "You are booking for {{appointment}}",
-			"your-details": "Your details",
-			"next-week": "Next week",
-			"previous-week": "Previous week",
-			"today": "Today",
-			"month": "Month",
-			"appointment-details": {
-				"title": "Appointment Details",
-				"mailto-subject": "🔔 About your appointment with {{therapistName}} 🔔",
-				"whatsapp-subject": "Hello, how is it going? I am sending this message regarding your appointment with me, {{therapistName}}",
-				"next-sessions": "Other appointments",
-				"edit-patient-details": "Edit Patient Details",
-				"edit-patient-appointment": "Edit appointment",
-				"edit-availability": "Edit availability",
-				"text-status": "This is slot is {{status}}"
-			},
-			"edit-appointment": {
-				"title": "Edit appointment",
-				"confirmation": "Are you sure you want to reschedule this appointment?"
-			},
-			"cancel-appointment": {
-				"title": "Cancel appointment(s)",
-				"select-all": "{{select}} All",
-				"global-reason": "Please, select a global reason:",
-				"confirmation": "Are you sure you want to cancel all appointments?",
-				"review": "Review the dates you selected"
-			},
-			"book-appointment": {
-				"title": "Booking your appointment"
-			}
-		}
-	},
-	"page": {
-		"landing": {
-			"seo": {
-				"title": "Psycron - Innovative Therapist Management App",
-				"description": "Revolutionize your therapy practice with a seamless all-in-one solution. With our app you can easily manage your appointments, payments, patient records, billing, and more.",
-				"ogTitle": "Psycron - Innovative Therapist Management App",
-				"ogDescription": "Revolutionize your therapy practice with a seamless all-in-one solution. With our app you can easily manage your appointments, payments, patient records, billing, and more."
-			},
-			"values": {
-				"all-in-one": "All-in-one solution",
-				"text": "From scheduling appointments to processing payments, maintaining patient records, and handling billing, we help you with your daily tasks, and you will have much more time to take care of your patients. Our solution can transform your practice management, integrating everything into a single, intuitive platform.",
-				"text-focus": "Now you can focus on what truly matters and let us handle the rest for you."
-			},
-			"benefits": {
-				"increased-efficiency": {
-					"name": "Increased Efficiency",
-					"description": "Spend less time on admin tasks. Automate reminders, schedule appointments, and manage patient records seamlessly. Focus more on your patients, not paperwork"
-				},
-				"better-patient-management": {
-					"name": "Better Patient Management",
-					"description": "Easily track patient history and appointments. Enhance care with organized, up-to-date records."
-				},
-				"reduced-administrative-burden": {
-					"name": "Reduced Administrative Burden",
-					"description": "We simplified your workflow"
-				},
-				"enhanced-financial-control": {
-					"name": "Enhanced Financial Control",
-					"description": "Take control of your finances with secure and efficient billing"
-				}
-			},
-			"ct-action": {
-				"heading": "Ready to revolutionize your practice?",
-				"join-waitlist": "<strong>Join our waitlist</strong> today and <strong>be the first</strong> to <strong>experience</strong> <strong>cutting-edge</strong> therapy practice management. <strong>Unlock</strong> <strong>new levels</strong> of <strong>efficiency</strong> and <strong>patient care</strong> with <strong>a product made for you</strong>."
-			}
-		},
-		"not-found": {
-			"title": "Oops, something went wrong!",
-			"sub-title": "But we promise we are working hard to fix it!",
-			"note": "Yes... both of us :)"
-		},
-		"unsubscribe": {
-			"title": "Goodbye for now, {{email}}!",
-			"body-text": "Thank you for being a part of our journey. While we’re sad to see you go, we completely understand your decision. We’ll keep working hard to bring you the best we’ve got, and just know, you’re always welcome back whenever you’re ready.",
-			"see-you": "Hope to see you again soon! ❤️",
-			"confirm": "Click here to complete and unsubscribe"
-		},
-		"reset-password": {
-			"reset": "Reset password",
-			"change-password": "Change password",
-			"password-rule": "Your password must contain at least:",
-			"password-example": "Example:",
-			"item-letter": "One letter {{rule}}",
-			"item-number": "One number {{rule}}",
-			"item-special": "One special character {{rule}}",
-			"item-minimum": "9 characters long",
-			"current-password": "Current password"
-		},
-		"availability": {
-			"wizard": {
-				"wizard-items": {
-					"intro": {
-						"label": "Intro",
-						"title": "Let's setup your availability. Are you ready?",
-						"alert": "You will need to finish your availability setup later"
-					},
-					"weekdays": {
-						"label": "Choose weekdays",
-						"title": "Tell us the days you usually see patients."
-					},
-					"duration": {
-						"label": "Appointment duration",
-						"title": "Let us know how long your sessions are."
-					},
-					"week-slots": {
-						"label": "Weekly time slots"
-					}
-				},
-				"intro": {
-					"options": {
-						"proceed": "Yes!",
-						"finish-later": "Set availability later"
-					}
-				},
-				"availability-days": {
-					"days": {
-						"mon": "Monday",
-						"tue": "Tuesday",
-						"wed": "Wednesday",
-						"thu": "Thursday",
-						"fri": "Friday"
-					},
-					"options": {
-						"all": "Include all days",
-						"weekends": "Don't include weekends",
-						"specific": "Select specific days"
-					}
-				},
-				"duration": {
-					"label": "Appointment duration",
-					"note": "If you have more than one type of appointment, please let us know the duration you use most often. You will be able to change this in the future without any issues!"
-				},
-				"hours": {
-					"no-session": "No session was found"
-				},
-				"modal-title": "Repeat your weekly availability",
-				"modal-info": "Please choose one of the options below. If you pick 'weekly,' your availability will be repeated until the end of the month. If you pick 'monthly,' it will be repeated until the end of the year.",
-				"complete": "Availability created with success"
-			},
-			"agenda": {
-				"status": {
-					"available": "Available",
-					"unavailable": "Unavailable",
-					"booked": "Booked",
-					"empty": "Empty",
-					"blocked": "Blocked",
-					"cancelled": "Cancelled",
-					"onhold": "On hold"
-				},
-				"therapist-edit-modal": {
-					"title": "Edit your availability"
-				}
-			}
-		},
-		"book-appointment": {
-			"title": "{{therapisName}}'s Open Appointments",
-			"description": "Quickly schedule your therapy session. Check available times and choose the best slot to book your appointment easily and conveniently.",
-			"confirmation-should-replicate": "Would you like to set this day as your default choice for future appointments?",
-			"recurrence-pattern": {
-				"month": "Weekly until month ends",
-				"year": "Weekly until year ends",
-				"single": "Only this appointment",
-				"all-future": "All future appointments"
-			},
-			"confirm-edit": "Please confirm that you want to change your appointment from {{previousDate}} to:",
-			"edit-recurrence-title": "Do you want to update only this appointment or all future appointments?",
-			"edit-appointment-title": "You are editing your appointment on {{formattedDate}} at {{startTime}}."
-		},
-		"booking-confirmation": {
-			"title": "Your Appointment with <strong>{{therapistName}}</strong> is confirmed 🎉",
-			"title-plain": "Your Appointment with {{therapistName}} is confirmed 🎉",
-			"subtitle": "We're excited to see you soon!",
-			"whats-next": "<strong>{{therapistName}}</strong> will reach out with additional details as the appointment date approaches.",
-			"advise": "Please be available a few minutes early.",
-			"reschedule": "You can reschedule your appointment up to 1 day before the session.",
-			"cancel": "To reschedule or cancel , please <strong>click here</strong>",
-			"help": "If you have any questions or need assistance, feel free to contact us at",
-			"thanks": "Thank you! We’re here to support you. Looking forward to your session!",
-			"cancel-or-edit": {
-				"title": "Need to make changes?",
-				"sub": "You can either reschedule or cancel your appointment here.",
-				"appointment-info": "Your appointment on {{date}} at {{startTime}}",
-				"donwload-ics": "Add to calendar 📅"
-			},
-			"no-appointments-title": "You dont have any appointments yet",
-			"no-appointments-link": "Click here to start booking an appointment"
-		},
-		"appointment-list": {
-			"date": "Date",
-			"starts": "Starts at",
-			"ends": "Ends at",
-			"modal": {
-				"title": "Are you sure you want to {{action}} this appointment"
-			},
-			"description": "Here you can set up your availability for appointments and share it with your patients. We will guide you through a simple process to define your available times, which will be replicated across the weeks or until the end of the year. The process is flexible, and you will be able to adjust the information at any time in the future.",
-			"guide": {
-				"step1": {
-					"title": "Decide if you want to start now or later",
-					"description": "If you prefer, you can return to this step later. We understand that it’s not always possible to set everything up immediately, so you will have the option to resume the process at a more convenient time."
-				},
-				"step2": {
-					"title": "Set your off days",
-					"description": "Let us know which days of the week you will not be available for appointments. These days will be blocked, but you can change them in the future, if necessary."
-				},
-				"step3": {
-					"title": "Session duration",
-					"description": "Provide the average duration of your appointments. If you offer more than one type of session, we will set a default now, and you can adjust the times later according to the patient and type of therapy."
-				},
-				"step4": {
-					"title": "Choose your available times",
-					"description": "In a visual and interactive way, you can select the times you will be available for appointments throughout the week. It’s a flexible process: if your preferences change, you can adjust your schedule at any time."
-				}
-			},
-			"session-past": "Past session"
-		},
-		"cancel-appointment": {
-			"title": "Cancel Appointment(s)",
-			"sub-title": "Please select the appointment(s) you want to cancel"
-		},
-		"edit-appointment": {
-			"title": "Edit Appointment",
-			"sub-title": "Please select the new date slot"
-		},
-		"add-patient": {
-			"title": "Add a New Patient",
-			"sub-title": "Fill out the form below with the patient’s details"
-		},
-		"dashboard": {
-			"title": "Dashboard",
-			"greeting": {
-				"headline": "Hello, {{name}}!",
-				"band": {
-					"morning": "Good morning",
-					"afternoon": "Good afternoon",
-					"evening": "Good evening"
-				}
-			},
-			"tiles": {
-				"action-center": "Action center",
-				"schedule": "Today's schedule",
-				"greeting": "Greeting",
-				"jupiter-insights": "Júpiter insights",
-				"notifications": "Notifications",
-				"quick-actions": "Quick actions",
-				"active-patients": "Active patients",
-				"billing-readiness": "Billing readiness",
-				"revenue": "Revenue estimate",
-				"session-analytics": "Session Analytics",
-				"pending-tasks": "Pending tasks",
-				"recent-patients": "Recent patients"
-			},
-			"tile": {
-				"close": "Close",
-				"hide": "Hide tile",
-				"layout-column": "Use column layout",
-				"layout-column-aria": "Switch tile to column layout",
-				"layout-row": "Use row layout",
-				"layout-row-aria": "Switch tile to row layout",
-				"read-more": "Read more",
-				"resize-down": "Reduce height",
-				"resize-down-aria": "Reduce tile height",
-				"resize-narrow": "Narrow",
-				"resize-narrow-aria": "Make tile narrower",
-				"resize-up": "Increase height",
-				"resize-up-aria": "Increase tile height",
-				"resize-wide": "Widen",
-				"resize-wide-aria": "Make tile wider",
-				"show": "Show tile",
-				"drag": "Drag to reorder",
-				"drag-aria": "Drag tile to reorder"
-			},
-			"customize": {
-				"open": "Customize",
-				"done": "Done",
-				"hint": "Drag tiles to reorder · click the eye icon to hide",
-				"organize": "Organize",
-				"reset": "Reset layout"
-			},
-			"widgets": {
-				"schedule": {
-					"title": "Today",
-					"title-week": "Week",
-					"title-label": "Today's schedule",
-					"title-week-label": "This week's schedule",
-					"range-aria-label": "Choose schedule range",
-					"count": "{{count}} sessions",
-					"empty": "No sessions scheduled for today",
-					"unknown-patient": "Unknown patient",
-					"sessions-today": "sessions today",
-					"sessions-week": "sessions this week",
-					"view-week": "View week",
-					"online": "Online",
-					"in-person": "In-person",
-					"min": "min",
-					"status": {
-						"live": "LIVE",
-						"done": "Done",
-						"confirmed": "Confirmed",
-						"pending": "Pending"
-					},
-					"info": {
-						"title": "Today's schedule",
-						"description": "Shows your booked sessions for today and this week, with live status tracking so you always know what's coming next.",
-						"future": "We'll surface prep notes per patient, smart conflict alerts, and one-tap rescheduling suggestions."
-					}
-				},
-				"jupiter-insights": {
-					"aria-label": "Júpiter AI insights carousel",
-					"dismiss": "Dismiss insight",
-					"empty": "No insights available at the moment",
-					"action-availability": "View availability",
-					"title-schedule": "Today's sessions",
-					"text-schedule": "You have {{count}} booked session(s) today. Keep it up!",
-					"title-patients": "Active patients",
-					"text-patients": "You currently have {{count}} active patient(s) on your roster.",
-					"subtitle": "AI co-pilot · learning your patterns",
-					"default-category": "Patient Care",
-					"category-daily-briefing": "Daily briefing",
-					"category-operations": "Operations",
-					"category-patient-care": "Patient Care",
-					"category-insights": "Insights",
-					"action-send-message": "Send message",
-					"action-view-profile": "View profile",
-					"mic": "Voice input",
-					"text-setup-availability": "Set up your schedule with Júpiter to start accepting bookings.",
-					"action-setup-availability": "Set up now",
-					"text-no-patients-yet": "You're all set — share your booking link with your first patients.",
-					"category-setup": "Setup",
-					"category-growth": "Growth",
-					"category-schedule": "Schedule",
-					"text-session-none-today": "No sessions today — a good time to catch up on notes.",
-					"text-session-count-today": "You have {{count}} session(s) today. Keep it up!",
-					"text-whatsapp-reminders": "Enable WhatsApp reminders to reduce no-shows in a few taps.",
-					"action-set-up-reminders": "Set up reminders",
-					"text-busy-day": "{{day}} looks like your busiest day this week. Keep that momentum!",
-					"action-view-schedule": "View schedule",
-					"text-week-cancellations": "{{count}} session(s) were cancelled this week. Consider reaching out to reschedule.",
-					"text-patient-milestone": "You've reached {{count}} active patients. Great milestone!",
-					"text-low-week-volume": "You have {{count}} session(s) this week. Opening more slots could help you grow.",
-					"text-billing-readiness-incomplete": "{{missing}} patient(s) still need session-cost details before future payment tools can fit your workflow.",
-					"text-billing-readiness-ready": "Your patient billing details are ready for future payment and invoicing flows.",
-					"action-review-patients": "Review patients",
-					"action-view-patients": "View patients",
-					"text-session-none-today-week": "No sessions today — you have {{count}} coming up this week. Check your schedule.",
-					"text-missed-rebooking": "{{name}} missed their last session and hasn't rebooked. A check-in might help.",
-					"text-dashboard-summary-fallback": "Júpiter is reading your dashboard. You have {{count}} session(s) booked this week.",
-					"info": {
-						"title": "Júpiter insights",
-						"description": "AI-generated observations about your practice based on your schedule, patients, and billing — personalised every session.",
-						"future": "Predictive scheduling recommendations, patient risk flags, and proactive clinical guidance tailored to your specialty."
-					}
-				},
-				"quick-actions": {
-					"title": "Quick Actions",
-					"descriptions": {
-						"add-patient": "Start a patient profile",
-						"availability-settings": "Working hours, time zone",
-						"fix-reminders-count": "{{count}} failed or queued",
-						"fix-reminders-setup": "Reminder settings",
-						"follow-up-cancellations": "{{count}} recovery item(s)",
-						"patients": "{{count}} active",
-						"setup-availability": "Create working hours",
-						"view-week": "{{count}} sessions"
-					},
-					"actions": {
-						"new-session": "New session",
-						"new-session-aria": "Open availability to book new session",
-						"patients": "My patients",
-						"patients-aria": "Navigate to patients list",
-						"add-patient": "Add patient",
-						"add-patient-aria": "Add a new patient",
-						"fix-reminders": "Fix reminders",
-						"follow-up-cancellations": "Follow up cancellations",
-						"notifications": "Notifications",
-						"notifications-aria": "View notifications",
-						"setup-availability": "Set up schedule",
-						"view-week": "View week",
-						"availability-settings": "Availability settings"
-					},
-					"info": {
-						"title": "Quick actions",
-						"description": "Shortcuts to the most relevant actions based on your current practice state. Psycron picks what matters most right now.",
-						"future": "Fully contextual action suggestions powered by Júpiter that adapt to your week, your patients, and your habits."
-					}
-				},
-				"active-patients": {
-					"label": "Active patients",
-					"title": "Latest patients",
-					"empty": "No patients added yet"
-				},
-				"billing-readiness": {
-					"label": "Billing readiness",
-					"status": {
-						"empty": "Prepare for future payment tools by adding patients first.",
-						"partial": "{{configured}} of {{total}} patients ready for future payments · {{missing}} to finish",
-						"ready": "Future payment setup is ready"
-					},
-					"details": "Add each patient's session cost now so Psycron can design payment and invoicing flows that match how your practice already works.",
-					"donut-meta": "{{configured}}/{{total}} ready",
-					"status-chip": {
-						"empty": "Action needed",
-						"partial": "In progress",
-						"ready": "Ready"
-					},
-					"teaser": {
-						"title": "Prepare for future payments",
-						"subtitle": "Track session costs now so future payment tools can fit your workflow from day one.",
-						"coming-soon": "Payment collection and invoicing will come later; this step only keeps your patient billing details ready."
-					},
-					"info": {
-						"title": "Billing readiness",
-						"description": "Add each patient's session cost now so Psycron can design payment and invoicing flows that match how your practice already works.",
-						"future": "Next, Psycron will move into payments by creating an automated payment system tailored to how you charge each patient."
-					}
-				},
-				"revenue": {
-					"title": "Revenue",
-					"title-with-month": "Revenue · {{month}}",
-					"estimate-chip": "Est.",
-					"completed": "Completed",
-					"configured": "Billing setup",
-					"sessions": "{{count}} session(s)",
-					"patients-ready": "{{configured}} ready · {{missing}} missing",
-					"info": {
-						"title": "Revenue estimate",
-						"description": "Estimates your monthly earnings based on the billing configurations you've set for active patients. Updated in real time.",
-						"future": "Psycron will use these revenue patterns to create an automated payment system tailored to your practice, with invoicing, collection, and payment tracking built around your workflow."
-					}
-				},
-				"notifications": {
-					"title": "Notifications · 24h",
-					"window": "Last 24h",
-					"sent": "Sent",
-					"failed": "Failed",
-					"queued": "Queued",
-					"view-feed": "View feed",
-					"info": {
-						"title": "Notifications",
-						"description": "Shows how many appointment reminders and confirmations were delivered to your patients in the last 24 hours.",
-						"future": "Channel performance over time, intelligent retry logic, and delivery failure alerts before patients miss sessions."
-					}
-				},
-				"action-center": {
-					"title": "Action center",
-					"count-chip": "{{count}} needs you",
-					"count-chip_other": "{{count}} need you",
-					"empty": "No operational alerts right now.",
-					"item-count": "{{count}} item(s)",
-					"summary-title": "{{count}} item needs attention",
-					"summary-title_other": "{{count}} items need attention",
-					"summary-body": "A quiet summary of unresolved operational work. Actions stay in the dedicated workspace.",
-					"breakdown-label": "Action center summary",
-					"view-all": "Open action center",
-					"view-all-meta": "Conflicts and recovery queue",
-					"items": {
-						"notification-failed": "Notification failed",
-						"patient-duplicate": "Patient duplicate",
-						"recovery-needed": "Recovery needed",
-						"schedule-conflict": "Schedule conflict"
-					},
-					"info": {
-						"title": "Action center",
-						"description": "Flags issues that require resolution — scheduling conflicts, failed notification deliveries, and cancellations awaiting follow-up.",
-						"future": "Automated conflict resolution proposals, one-click recovery workflows, and priority-ranked issue queues."
-					}
-				},
-				"session-analytics": {
-					"title": "Session Analytics",
-					"range-aria-label": "Choose analytics range",
-					"completion-rate": "Completion rate",
-					"blocked": "Admin blocks",
-					"blocked-hours": "{{hours}}h blocked",
-					"cancelled": "Cancelled",
-					"chart-aria-label": "Stacked bar chart showing sessions by day",
-					"completed": "Completed",
-					"insight-down": "Completion rate down {{delta}}% vs last {{period}} — cancellations need attention.",
-					"insight-empty": "No concluded sessions yet — comparison starts once data arrives.",
-					"insight-flat": "Completion rate steady vs last {{period}} — keep the reminder rhythm.",
-					"insight-source": "Júpiter",
-					"insight-summary": "{{completed}} of {{concluded}} concluded sessions completed.",
-					"insight-up": "Completion rate up {{delta}}% vs last {{period}} — reminders are working.",
-					"legend": {
-						"blocked": "Admin blocks",
-						"cancelled": "Cancelled",
-						"completed": "Completed",
-						"upcoming": "Upcoming"
-					},
-					"period": {
-						"month": "month",
-						"week": "week"
-					},
-					"sessions": "sessions",
-					"upcoming": "Upcoming",
-					"view-month": "Month",
-					"view-week": "Week",
-					"info": {
-						"title": "Session analytics",
-						"description": "Tracks your session completion rate, cancellations, and session volume over time — your practice health at a glance.",
-						"future": "Trend analysis, no-show prediction, and session pace benchmarks compared to similar practices."
-					}
-				},
-				"pending-tasks": {
-					"title": "Pending Tasks",
-					"cancellation-followups": "Cancellation follow-ups",
-					"descriptions": {
-						"cancellation-followups": "{{count}} need recovery",
-						"missing-billing": "{{count}} patient(s) to configure",
-						"missing-contact": "{{count}} patient(s) to update",
-						"reminder-delivery": "{{count}} need review",
-						"setup-availability": "Required before bookings"
-					},
-					"empty": "Nothing requires your attention right now.",
-					"missing-billing": "Patients missing billing",
-					"missing-contact": "Patients missing contact info",
-					"reminder-delivery": "Reminder delivery issues",
-					"setup-availability": "Finish schedule setup",
-					"empty-heading": "All clear",
-					"info": {
-						"title": "Pending tasks",
-						"description": "Surfaces admin items that need your attention to keep your practice running smoothly — from missing billing to unresolved cancellations.",
-						"future": "Priority scoring, task delegation for group practices, and completion streaks to keep your admin momentum."
-					}
-				},
-				"recent-patients": {
-					"title": "Recent Patients",
-					"activity": {
-						"cancelled": "Cancelled session",
-						"created": "Added",
-						"session": "Session activity",
-						"updated": "Updated"
-					},
-					"empty": "Recent patient activity will appear here.",
-					"view-all": "All",
-					"last-note": "last note",
-					"message-aria": "Send message to {{name}}",
-					"info": {
-						"title": "Recent patients",
-						"description": "Highlights the patients with the most recent activity in your caseload, so you can quickly pick up where you left off.",
-						"future": "Patient engagement scores, session frequency heatmaps, and proactive care alerts when a patient goes quiet."
-					}
-				},
-				"latest-patients": {
-					"info": {
-						"title": "Latest patients",
-						"description": "Shows the most recently added patients so you never lose track of new intakes and can start onboarding them right away.",
-						"future": "Automated onboarding checklists, intake form integration, and personalised welcome message templates."
-					}
-				},
-				"info-modal": {
-					"feedback-error": "We couldn't save this feedback. Please try again.",
-					"feedback-placeholder": "Share your thoughts on this widget...",
-					"feedback-submit": "Send feedback",
-					"feedback-thanks": "Thanks! Your input helps shape Psycron.",
-					"future-heading": "What's coming",
-					"tooltip": "About this widget"
-				}
-			}
-		}
-	},
-	"chat": {
-		"greeting": "Hi! I’m Júpiter, your assistant to help set up your appointment schedule. Let’s build it together, step by step 🧘‍♀️! Shall we?",
-		"let-start": "What types of therapy do you offer?",
-		"system-instruction": "You are a kind assistant helping therapists build their schedule, step by step. Always respond with the next question and any information extracted so far. For example, if the question is regarding the reccurencePattern, you should explain that weekly it’s until the current month, and monthly is until the current year",
-		"error": "Oops! We couldn’t proceed  with your chat, please try again later"
-	},
-	"jupiter": {
-		"welcome": {
-			"title-line1": "I am Jupiter,",
-			"title-line2": "your Smart Assistant",
-			"subtitle": "I’ll help you set up your availability in just a few moments. Let’s make scheduling feel effortless.",
-			"cta": "Set up my schedule"
-		},
-		"specialty": {
-			"response": "What do you practice? Use the professional name for your work.",
-			"chip-occupational-therapist": "Occupational Therapist",
-			"chip-nutritionist": "Nutritionist",
-			"chip-other": "Other",
-			"chip-physiotherapist": "Physiotherapist",
-			"chip-psychiatrist": "Psychiatrist",
-			"chip-psychologist": "Psychologist",
-			"chip-speech-therapist": "Speech Therapist",
-			"continue": "Continue",
-			"other-placeholder": "Your specialty or professional title",
-			"acknowledged": "Got it! I'll set things up with that in mind.",
-			"error-rephrase": "I couldn't quite catch that — try using the professional name for what you practice.",
-			"error-rejected": "I'm not able to set up scheduling for that. If you have another specialty, I'd love to help you get started."
-		},
-		"calendar-choice": {
-			"msg1": "Hi! I’m Júpiter, your scheduling assistant. I’m here to help you set up your availability in a way that feels natural and effortless.",
-			"msg2": "Let’s start by setting up your calendar. How would you like to begin?",
-			"chip-google": "Connect Google Calendar",
-			"chip-manual": "Create manually",
-			"google-already-connected": "Your Google Calendar is already connected! Would you like to import your schedule from it?"
-		},
-		"working-days": {
-			"response": "Great! Which days do you usually work with your clients?",
-			"chip-mon": "Mon",
-			"chip-tue": "Tue",
-			"chip-wed": "Wed",
-			"chip-thu": "Thu",
-			"chip-fri": "Fri",
-			"chip-sat": "Sat",
-			"chip-sun": "Sun",
-			"back": "← Back",
-			"continue": "Continue",
-			"other-placeholder": "Or type your schedule..."
-		},
-		"time-range": {
-			"response": "Perfect! What time range works best for you on those days?",
-			"chip-1": "9:00 AM – 5:00 PM",
-			"chip-2": "10:00 AM – 6:00 PM",
-			"chip-3": "12:00 PM – 8:00 PM",
-			"chip-custom": "Custom",
-			"other-placeholder": "e.g. 8:30 AM – 4:00 PM"
-		},
-		"session-duration": {
-			"response": "How long is a typical session? You can always edit this later.",
-			"chip-45": "45 min",
-			"chip-60": "60 min",
-			"chip-custom": "Custom",
-			"other-placeholder": "e.g. 90 minutes"
-		},
-		"session-type": {
-			"response": "How do you usually conduct your sessions?",
-			"response-with-suggestion": "How do you usually conduct your sessions? I have a suggestion based on your specialty — pick what works best for you.",
-			"chip-online": "Online only",
-			"chip-in-person": "In person only",
-			"chip-both": "Both online and in person"
-		},
-		"timezone": {
-			"response": "Almost there! I’ll use your device’s timezone to schedule appointments accurately. This helps ensure your clients book at the right time for you. Sound good?",
-			"chip-yes": "Yes",
-			"chip-no": "No",
-			"follow-up": "No problem! Please select your timezone:",
-			"search-placeholder": "Search timezone..."
-		},
-		"recurrence-pattern": {
-			"response": "One last thing — how often would you like your availability to repeat?",
-			"chip-weekly": "Weekly (until end of month)",
-			"chip-monthly": "Monthly (until end of year)",
-			"summary-weekly": "Got it! Your slots will repeat every week until the end of this month. You can always extend from your dashboard.",
-			"summary-monthly": "Perfect! Your availability will repeat monthly until the end of the year — giving you full-year scheduling coverage.",
-			"value-weekly": "Weekly (until end of month)",
-			"value-monthly": "Monthly (until end of year)"
-		},
-		"preview": {
-			"title": "Your Availability Preview",
-			"label-days": "Working days:",
-			"label-hours": "Hours:",
-			"label-duration": "Duration:",
-			"label-recurrence": "Repeat:",
-			"label-session-type": "Session type:",
-			"label-timezone": "Timezone:",
-			"footer": "You can edit your availability anytime from your dashboard.",
-			"cta": "Publish Availability",
-			"loading": "Publishing...",
-			"reset": "Start over"
-		},
-		"post-publish": {
-			"page-title": "Availability",
-			"page-subtitle": "Manage your availability and scheduling preferences",
-			"success-toast": "Your availability is now live. Clients can start booking sessions with you right away.",
-			"welcome-toast": "Welcome to Psycron!",
-			"tip-title": "Jupiter’s tip",
-			"tip-text": "Your availability looks great. Adding a cancellation policy helps reduce no-shows and sets clear expectations with clients.",
-			"tip-cta": "Set cancellation policy",
-			"status-active-hours": "Active hours",
-			"status-bookings": "Upcoming bookings",
-			"status-this-week": "This week",
-			"status-booked-label": "{{percent}}% Booked",
-			"checklist-title": "Complete your availability",
-			"checklist-subtitle": "Enhance your scheduling setup for a better experience",
-			"checklist-session-types": "Define session types",
-			"checklist-session-types-desc": "Create different appointment types and durations",
-			"checklist-price": "Add session price",
-			"checklist-price-desc": "Set your consultation rates and payment terms",
-			"checklist-price-badge": "Recommended",
-			"checklist-buffer": "Add buffer time",
-			"checklist-buffer-desc": "Set time between appointments for preparation",
-			"checklist-cancel-policy": "Configure cancellation policy",
-			"checklist-cancel-desc": "Define how clients can cancel or reschedule",
-			"checklist-calendar-sync": "Sync with your existing calendar",
-			"checklist-calendar-desc": "Connect your calendar to prevent conflicts",
-			"checklist-recurrence": "Set recurrence style",
-			"checklist-recurrence-desc": "Choose how your schedule is generated and managed",
-			"checklist-specialty": "Add your specialty",
-			"checklist-specialty-desc": "Let patients know your area of practice",
-			"help-title": "Need help?",
-			"help-text": "Jupiter can guide you through completing your setup",
-			"help-cta": "Talk to Jupiter",
-			"banner-dismiss": "Dismiss",
-			"buffer-drawer-desc": "Buffer time adds a gap between sessions so you can prepare, take notes, or simply breathe between appointments.",
-			"buffer-drawer-title": "Buffer time",
-			"buffer-custom-input-helper": "Choose the buffer that feels best between sessions.",
-			"buffer-impact-day": "Adds about {{value}} on your daily schedule.",
-			"buffer-impact-empty": "We'll estimate the impact once future sessions are available.",
-			"buffer-impact-hours-value": "{{hours}}h",
-			"buffer-impact-hours-minutes-value": "{{hours}}h {{minutes}} min",
-			"buffer-impact-minutes-value": "{{minutes}} min",
-			"buffer-impact-title": "Impact preview",
-			"buffer-impact-week": "Adds about {{value}} across your working weekly hours.",
-			"buffer-input-label": "Minutes between sessions",
-			"buffer-jupiter-title": "Jupiter recommendation",
-			"buffer-range-helper": "Choose a buffer from 5 to 20 minutes. Jupiter will tailor a suggestion using your upcoming schedule.",
-			"buffer-jupiter-empty": "We’ll personalize this once upcoming sessions are available.",
-			"buffer-jupiter-thinking": "Jupiter is reviewing your upcoming schedule",
-			"buffer-jupiter-unavailable": "Jupiter couldn’t personalize this right now. You can still choose a buffer manually.",
-			"buffer-save": "Save",
-			"buffer-save-fail": "Could not save buffer time. Please try again.",
-			"buffer-save-success": "Buffer time saved successfully.",
-			"buffer-warning-overflow": "{{day}} may run past your configured end time with this buffer.",
-			"buffer-warning-soft-weekly": "This adds a noticeable amount of recovery time across the week, which can reduce stress but may lengthen your schedule.",
-			"buffer-warning-strong-weekly": "This adds a large amount of recovery time across the week and may noticeably extend your workload.",
-			"buffer-warning-title": "Schedule warning",
-			"checklist-action-configure": "Configure",
-			"checklist-action-edit": "Edit",
-			"checklist-action-soon": "Coming soon",
-			"checklist-action-view": "View",
-			"checklist-badge-recommended": "Recommended",
-			"checklist-duration": "Session duration",
-			"checklist-duration-desc": "Set the length of each appointment",
-			"checklist-progress-label": "{{count}} of {{total}} completed",
-			"checklist-session-type": "Session type",
-			"checklist-session-type-desc": "How do you conduct your sessions",
-			"checklist-timezone": "Time zone",
-			"checklist-timezone-desc": "Ensure all bookings use the correct time zone",
-			"checklist-working-hours": "Working hours",
-			"checklist-working-hours-desc": "Your available days and hours for appointments",
-			"tip-buffer-time": "Adding buffer time between sessions helps you prepare, take notes, and avoid running late. Even 5 minutes makes a difference.",
-			"tip-session-address": "Let your patients know where to find you. Add your clinic or office address so in-person sessions are easy to locate."
-		},
-		"google-calendar": {
-			"permissions-intro": "We’ll securely connect to your Google Calendar to:",
-			"permission-1": "Read your busy times",
-			"permission-2": "Prevent double bookings",
-			"permission-3": "Keep everything in sync",
-			"privacy-note": "We never edit or delete events without your permission.",
-			"back": "← Back",
-			"continue": "Continue",
-			"success-line1": "Perfect! 🎉",
-			"success-line2": "Your Google Calendar is now connected.",
-			"success-line3": "I’ll automatically block times when you’re already busy.",
-			"next-choice": "Would you like to:",
-			"chip-use-existing": "Use my existing schedule as availability",
-			"chip-define-hours": "Define specific working hours",
-			"define-hours-fallback": "Got it! Google Calendar import is coming soon. Let’s set your working hours manually for now.",
-			"importing": "Give me a moment — I’m importing your schedule from Google Calendar...",
-			"imported": "Done! I found your working days and hours. Just a couple more things to set up.",
-			"import-failed": "I couldn’t read your calendar schedule. Let’s set your working hours manually."
-		},
-		"errors": {
-			"network": "Something went wrong. Let’s try that again.",
-			"retry": "Try again",
-			"google-oauth-fail": "I couldn’t connect to Google Calendar. Please try again or set up manually.",
-			"google-oauth-cancel": "No problem! You can always connect your calendar later. Let’s set things up manually.",
-			"save-fail": "I couldn’t save your availability. Please try again.",
-			"session-timeout": "It looks like you’ve been away. Your progress is saved — pick up where you left off.",
-			"empty-days": "Please select at least one working day to continue.",
-			"invalid-time-range": "The end time must be after the start time.",
-			"invalid-input": "I didn’t quite get that. Could you try again?",
-			"ai-fallback": "Thanks! Let me process that for you.",
-			"ai-thinking": "Thinking...",
-			"no-timezone": "I couldn’t detect your timezone automatically. Please select it below.",
-			"publish-success": "All set! Your availability is live.",
-			"publish-redirect": "Redirecting to your dashboard..."
-		},
-		"subtitle": "Your scheduling assistant",
-		"days": {
-			"MONDAY": "Monday",
-			"TUESDAY": "Tuesday",
-			"WEDNESDAY": "Wednesday",
-			"THURSDAY": "Thursday",
-			"FRIDAY": "Friday",
-			"SATURDAY": "Saturday",
-			"SUNDAY": "Sunday"
-		}
-	},
-	"availability": {
-		"calendar": {
-			"legend-available": "Available",
-			"legend-busy": "Busy",
-			"legend-empty": "Unavailable",
-			"legend-full": "Full",
-			"legend-partial": "Partial",
-			"legend-today": "Today",
-			"page-title": "Availability",
-			"source-google": "Google",
-			"source-jupiter": "Júpiter",
-			"subtitle": "Your availability calendar",
-			"settings": "Availability settings"
-		},
-		"cancellation-recovery": {
-			"title": "Cancellation recovery",
-			"subtitle": "Review cancelled appointments, reopen slots, and jump into patient follow-up without cluttering the live calendar.",
-			"accessibility": {
-				"detail": "Recovery detail",
-				"queue": "Recovery queue"
-			},
-			"empty": "No cancelled appointments match your current filters.",
-			"empty-selection": "Choose a cancelled appointment to review its recovery details and next actions.",
-			"unknown-patient": "Unknown patient",
-			"queue": {
-				"title": "Recovery queue",
-				"subtitle": "Track cancelled appointments that still need therapist attention."
-			},
-			"stats": {
-				"total": "Total",
-				"pending-follow-up": "Pending",
-				"reopened": "Reopened"
-			},
-			"filters": {
-				"title": "Filters",
-				"summary-default": "Expand to refine the recovery queue.",
-				"summary-active": "{{count}} active filters",
-				"patient": "Patient",
-				"patient-placeholder": "Search by patient name",
-				"period": "Period",
-				"status": "Status",
-				"cancelled-by": "Cancelled by",
-				"reason": "Reason",
-				"reason-all": "All reasons",
-				"delivery": "Delivery",
-				"period-options": {
-					"all": "All",
-					"past": "Past",
-					"upcoming": "Upcoming"
-				},
-				"status-options": {
-					"all": "All",
-					"needs-action": "Needs action",
-					"resolved": "Resolved"
-				},
-				"cancelled-by-options": {
-					"all": "All",
-					"patient": "Patient",
-					"therapist": "Therapist",
-					"unknown": "Unknown"
-				},
-				"delivery-options": {
-					"all": "All",
-					"in-person": "In person",
-					"online": "Online",
-					"unknown": "Unknown"
-				}
-			},
-			"state": {
-				"pending-follow-up": "Pending follow-up",
-				"followed-up": "Followed up",
-				"reopened": "Reopened",
-				"rebooked": "Rebooked",
-				"archived": "Archived",
-				"overdue": "Overdue"
-			},
-			"cancelled-by": {
-				"patient": "Cancelled by patient",
-				"therapist": "Cancelled by therapist",
-				"unknown": "Cancelled by unknown source"
-			},
-			"delivery": {
-				"in-person": "In person",
-				"online": "Online",
-				"unknown": "Not provided"
-			},
-			"detail": {
-				"eyebrow": "Recovery detail",
-				"cancelled-at": "Cancelled at",
-				"cancelled-by": "Cancelled by",
-				"reason": "Reason",
-				"delivery": "Delivery mode",
-				"followed-up-at": "Followed up at",
-				"patient": "Patient",
-				"rebooked-appointment": "Rebooked appointment",
-				"recovery-state": "Recovery state",
-				"not-provided": "Not provided"
-			},
-			"actions": {
-				"rebook": "Rebook this patient",
-				"archive": "Mark as resolved",
-				"archive-all": "Mark all as resolved ({{count}})",
-				"more": "More actions",
-				"open-patient": "Open patient profile",
-				"reopen": "Set slot to available again",
-				"archive-success": "Recovery closed without further action.",
-				"archive-error": "Failed to close this recovery item. Please try again.",
-				"archive-all-success": "{{count}} recovery items marked as resolved.",
-				"archive-all-error": "Failed to resolve all recovery items. Please try again.",
-				"reopen-success": "Slot reopened successfully.",
-				"reopen-error": "Failed to reopen the slot. Please try again."
-			}
-		},
-		"week": {
-			"drawer": {
-				"address-override": "Session location",
-				"address-override-question": "Use a different location for this session?",
-				"address-reset": "Reset to default",
-				"address-save": "Save location",
-				"address-save-error": "Failed to save session location. Please try again.",
-				"address-saved": "Session location saved.",
-				"block-confirm": "Confirm block",
-				"block-confirm-body": "This slot will no longer be available for patients to book.",
-				"block-error": "Failed to block slot. Please try again.",
-				"block-reason-label": "Block reason",
-				"block-reason-placeholder": "Optional: Add a reason for blocking",
-				"block-slot": "Block slot",
-				"block-success": "Slot blocked successfully.",
-				"break-edit": "Edit break",
-				"break-edit-body": "This break is controlled by your global buffer-time setting. Update the minutes below to change future break blocks.",
-				"break-edit-save": "Save break",
-				"break-note": "Automatically blocked for rest between sessions.",
-				"break-note-label": "How this works",
-				"break-remove": "Remove",
-				"break-subtitle": "Scheduled break",
-				"break-title": "Break time",
-				"blocked-at": "Blocked on {{date}}",
-				"blocked-subtitle": "Patients cannot book this time slot",
-				"blocked-title": "Slot blocked",
-				"cancelled-at": "Cancelled on {{date}}",
-				"cancelled-reason-label": "Reason for cancellation",
-				"cancelled-by-patient": "This appointment was cancelled by the patient",
-				"cancelled-by-therapist": "This appointment was cancelled by the therapist",
-				"cancelled-subtitle": "This appointment was cancelled",
-				"cancelled-title": "Cancelled appointment",
-				"booking-link-copy-aria": "Copy booking link to clipboard",
-				"booking-link-hint": "Share this link to open the public booking page with this slot preselected when it is still available.",
-				"booking-link-label": "Booking link",
-				"booking-share-text": "Open this link to book the selected session.",
-				"booking-share-title": "Book this session on {{date}} at {{time}}",
-				"book-slot": "Book this slot",
-				"cancel": "Cancel",
-				"cancel-appointment": "Cancel appointment",
-				"cancel-back": "Go back",
-				"cancel-choice-sub": "Cancel this appointment permanently",
-				"cancel-confirm": "Confirm cancellation",
-				"cancel-custom-reason-label": "Additional details (optional)",
-				"cancel-error": "Failed to cancel appointment. Please try again.",
-				"cancel-reason-label": "Reason for cancellation",
-				"cancel-success": "Appointment cancelled successfully.",
-				"confirm-booking": "Confirm",
-				"confirmed": "Confirmed",
-				"date": "Date",
-				"edit": "Edit",
-				"edit-end-time": "End time",
-				"booking-error": "Failed to book appointment. Please try again.",
-				"booking-success": "Appointment booked successfully.",
-				"conflict-change-details": "Change contact details",
-				"conflict-confirm": "Book for {{name}}",
-				"conflict-multiple-body": "The phone and email match different patients. Update the contact details to continue.",
-				"conflict-single-body": "A patient with this contact is already registered:",
-				"conflict-title": "Patient already registered",
-				"existing-booking-body": "{{name}} already has a session booked on {{date}} at {{time}}. Would you like to add another session for this patient?",
-				"existing-booking-cancel": "Choose another patient",
-				"existing-booking-confirm": "Add another session",
-				"existing-booking-title": "Patient already has a session",
-				"edit-error": "Failed to save changes. Please try again.",
-				"edit-note": "Notes",
-				"edit-save": "Save changes",
-				"edit-start-time": "Start time",
-				"edit-success": "Slot updated successfully.",
-				"edit-success-booked": "Slot updated. Note: this session had an active booking.",
-				"let-patient-choose-address": "Let the patient choose the location?",
-				"location-choice-clinic": "Clinic",
-				"location-choice-custom": "Custom",
-				"location-choice-label": "Session location",
-				"session-delivery-in-person": "In person",
-				"session-delivery-in-person-subtitle": "At your clinic or the patient's location",
-				"session-delivery-label": "How will this session be held?",
-				"session-delivery-online": "Online",
-				"recurrence-all": "All future appointments",
-				"recurrence-end-month": "Until end of month",
-				"recurrence-end-year": "Until end of year",
-				"recurrence-label": "Repeat booking",
-				"recurrence-single": "This appointment only",
-				"session-delivery-online-subtitle": "Video call, phone, or messaging",
-				"location-choice-patient": "Patient",
-				"location-subtitle-clinic": "We will share your clinic address in the booking location",
-				"location-subtitle-custom": "We will share the custom address in the booking location",
-				"location-subtitle-patient": "You will allow your patient to choose an address in the booking location",
-				"minutes": "minutes",
-				"notes": "Notes",
-				"patient-email": "Patient's email",
-				"patient-timezone": "Patient's timezone",
-				"patient-timezone-placeholder": "Search by city, e.g. Sao Paulo",
-				"patient-first-name": "Patient's first name",
-				"patient-last-name": "Patient's last name",
-				"patient-search": {
-					"no-results": "No patients found",
-					"placeholder": "Search or type a new name",
-					"type-to-search": "Type at least 2 characters to search"
-				},
-				"patient-time": "Patient's local time",
-				"reschedule": "Reschedule",
-				"reschedule-choice-sub": "Move to a different time slot",
-				"reschedule-confirm": "Confirm reschedule",
-				"reschedule-error": "Failed to reschedule appointment. Please try again.",
-				"reschedule-no-slots": "No available slots to reschedule to. Try adjusting your working hours.",
-				"reschedule-select-prompt": "Select a new time slot for this appointment.",
-				"reschedule-success": "Appointment rescheduled successfully.",
-				"reopen-slot": "Set to available again",
-				"reopened-note-fallback-name": "this patient",
-				"reopened-note-label": "Previously cancelled",
-				"reopened-note-text": "Previously cancelled to {{name}} on {{date}}.",
-				"session-duration": "Duration: ",
-				"session-type": "Session type",
-				"share-address": "Share clinic address with patient",
-				"status-cancelled": "Cancelled",
-				"status-confirmed": "Confirmed",
-				"available-status-open": "Open for booking",
-				"your-time": "Your local time",
-				"appointment-address": "Appointment address",
-				"patient-phone": "Patient's phone",
-				"patient-provides-address": "Patient will provide the address",
-				"call-whatsapp": "Call on WhatsApp",
-				"call-phone": "Call patient",
-				"join-meet": "Join on Google Meet",
-				"join-zoom": "Join on Zoom",
-				"booked-section-session": "Session",
-				"booked-section-patient": "Patient",
-				"booked-section-location": "Location",
-				"booked-section-notes": "Notes",
-				"booked-date": "Date",
-				"booked-time": "Time",
-				"booked-duration": "Duration",
-				"booked-session-count": "Session {{count}} with {{name}}",
-				"booked-session-first": "First session with {{name}}",
-				"booked-email": "Email",
-				"booked-phone": "Phone",
-				"booked-online-session": "Online session",
-				"booked-hybrid": "Online / In person",
-				"booked-in-person": "In person",
-				"booked-google-sync": "Synced from Google Calendar",
-				"booked-profile-link": "Profile",
-				"booked-profile-coming-soon": "Patient profile — coming soon",
-				"booked-no-email": "No email provided",
-				"booked-no-phone": "No phone provided",
-				"booked-awaiting-address": "Awaiting patient address",
-				"booked-request-address": "Request address",
-				"booked-view-notifications": "View notifications",
-				"booked-past-disabled": "Past appointment — actions disabled",
-				"booked-copied": "Copied",
-				"booked-copy-aria": "Copy {{field}} to clipboard",
-				"booked-call-aria": "Call {{name}}",
-				"booked-whatsapp-aria": "Message {{name}} on WhatsApp",
-				"booked-email-aria": "Email {{name}}",
-				"source-manual": "Booked",
-				"unblock-confirm": "Confirm unblock",
-				"unblock-confirm-body": "This slot will become available for booking again.",
-				"unblock-error": "Failed to unblock slot. Please try again.",
-				"unblock-slot": "Unblock slot",
-				"unblock-success": "Slot unblocked successfully."
-			},
-			"buffer-label": "Buffer",
-			"legend-available": "Available",
-			"legend-blocked": "Blocked",
-			"legend-booked-google": "Google",
-			"legend-booked-jupiter": "Booked",
-			"legend-buffer": "Buffer",
-			"legend-cancelled": "Cancelled",
-			"next-week": "Next week",
-			"no-appointments": "No appointments",
-			"page-title": "Availability",
-			"prev-week": "Previous week",
-			"filter-clear": "Clear filters",
-			"filter-delivery-in-person": "In person",
-			"filter-delivery-online": "Online",
-			"filter-hide-free": "Hide free slots",
-			"filter-label-cancelled": "Cancelled slots",
-			"filter-label-free": "Free slots",
-			"filter-section-delivery": "Delivery",
-			"filter-section-session-type": "Session type",
-			"filter-section-source": "Source",
-			"filter-section-status": "Slot status",
-			"filter-section-time": "Time of day",
-			"filter-show-free": "Show free slots",
-			"filter-source-google": "Google",
-			"filter-source-jupiter": "Jupiter",
-			"filter-time-afternoon": "Afternoon",
-			"filter-time-evening": "Evening",
-			"filter-time-morning": "Morning",
-			"filters": "Filters",
-			"collapse-day": "Show less",
-			"expand-day": "+{{count}} more",
-			"blocked-hover-label": "Blocked slot",
-			"show-available-slots": "Show available times ({{count}})",
-			"slot": "slot",
-			"slots": "slots",
-			"title": "Week Schedule",
-			"settings": "Settings",
-			"default-blocked-day": {
-				"body": "{{day}} is closed by your default availability settings. Open only this date as a full day, part of the day, or selected time slots.",
-				"confirm": "Open this day",
-				"end-time": "End time",
-				"error": "Could not open this day. Please try again.",
-				"open-full-day": "Open full day",
-				"open-full-day-desc": "Create all available slots for this date using your usual working hours.",
-				"open-part-day": "Open part of day",
-				"open-part-day-desc": "Choose a custom time range for this specific date only.",
-				"open-specific-slots": "Open specific slots",
-				"open-specific-slots-desc": "Select only the exact times you want to make available.",
-				"start-time": "Start time",
-				"success": "This day is now available.",
-				"title": "Open this closed day?"
-			},
-			"day-header": {
-				"actions": "Day actions",
-				"block-all": "Block all available slots",
-				"block-all-confirm": "Block all {{count}} available slots on {{day}}? Patients won't be able to book these times.",
-				"booked-warning": "This day has {{count}} booked appointment(s). Blocking the day will only affect the remaining available slots.",
-				"block-all-error": "Failed to block slots. Please try again.",
-				"block-all-success": "All available slots blocked successfully.",
-				"summary": "{{total}} total · {{available}} available · {{booked}} booked · {{blocked}} blocked · {{cancelled}} cancelled",
-				"unblock-all": "Unblock all blocked slots",
-				"unblock-all-confirm": "Unblock all {{count}} blocked slots on {{day}}? These slots will become available for booking.",
-				"unblock-all-error": "Failed to unblock slots. Please try again.",
-				"unblock-all-success": "All blocked slots unblocked successfully."
-			}
-		},
-		"gate": {
-			"deleted-notice": "You no longer have availability set up. Head to Jupiter to create a new one."
-		},
-		"settings": {
-			"google-calendar-connect-btn": "Connect Google Calendar",
-			"google-calendar-connect-error": "Could not start Google Calendar connection. Please try again.",
-			"first-publish-alert": "Your availability is live! Complete the checklist below to optimize your setup.",
-			"google-calendar-connected": "Your Google Calendar is connected.",
-			"google-calendar-desc": "Sync your Google Calendar to import your existing schedule, block busy times automatically, and keep your Psycron sessions in sync.",
-			"google-calendar-drawer-title": "Google Calendar",
-			"live-alert": "Your availability is now live. Clients can start booking sessions with you right away.",
-			"page-title": "Availability Settings",
-			"save-error": "Could not save settings. Please try again.",
-			"save-success": "Settings saved successfully.",
-			"session-duration-desc": "Set the default length for each appointment.",
-			"session-duration-drawer-title": "Session duration",
-			"session-type-both": "Both",
-			"session-type-desc": "Choose how you conduct your sessions.",
-			"session-type-drawer-title": "Session type",
-			"session-type-in-person": "In person",
-			"session-type-online": "Online",
-			"session-address-desc": "Enter your clinic or office address so patients can find you.",
-			"session-type-address-hint": "In-person sessions require a clinic address. You'll be prompted to add it after saving.",
-			"session-address-drawer-title": "Session address",
-			"session-address-title": "Clinic address",
-			"specialty-drawer-title": "Your specialty",
-			"specialty-desc": "Choose the broad field you work in. You can add your specific approach below.",
-			"specialty-psychology": "Psychology",
-			"specialty-psychiatry": "Psychiatry",
-			"specialty-physiotherapy": "Physiotherapy",
-			"specialty-nutrition": "Nutrition",
-			"specialty-coaching": "Coaching",
-			"specialty-occupational-therapy": "Occupational therapy",
-			"specialty-speech-therapy": "Speech therapy",
-			"specialty-social-work": "Social work",
-			"specialty-other": "Other",
-			"specialty-detail-label": "Specific approach or method (optional)",
-			"specialty-detail-helper": "e.g. Cognitive Behavioural Therapy, EMDR — used to improve your profile",
-			"feature-disabled-tooltip": "This feature is coming soon",
-			"jupiter-cta-disabled-tooltip": "Júpiter is not available yet — we're rolling this out gradually",
-			"jupiter-help-action": "Talk to Júpiter",
-			"jupiter-help-description": "Júpiter can guide you through completing your setup",
-			"jupiter-help-title": "Need help?",
-			"talk-to-jupiter": "Edit with Jupiter",
-			"timezone-desc": "All bookings will be displayed and scheduled in this time zone.",
-			"timezone-drawer-title": "Time zone",
-			"timezone-input-label": "Time zone",
-			"timezone-warning-body": "Your existing appointments won't move — they'll continue at the same UTC time but displayed in the new time zone.",
-			"timezone-warning-confirm": "Change time zone",
-			"timezone-warning-title": "Change time zone?",
-			"working-hours-days-label": "Working days",
-			"working-hours-desc": "Set your available days and the time range for appointments.",
-			"working-hours-drawer-title": "Working hours",
-			"working-hours-end-label": "End",
-			"recurrence-consistent": "Consistent",
-			"recurrence-consistent-desc": "Your schedule repeats the same days and hours every week, generated one month at a time. Best for a consistent, predictable routine.",
-			"recurrence-flexible": "Flexible",
-			"recurrence-flexible-desc": "Slots are generated for the full month at once. Best if your availability varies — you can edit individual slots without rebuilding your entire schedule.",
-			"recurrence-pattern-desc": "Changing this will regenerate your open availability slots using the new pattern. Any already-booked appointments will remain exactly as scheduled.",
-			"recurrence-pattern-drawer-title": "Recurrence pattern",
-			"working-hours-start-label": "Start",
-			"working-hours-time-label": "Time range"
-		}
-	},
-	"conflicts": {
-		"title": "Conflict panel",
-		"subtitle": "Review and resolve booking and patient conflicts.",
-		"empty": "No conflicts match your current filters.",
-		"filters": {
-			"title": "Filters",
-			"summary-default": "Refine the queue by status or conflict type.",
-			"summary-active": "{{count}} active filter",
-			"summary-active_other": "{{count}} active filters",
-			"status": "Status",
-			"type": "Type",
-			"open": "Open",
-			"all-statuses": "All statuses",
-			"all-types": "All types"
-		},
-		"queue": {
-			"eyebrow": "Operations",
-			"title": "Conflict queue",
-			"subtitle": "Review the items that still need your decision."
-		},
-		"layout": {
-			"expand-queue": "Expand queue",
-			"collapse-queue": "Collapse queue"
-		},
-		"accessibility": {
-			"queue": "Conflict queue",
-			"detail": "Conflict detail"
-		},
-		"status": {
-			"open": "Open",
-			"resolved": "Resolved",
-			"dismissed": "Dismissed"
-		},
-		"types": {
-			"patient-duplicate": "Patient duplicate",
-			"slot-replication": "Slot replication"
-		},
-		"patient-duplicate": {
-			"title": "Possible duplicate patient",
-			"and": "and",
-			"summary": {
-				"phone-and-email": "Matches existing patient records by phone {{phone}} and email {{email}}. Review: {{candidates}}.",
-				"phone-only": "Matches existing patient records by phone {{phone}}. Review: {{candidates}}.",
-				"email-only": "Matches existing patient records by email {{email}}. Review: {{candidates}}.",
-				"generic": "Matches an existing patient record. Review: {{candidates}}."
-			},
-			"match": {
-				"phone-and-email": "Phone {{phone}} and email {{email}}",
-				"phone-only": "Phone {{phone}}",
-				"email-only": "Email {{email}}",
-				"generic": "Existing patient details"
-			}
-		},
-		"detail": {
-			"incoming-patient": "Incoming patient",
-			"existing-patient": "Existing patient",
-			"matched-by": "Matched by",
-			"candidate-records": "Candidate records",
-			"conflicting-details": "Conflicting details",
-			"conflicting-date": "Conflicting date",
-			"conflicting-time": "Conflicting time",
-			"recurrence-pattern": "Recurrence pattern",
-			"preferred-contact": "Preferred contact",
-			"additional-candidates": "{{count}} more possible match is still queued for review.",
-			"additional-candidates_other": "{{count}} more possible matches are still queued for review.",
-			"not-provided": "Not provided"
-		},
-		"merge-review": {
-			"title": "Choose what to keep",
-			"description": "Bookings, cancellations, and notifications will be combined automatically. Choose the profile details that should remain on the surviving patient.",
-			"primary": "Keep from {{name}}",
-			"secondary": "Use from {{name}}",
-			"confirm": "Confirm merge",
-			"fields": {
-				"firstName": "First name",
-				"lastName": "Last name",
-				"contacts": {
-					"email": "Email",
-					"phone": "Phone",
-					"whatsapp": "WhatsApp"
-				},
-				"billing": "Billing",
-				"preferredContact": "Preferred contact",
-				"timeZone": "Timezone",
-				"address": "Address"
-			}
-		},
-		"resolution": {
-			"title": "Resolution history",
-			"completed-at": "Completed on {{date}}.",
-			"actions": {
-				"auto-dismissed-stale": "Psycron closed this because the duplicate records are no longer active.",
-				"dismissed": "The therapist dismissed this conflict without changing patient records.",
-				"keep-existing": "The therapist kept the existing patient record and did not merge records.",
-				"keep-new": "The therapist kept the new patient record and did not merge records.",
-				"marked-resolved": "The therapist marked this conflict as resolved.",
-				"merged": "The therapist merged the duplicate patient records.",
-				"merge-reconciled": "Psycron closed this because another merge already handled the duplicate patient.",
-				"unknown": "This conflict was closed."
-			},
-			"sources": {
-				"primary": "Kept from {{name}}",
-				"secondary": "Changed to {{name}}"
-			}
-		},
-		"actions": {
-			"recommended-title": "Recommended resolution",
-			"recommended-hint": "Merge both records and keep one patient as the source of truth.",
-			"alternatives-title": "Other options",
-			"alternatives-hint": "Use one record only if you do not want to merge them now.",
-			"merge": "Merge patients",
-			"keep-existing": "Keep existing patient",
-			"keep-new": "Keep new patient",
-			"dismiss": "Dismiss",
-			"mark-resolved": "Mark resolved",
-			"error": "We couldn't update this conflict. Please try again."
-		}
-	},
-	"action-center": {
-		"title": "Action center",
-		"subtitle": "Resolve the operational items that need your attention today.",
-		"tabs": {
-			"aria-label": "Action center sections",
-			"conflicts": "Conflicts",
-			"recovery": "Recovery"
-		}
-	},
-	"notifications": {
-		"title": "Notifications",
-		"subtitle": "Track outbound patient communication across WhatsApp, email, and SMS.",
-		"empty": "No notifications match your current filters.",
-		"load-more": "Load more",
-		"queue": {
-			"title": "Notification feed",
-			"subtitle": "A delivery timeline for patient communication."
-		},
-		"layout": {
-			"expand-feed": "Expand feed",
-			"collapse-feed": "Collapse feed"
-		},
-		"accessibility": {
-			"page": "Notifications workspace",
-			"queue": "Notification feed",
-			"detail": "Notification detail"
-		},
-		"stats": {
-			"total": "Total",
-			"failed": "Failed",
-			"delivered": "Delivered",
-			"sent": "Sent"
-		},
-		"search": {
-			"placeholder": "Search patient or message"
-		},
-		"sort": {
-			"label": "Sort",
-			"options": {
-				"newest": "Newest first",
-				"oldest": "Oldest first",
-				"status": "Status"
-			}
-		},
-		"filters": {
-			"title": "Filters",
-			"summary-default": "Refine the feed by channel, status, type, or date.",
-			"summary-active": "{{count}} active filter",
-			"summary-active_other": "{{count}} active filters",
-			"channel": "Channel",
-			"status": "Status",
-			"message-type": "Message type",
-			"date-range": "Date range",
-			"from": "From",
-			"to": "To",
-			"all-channels": "All channels",
-			"all-statuses": "All statuses",
-			"all-types": "All types",
-			"active": "Active",
-			"archived": "Archived"
-		},
-		"channels": {
-			"whatsapp": "WhatsApp",
-			"email": "Email",
-			"sms": "SMS",
-			"icalendar": "Calendar invite"
-		},
-		"statuses": {
-			"pending": "Pending",
-			"sent": "Sent",
-			"delivered": "Delivered",
-			"failed": "Failed"
-		},
-		"message-types": {
-			"appointment_confirmation": "Appointment confirmation",
-			"appointment_updated": "Appointment updated",
-			"reminder": "Reminder",
-			"conflict": "Conflict",
-			"account_setup": "Account setup",
-			"daily_schedule_summary": "Daily schedule summary",
-			"unknown": "Notification"
-		},
-		"bulk": {
-			"resend-eligible": "Re-notify eligible",
-			"action": "Notify again"
-		},
-		"card": {
-			"appointment": "Appointment: {{value}}",
-			"delivered-at": "Sent at {{value}}",
-			"failed": "Failed delivery"
-		},
-		"patient-settings": {
-			"action": "Patient notification settings",
-			"title": "Patient Notification Preferences",
-			"subtitle": "Configure which channels this patient receives notifications on.",
-			"subtitle-named": "Configure which channels {{name}} receives notifications on.",
-			"save-success": "Patient notification preferences saved.",
-			"save-error": "Could not save patient notification preferences."
-		},
-		"settings": {
-			"action": "Setup notifications",
-			"title": "Notification Preferences",
-			"subtitle": "Control which channels are used for each type of patient communication.",
-			"save-success": "Notification preferences saved.",
-			"save-error": "Could not save notification preferences. Please try again.",
-			"appointment-confirmation": {
-				"title": "Appointment Confirmation",
-				"description": "Sent to the patient when a new appointment is booked."
-			},
-			"reminder": {
-				"title": "Appointment Reminders",
-				"description": "Sent to the patient before the appointment.",
-				"toggle": "Enable reminders",
-				"lead-time": {
-					"label": "Send reminder",
-					"30m": "30 min before",
-					"1h": "1 hour before",
-					"2h": "2 hours before",
-					"24h": "24 hours before",
-					"48h": "48 hours before"
-				}
-			},
-			"appointment-updated": {
-				"title": "Appointment Updated",
-				"description": "Sent to the patient when an appointment is rescheduled or modified."
-			},
-			"calendar-invite": {
-				"title": "Calendar Invite",
-				"description": "Attach a .ics calendar file to email confirmations and reminders.",
-				"toggle": "Include calendar attachment"
-			}
-		},
-		"context": {
-			"channel-status": "{{channel}} notification is {{status}}.",
-			"sent-at": "Sent at {{value}}.",
-			"delivered-at": "Delivered at {{value}}.",
-			"appointment": "Appointment: {{value}}.",
-			"session": "Session: {{value}}.",
-			"calendar-invite-attached": "Calendar invite attached.",
-			"error": "Delivery error: {{value}}"
-		},
-		"detail": {
-			"title": "Communication details",
-			"patient": "Patient",
-			"unknown-patient": "Unknown patient",
-			"message-type": "Message type",
-			"channel": "Channel",
-			"status": "Status",
-			"sent-at": "Sent at",
-			"delivered-at": "Delivered at",
-			"appointment": "Appointment",
-			"ics": "Calendar invite",
-			"ics-attached": "Attached",
-			"ics-empty": "Not attached",
-			"message": "Message",
-			"context": "Context",
-			"error": "Delivery error",
-			"payload": "Payload"
-		},
-		"retry": {
-			"action": "Retry notification",
-			"action-short": "Retry",
-			"success": "Notification sent again.",
-			"error": "We could not send this notification again. Please try again."
-		},
-		"resend": {
-			"action": "Notify again",
-			"action-short": "Notify again"
-		},
-		"archive": {
-			"action": "Archive",
-			"success": "Notification archived.",
-			"error": "Could not archive this notification."
-		}
-	}
+  "public": {
+    "powered-by": "Powered by Psycron"
+  },
+  "booking": {
+    "page": {
+      "title": "Book a Session"
+    },
+    "calendar": {
+      "title": "Select a date and time",
+      "subtitle": "Pick a day first, then choose the time that works best for you.",
+      "booking-greeting": "Hello, choose your appointment.",
+      "detail-title": "Choose a date",
+      "view-month": "Month",
+      "view-week": "Week",
+      "pick-a-day": "Select a date on the calendar to see what is available.",
+      "no-date-title": "No date selected yet",
+      "no-date-body": "Start by choosing a highlighted day from the calendar.",
+      "no-times-title": "No times for this day",
+      "no-times-body": "Try another highlighted date or switch the time-of-day filter.",
+      "available-count": "available times",
+      "sidebar-description": "Choose the day and time that work best for you.",
+      "duration-heading": "Session length",
+      "duration-pending": "Select a time to preview the duration.",
+      "location-pending": "Choose a date and time to preview the session location.",
+      "date-heading": "Selected day",
+      "date-pending": "Pick a date from the calendar.",
+      "agenda-title": "Appointments",
+      "agenda-main-title": "Calendar",
+      "agenda-subtitle": "Tap a day to focus on just the appointments that matter on that date.",
+      "agenda-greeting": "Hello, {{name}}, check your appointments.",
+      "agenda-greeting-fallback": "Hello, check your appointments.",
+      "agenda-sidebar-description": "A view of your journey with quick access to upcoming, past, and cancelled sessions.",
+      "agenda-overview-title": "Overview",
+      "agenda-overview-fallback": "Overview",
+      "agenda-overview-heading": "Overview",
+      "agenda-overview-heading-fallback": "Overview",
+      "active-days": "Active days",
+      "day-appointments": "appointments on this day",
+      "selected-day-section": "Appointments of the day",
+      "next-appointments-section": "Next appointments",
+      "no-appointments-title": "Nothing scheduled for this day",
+      "no-appointments-body": "Choose another highlighted date to review your appointments.",
+      "no-next-appointments": "Your next confirmed appointments will appear here."
+    },
+    "filter": {
+      "from": "From",
+      "label-date-range": "Date range",
+      "label-time-of-day": "Time of day",
+      "time-all": "Any time",
+      "time-morning": "Morning (before noon)",
+      "time-afternoon": "Afternoon (12–17h)",
+      "time-evening": "Evening (after 17h)",
+      "time-of-day": "Time of day",
+      "to": "To",
+      "weeks-1": "Next week",
+      "weeks-2": "Next 2 weeks",
+      "weeks-4": "Next month",
+      "weeks-12": "Next 3 months",
+      "weeks-all": "All available"
+    },
+    "slot": {
+      "booked": "Booked",
+      "taken": "Taken"
+    },
+    "drawer": {
+      "aria-label": "Book appointment",
+      "title": "Confirm your booking"
+    },
+    "confirm": "Confirm",
+    "error": "Something went wrong. Please try again.",
+    "no-slots": "No available slots match your filters.",
+    "form": {
+      "address-fallback": "Address will appear here after you enter it above.",
+      "email": "Email",
+      "first-name": "First name",
+      "last-name": "Last name",
+      "notify-email": "Notify me by email",
+      "notify-fallback": "Provide your contact details above to enable notifications.",
+      "notify-whatsapp": "Notify me by WhatsApp",
+      "section-notifications": "Notifications",
+      "section-personal": "Your details",
+      "section-recurrence": "Recurrence",
+      "your-address": "Session address"
+    },
+    "notifications": {
+      "description": "We'll send you a reminder before each session.",
+      "email": "Notify me by email",
+      "fallback-note": "Add your contact details above to enable reminders.",
+      "title": "Reminders",
+      "whatsapp": "Notify me by WhatsApp"
+    },
+    "recurrence": {
+      "biweekly": "Every 2 weeks",
+      "monthly": "Every month",
+      "not-yet": "Not yet — decide later",
+      "single": "One-time session",
+      "title": "How often would you like to meet?",
+      "weekly": "Every week"
+    },
+    "confirmation": {
+      "title": "You're booked!",
+      "subtitle": "Great, {{name}}! Your session has been confirmed.",
+      "date": "Date",
+      "time": "Time",
+      "your-agenda": "Your personal agenda",
+      "agenda-description": "Use this link to view and manage your upcoming appointments.",
+      "copy-link": "Copy link"
+    },
+    "appointments": {
+      "title": "Your appointments",
+      "subtitle": "View and manage your scheduled sessions.",
+      "upcoming": "Upcoming",
+      "past": "Past",
+      "cancelled": "Cancelled",
+      "no-upcoming": "You have no upcoming appointments.",
+      "no-upcoming-title": "No upcoming sessions",
+      "no-past": "Completed appointments will appear here after your sessions.",
+      "no-past-title": "No past appointments yet",
+      "no-cancelled": "Cancelled appointments will stay here for your reference.",
+      "no-cancelled-title": "No cancelled appointments",
+      "therapist-fallback": "Your therapist"
+    },
+    "patient-drawer": {
+      "aria-label": "Patient appointment details",
+      "role": "Your appointment",
+      "available-title": "Confirm & book",
+      "available-subtitle": "Review this slot before completing your booking.",
+      "available-badge": "Available",
+      "confirmed-title": "Your appointment",
+      "confirmed-badge": "Confirmed",
+      "completed-title": "Completed appointment",
+      "completed-badge": "Completed",
+      "cancelled-title": "Cancelled appointment",
+      "cancelled-badge": "Cancelled",
+      "cancelled-notice": "This appointment was cancelled on {{date}}.",
+      "therapist-section": "Therapist",
+      "details-section": "Session details",
+      "contact-section": "Contact",
+      "reschedule-section": "Choose a new time",
+      "specialty-fallback": "Specialty details coming soon",
+      "when": "{{date}} at {{time}}",
+      "when-label": "When",
+      "duration": "{{minutes}} min",
+      "duration-label": "Duration",
+      "session-type-label": "Session type",
+      "session-online": "Online session",
+      "session-in-person": "In-person session",
+      "location-label": "Location",
+      "location-online": "Online session",
+      "location-in-person": "In-person location will be confirmed by your therapist.",
+      "location-address": "{{address}}",
+      "awaiting-address": "Waiting for the session address",
+      "call-therapist": "Call therapist",
+      "copy-phone": "Copy phone",
+      "cancel": "Cancel appointment",
+      "reschedule": "Reschedule",
+      "confirm-reschedule": "Confirm reschedule",
+      "reschedule-success": "Appointment rescheduled successfully.",
+      "reschedule-error": "We could not reschedule this appointment. Please try again.",
+      "no-reschedule-slots": "No other available slots were found right now.",
+      "book-new": "Book new appointment",
+      "session-completed": "Session completed"
+    },
+    "cancel": {
+      "button": "Cancel appointment",
+      "reason-prompt": "Please let us know why you need to cancel.",
+      "reason-label": "Reason",
+      "reason": {
+        "emergency": "Personal emergency",
+        "schedule-conflict": "Schedule conflict",
+        "financial": "Financial reasons",
+        "mental-health": "Not feeling ready",
+        "other": "Other"
+      },
+      "custom-reason": "Tell us more (optional)",
+      "confirm": "Confirm cancellation",
+      "success": "Your appointment has been cancelled.",
+      "error": "Something went wrong. Please try again."
+    }
+  },
+  "common": {
+    "back": "Back",
+    "cancel": "Cancel",
+    "close": "Close",
+    "layout": {
+      "collapse-queue": "Collapse",
+      "expand-queue": "Expand"
+    },
+    "loading": "Loading...",
+    "required": "Required",
+    "save": "Save",
+    "saving": "Saving...",
+    "today": "Today"
+  },
+  "patients": {
+    "list": {
+      "title": "Patient Center",
+      "subtitle": "Browse, search and manage your patients.",
+      "search-label": "Search",
+      "search-placeholder": "Search by name, email, or phone",
+      "status-label": "Status",
+      "status-all": "All patients",
+      "status-active": "Active",
+      "status-inactive": "Inactive",
+      "sort-label": "Sort by",
+      "sort-name": "Name (A-Z)",
+      "sort-name-desc": "Name (Z-A)",
+      "sort-last-appointment-asc": "Last appointment (oldest first)",
+      "sort-last-appointment": "Last appointment",
+      "sort-total-sessions-asc": "Total sessions (lowest first)",
+      "sort-total-sessions": "Total sessions",
+      "columns": {
+        "patient": "Patient",
+        "contact": "Contact",
+        "preferred-contact": "Preferred contact",
+        "timezone": "Timezone",
+        "billing": "Billing",
+        "recovery": "Recovery",
+        "last-appointment": "Last appointment",
+        "sessions": "Sessions",
+        "status": "Status"
+      },
+      "empty": {
+        "initial-title": "No patients yet",
+        "initial-body": "When you add or book your first patient, they will appear here and become part of your Patient Center.",
+        "filtered-title": "No patients match these filters",
+        "filtered-body": "Try adjusting your search or filters to find the patient you are looking for."
+      },
+      "clear-search": "Clear search",
+      "billing": {
+        "none": "Not set",
+        "per-session-short": "/ session",
+        "monthly-short": "/ month"
+      },
+      "not-available": "Not available",
+      "no-appointments": "No appointments yet",
+      "contact-method-not-set": "Not set",
+      "possible-duplicate": "Possible duplicate",
+      "cancellation-follow-up-needed": "{{count}} needs follow-up",
+      "cancellation-follow-up-needed_other": "{{count}} need follow-up",
+      "cancellation-follow-up-tooltip": "{{count}} cancelled session has no follow-up, rebook, archive, or reopen recorded.",
+      "cancellation-follow-up-tooltip_other": "{{count}} cancelled sessions have no follow-up, rebook, archive, or reopen recorded.",
+      "cancellation-follow-up-none": "No cancellations",
+      "cancellation-follow-up-resolved": "Resolved",
+      "cancelled-sessions-notice": "{{count}} cancelled session",
+      "cancelled-sessions-notice_other": "{{count}} cancelled sessions"
+    },
+    "profile": {
+      "subtitle": "Review contact details, care preferences, and session history.",
+      "member-since": "Patient since {{date}}",
+      "unknown-patient": "unknown patient",
+      "merged-note": "This patient record was merged into {{patientId}} and is kept for audit history.",
+      "not-found": "We could not load this patient. They may have been archived or merged into another record.",
+      "actions": {
+        "call": "Call",
+        "edit": "Edit patient",
+        "open-sessions": "Open sessions page",
+        "whatsapp": "WhatsApp",
+        "email": "Email"
+      },
+      "edit": {
+        "title": "Edit patient details",
+        "description": "Update contact details, care preferences, timezone, and address.",
+        "save": "Save changes"
+      },
+      "session-drawer": {
+        "title": "Session details",
+        "open-label": "Open session details for {{date}}",
+        "status": "Status",
+        "delivery": "Session format",
+        "cancelled-at": "Cancelled at",
+        "cancellation-reason": "Cancellation reason",
+        "cancelled-by": "Cancelled by",
+        "cancelled-by-patient": "Patient",
+        "cancelled-by-therapist": "Therapist",
+        "cancelled-by-unknown": "Not available",
+        "notification": "Notification",
+        "notification-sent": "Notification sent",
+        "notification-not-sent": "Notification not sent",
+        "cancel-confirm": "Confirm cancellation",
+        "cancel-custom-reason": "Please describe the reason",
+        "cancel-error": "We could not cancel this session. Please try again.",
+        "cancel-reason-prompt": "Why are you cancelling this session?",
+        "cancel-session": "Cancel session",
+        "cancel-success": "Session cancelled successfully.",
+        "cancelled-title": "Session cancelled",
+        "completed-title": "Session completed",
+        "notify": "Notify patient",
+        "notify-error": "We could not send the notification. Please try again.",
+        "notify-sending": "Sending notification…",
+        "notify-success": "Patient notified successfully.",
+        "read-only": "Cancelled sessions are available for review only.",
+        "reschedule": "Reschedule",
+        "reschedule-confirm": "Confirm reschedule",
+        "reschedule-error": "We could not reschedule this appointment. Please try again.",
+        "reschedule-no-slots": "No available slots to reschedule to. Try adjusting your working hours.",
+        "reschedule-prompt": "Select a new time slot for this appointment.",
+        "reschedule-success": "Appointment rescheduled successfully.",
+        "role": "Patient session",
+        "upcoming-title": "Upcoming session",
+        "update-error": "We could not update this session. Please try again.",
+        "update-no-change": "No changes were made — the session time is the same.",
+        "update-success": "Session updated successfully."
+      },
+      "status": {
+        "active": "Active",
+        "archived": "Archived",
+        "merged": "Merged"
+      },
+      "stats": {
+        "total": "Total sessions",
+        "upcoming": "Upcoming",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "notifications": {
+        "label": "Notifications",
+        "reminders-off": "Reminders off"
+      },
+      "sections": {
+        "billing": "Billing",
+        "details": "Patient details",
+        "timeline": "Session timeline"
+      },
+      "billing": {
+        "model": "Billing model",
+        "category": "Billing category",
+        "amount": "Price",
+        "currency": "Currency",
+        "models": {
+          "per-session": "Paid per session",
+          "monthly": "Paid monthly"
+        },
+        "categories": {
+          "standard": "Standard",
+          "social": "Social care",
+          "pro-bono": "Pro bono"
+        },
+        "category-descriptions": {
+          "standard": "Regular paid care at the agreed rate.",
+          "social": "Reduced-fee or socially supported care, tracked separately.",
+          "pro_bono": "Free care with no payment expected."
+        }
+      },
+      "share": {
+        "title": "Your sessions page",
+        "text": "Use this link to view and manage your scheduled sessions.",
+        "link-label": "Public sessions link"
+      },
+      "preferred-contact": {
+        "phone": "Phone",
+        "whatsapp": "WhatsApp",
+        "google-meet": "Google Meet",
+        "zoom": "Zoom",
+        "not-set": "Not set"
+      },
+      "next-session": "Next session",
+      "last-session": "Last completed session",
+      "no-upcoming-session": "No upcoming session scheduled",
+      "no-completed-session": "No completed sessions yet",
+      "no-sessions": "No sessions have been scheduled for this patient yet.",
+      "delivery": {
+        "online": "Online",
+        "in-person": "In person",
+        "not-set": "Delivery mode not set"
+      },
+      "sessions": {
+        "upcoming": "Upcoming",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      }
+    }
+  },
+  "auth": {
+    "error": {
+      "login-failed": "Invalid email or password. Please check your credentials and try again.",
+      "registration-failed": "Unable to complete registration. Please check your information and try again.",
+      "password-reset-request": "If this email is registered, you will receive password reset instructions.",
+      "password-reset-failed": "Unable to reset password. The link may have expired. Please request a new one.",
+      "session-expired": "Your session has expired. Please sign in again.",
+      "rate-limited": "Too many attempts. Please wait a moment before trying again.",
+      "generic": "Something went wrong. Please try again later.",
+      "not-found": "User ID not found",
+      "not-allowed": "You can't delete this account."
+    },
+    "success": {
+      "password-reset-request": "If this email is registered, you will receive password reset instructions shortly.",
+      "password-reset": "Your password has been changed successfully. You can now sign in.",
+      "logout": "You have been signed out successfully."
+    },
+    "continue-google": "Continue with Google",
+    "continue-email": "Continue with email"
+  },
+  "globals": {
+    "email": "Email",
+    "name": "Name",
+    "password": "Password",
+    "phone": "Phone",
+    "whatsapp": "Whatsapp",
+    "address": "Address",
+    "patients": "Patients",
+    "patient": "Patient",
+    "registered-patients": "Registered patients",
+    "patients-manager": "Patients manager",
+    "billing-manager": "Billing manager",
+    "subscription-manager": "Subscription manager",
+    "appointments": "Appointments",
+    "appointments-manager": "Manage your appointments",
+    "change-language": "Change language",
+    "help": "Help center",
+    "logout": "Logout",
+    "plan": "Plan",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "edit": "Edit",
+    "date-time-format": "{{format}}",
+    "time-remaining": {
+      "days": "In {{count}} day(s)",
+      "hours": "In {{count}} hour(s)",
+      "minutes": "In {{count}} minute(s)",
+      "less-than-a-minute": "Session {{status}}"
+    },
+    "in-progress": "In progress",
+    "paused": "Paused",
+    "proceed": "Proceed",
+    "resume": "Resume",
+    "reason": "Reason",
+    "global-reason": "Global reason",
+    "custom-reason": "Describe the reason",
+    "select": "Select",
+    "unselect": "Unselect",
+    "error": {
+      "already-subscribed": "Your email is already subscribed",
+      "internal-server-error": "Something went wrong, please try again later",
+      "invalid-user": "Invalid email or password"
+    },
+    "success": {
+      "subscribed": "You were successfully subscribed. Please check your email!"
+    },
+    "date": "Date",
+    "time": "Time",
+    "at": "at",
+    "date-time": "Date and Time: ",
+    "therapist": "Therapist",
+    "appointment-status": {
+      "booked": "Booked",
+      "available": "Available",
+      "onhold": "on Hold",
+      "blocked": "Blocked",
+      "cancelled": "Cancelled"
+    },
+    "contacts": "Contacts",
+    "starts": "Starts",
+    "ends": "Ends",
+    "time-range": {
+      "time-from-to": "from {{start}} to {{end}}",
+      "time-range-date": "{{date}} from {{start}} to {{end}}",
+      "your-time": "Your local time",
+      "patient-time": "Patient's time",
+      "therapist-time": "Therapist's time"
+    },
+    "notification": {
+      "email": "Send email",
+      "phone": "Call patient",
+      "whatsapp": "Send WhatsApp message"
+    },
+    "cancellation-title": "Please choose the reason you are cancelling your appointment",
+    "cancellation-reason": {
+      "1": "Emergency (Personal/Health Issue)",
+      "2": "Schedule Conflict",
+      "3": "Financial Issues",
+      "4": "Mental Issues",
+      "5": "No-Show",
+      "6": "Other",
+      "7": "Other"
+    },
+    "cancellation-other-title": "Please specify the reason",
+    "status": "Status",
+    "close": "Close",
+    "read-only": "Read-only",
+    "auth-method": "Auth method",
+    "privacy-policy": "Privacy Policy",
+    "terms-of-service": "Terms of Use",
+    "privacy": "Privacy",
+    "previous": "Previous",
+    "next": "Next"
+  },
+  "components": {
+    "form": {
+      "confirm-password": "Confirm password",
+      "keep-loggedin": "Keep me logged in",
+      "not-valid": "Some fields are missing",
+      "signup": {
+        "sign-up": "Sign up",
+        "title-email": "Create your account",
+        "title": "Create your Psycron account",
+        "first-name": "First name",
+        "last-name": "Last name",
+        "already-have-acc": "Already have an account?",
+        "signin-here-link": "Sign in here"
+      },
+      "signin": {
+        "sign-in": "Sign in",
+        "title": "Welcome back",
+        "dont-have-acc": "Don't have an account?",
+        "signup-here-link": "Sign up here",
+        "forgot-password": "Forgot your password?"
+      },
+      "validation": {
+        "required": "{{name}} is required",
+        "invalid": "{{name}} is invalid",
+        "characters": "Password must be at least {{numChar}} characters",
+        "pass-rules": "Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character",
+        "at-least-one-contact": "Please provide an email or phone number",
+        "match": "{{name}} must match"
+      },
+      "address-form": {
+        "search": "Search the address here",
+        "search-note": "You can start searching for the address, or type it in the below fields.",
+        "street": "Street",
+        "number": "Nº",
+        "hood": "Neighbourhood",
+        "more-info": "Complementary info",
+        "city": "City",
+        "state": "State / Province",
+        "zip": "Zip Code",
+        "country": "Country",
+        "more-info-bttn": "Add more info"
+      },
+      "add-patient": {
+        "name": "Add patient"
+      },
+      "contacts-form": {
+        "contact-via": "Contact via {{method}}?",
+        "contact-via-same": "Is phone number the same as whatsapp?"
+      },
+      "preferred-contact": {
+        "coming-soon": "Integration coming soon — paste your meeting link for now",
+        "label": "Preferred session platform",
+        "value-phone": "Phone number",
+        "value-url": "Meeting link (URL)",
+        "type": {
+          "google_meet": "Google Meet",
+          "phone": "Phone call",
+          "whatsapp": "WhatsApp",
+          "zoom": "Zoom"
+        }
+      },
+      "consent": {
+        "terms": "I agree to the <privacyLink>Privacy Policy</privacyLink> and <termsLink>Terms of Use.</termsLink>",
+        "marketing": "I consent to receive <marketingLink>marketing communications.</marketingLink>",
+        "info": "By continuing, you agree to Psycron's <privacyLink>Privacy Policy</privacyLink> and <termsLink>Terms of Use.</termsLink>"
+      }
+    },
+    "input": {
+      "phone-input": {
+        "select-label": "Country",
+        "phone-num-label": "{{registerName}} number here",
+        "phone-number-guide": "Please provide a phone number including the city code if applicable.",
+        "invalid": "Invalid phone number",
+        "valid": "Valid phone number"
+      },
+      "text": {
+        "first-name": "Your first name here",
+        "last-name": "Your last name here",
+        "email": "Your email here"
+      }
+    },
+    "navbar": {
+      "action-center": "Action center",
+      "dashboard": "Dashboard",
+      "conflicts": "Conflicts",
+      "notifications": "Notifications",
+      "user-settings": "User settings",
+      "test": "Tests"
+    },
+    "user-details": {
+      "edit": "Edit details",
+      "edit-contacts": "Edit contacts",
+      "edit-success": "Details updated",
+      "add-contacts": "Add your {{contactValue}} number",
+      "change": "Change {{name}}",
+      "save": "Save details",
+      "address-not-found": "Address not found. Please add your info.",
+      "detail-not-found": "{{detail}} is not registered yet",
+      "no-changes": "Select a section to edit before saving.",
+      "delete": {
+        "title": "Delete account",
+        "description": "Your account will be deactivated and your personal data anonymised within 30 days. You can contact support to cancel this request.",
+        "confirmation": "Delete permanently"
+      },
+      "section": {
+        "title": {
+          "account": "Account",
+          "clinic": "Clinic Address",
+          "contact": "Contact",
+          "patients": "Patients",
+          "security": "Security & Privacy",
+          "subscription": "Subscription"
+        },
+        "local": "Email & Password",
+        "security": {
+          "google-mgmt": "Managed by Google - Your password is securely handled through Google's authentication system.",
+          "accepted": "By creating your Psycron account, you agreed to our <privacyLink>Privacy Policy</privacyLink> and <termsLink>Terms of Use.</termsLink>",
+          "accepted-info": "You can review these documents at any time.",
+          "marketing": "Receive marketing communications"
+        },
+        "clinic": {
+          "add-address": "Add clinic address",
+          "address-label": "Address",
+          "edit-address": "Edit address",
+          "title-empty": "Add your clinic address so patients can receive it in their booking confirmation."
+        },
+        "contact": {
+          "title-empty": "Add your phone number to enable SMS or WhatsApp notifications."
+        }
+      }
+    },
+    "dashboard": {
+      "card": {
+        "delay-notification": "Pausing the timer will delay all your remaining appointments for today by the duration of this pause.",
+        "delay-confirmation": "Are you sure you want to pause the timer?",
+        "pause": "Sause timer",
+        "session-progress": "Session progress:"
+      },
+      "availability-card": {
+        "first-availability": "Please create your first availability here"
+      }
+    },
+    "appointments": {
+      "card-title": "Appointments of the day",
+      "manager": "Appointments manager"
+    },
+    "patients-table": {
+      "name": "Patient name",
+      "next-session": "Next session",
+      "payment-status": "Payment status",
+      "sessions-month": "Sessions per Month",
+      "value": "Value per session",
+      "discount": "Discount?",
+      "discount-val": "Discount value",
+      "amount": "Full amount",
+      "currency": "Currency",
+      "latest-payment": "Latest payment",
+      "manage": "Manage patient"
+    },
+    "progress": {
+      "received": "You have already received {{progress}}% of your payments 🥳",
+      "missing": "You are missing {{progress}}% of your payments",
+      "not-received": "You haven't received any payments yet",
+      "received-all": "You have received 100% of your payments for this period 🥳 😎"
+    },
+    "c2-action": {
+      "join-waitlist": "Join our <strong>waitlist</strong> today to streamline your therapy practice and focus more on your patients.",
+      "email": "Your email",
+      "join-now": "Join now"
+    },
+    "hero": {
+      "heading": "Revolutionize your therapy practice with a seamless all-in-one solution",
+      "helper": "Easily manage your appointments, payments, patient records, billing, and more."
+    },
+    "header": {
+      "join": "Join now",
+      "benefits": "Benefits",
+      "contact": "Contact",
+      "language": "Language"
+    },
+    "link": {
+      "navigate": {
+        "back": "Back",
+        "next": "Proceed",
+        "finish": "Finish",
+        "confirm": "Confirm",
+        "cancel": "Cancel"
+      }
+    },
+    "footer": {
+      "contact": "Would you like to get in touch? <a>Find us here</a>",
+      "find-me": "Find us here",
+      "credit": {
+        "illustration": "Illustrations by <owner>Icons 8</owner> from <page>Ouch!</page>"
+      }
+    },
+    "share-button": {
+      "alert": {
+        "success": "Shared successfully!",
+        "success-copy": "Link copied successfully!",
+        "error": "Someting went wrong, please try again later.",
+        "error-copy": "We couldn't copy the link, please try again later."
+      },
+      "tooltip-tile": "Share with {{with}}",
+      "share-with-name": "with {{name}}",
+      "share-with-patients": "with your patients",
+      "share-infos": {
+        "availability": {
+          "title": "{{therapistName}} shared with you their availability",
+          "text": "Enter here to book an appointment"
+        }
+      }
+    },
+    "agenda": {
+      "modal": "You are booking for {{appointment}}",
+      "your-details": "Your details",
+      "next-week": "Next week",
+      "previous-week": "Previous week",
+      "today": "Today",
+      "month": "Month",
+      "appointment-details": {
+        "title": "Appointment Details",
+        "mailto-subject": "🔔 About your appointment with {{therapistName}} 🔔",
+        "whatsapp-subject": "Hello, how is it going? I am sending this message regarding your appointment with me, {{therapistName}}",
+        "next-sessions": "Other appointments",
+        "edit-patient-details": "Edit Patient Details",
+        "edit-patient-appointment": "Edit appointment",
+        "edit-availability": "Edit availability",
+        "text-status": "This is slot is {{status}}"
+      },
+      "edit-appointment": {
+        "title": "Edit appointment",
+        "confirmation": "Are you sure you want to reschedule this appointment?"
+      },
+      "cancel-appointment": {
+        "title": "Cancel appointment(s)",
+        "select-all": "{{select}} All",
+        "global-reason": "Please, select a global reason:",
+        "confirmation": "Are you sure you want to cancel all appointments?",
+        "review": "Review the dates you selected"
+      },
+      "book-appointment": {
+        "title": "Booking your appointment"
+      }
+    }
+  },
+  "page": {
+    "landing": {
+      "seo": {
+        "title": "Psycron - Innovative Therapist Management App",
+        "description": "Revolutionize your therapy practice with a seamless all-in-one solution. With our app you can easily manage your appointments, payments, patient records, billing, and more.",
+        "ogTitle": "Psycron - Innovative Therapist Management App",
+        "ogDescription": "Revolutionize your therapy practice with a seamless all-in-one solution. With our app you can easily manage your appointments, payments, patient records, billing, and more."
+      },
+      "values": {
+        "all-in-one": "All-in-one solution",
+        "text": "From scheduling appointments to processing payments, maintaining patient records, and handling billing, we help you with your daily tasks, and you will have much more time to take care of your patients. Our solution can transform your practice management, integrating everything into a single, intuitive platform.",
+        "text-focus": "Now you can focus on what truly matters and let us handle the rest for you."
+      },
+      "benefits": {
+        "increased-efficiency": {
+          "name": "Increased Efficiency",
+          "description": "Spend less time on admin tasks. Automate reminders, schedule appointments, and manage patient records seamlessly. Focus more on your patients, not paperwork"
+        },
+        "better-patient-management": {
+          "name": "Better Patient Management",
+          "description": "Easily track patient history and appointments. Enhance care with organized, up-to-date records."
+        },
+        "reduced-administrative-burden": {
+          "name": "Reduced Administrative Burden",
+          "description": "We simplified your workflow"
+        },
+        "enhanced-financial-control": {
+          "name": "Enhanced Financial Control",
+          "description": "Take control of your finances with secure and efficient billing"
+        }
+      },
+      "ct-action": {
+        "heading": "Ready to revolutionize your practice?",
+        "join-waitlist": "<strong>Join our waitlist</strong> today and <strong>be the first</strong> to <strong>experience</strong> <strong>cutting-edge</strong> therapy practice management. <strong>Unlock</strong> <strong>new levels</strong> of <strong>efficiency</strong> and <strong>patient care</strong> with <strong>a product made for you</strong>."
+      }
+    },
+    "not-found": {
+      "title": "Oops, something went wrong!",
+      "sub-title": "But we promise we are working hard to fix it!",
+      "note": "Yes... both of us :)"
+    },
+    "unsubscribe": {
+      "title": "Goodbye for now, {{email}}!",
+      "body-text": "Thank you for being a part of our journey. While we’re sad to see you go, we completely understand your decision. We’ll keep working hard to bring you the best we’ve got, and just know, you’re always welcome back whenever you’re ready.",
+      "see-you": "Hope to see you again soon! ❤️",
+      "confirm": "Click here to complete and unsubscribe"
+    },
+    "reset-password": {
+      "reset": "Reset password",
+      "change-password": "Change password",
+      "password-rule": "Your password must contain at least:",
+      "password-example": "Example:",
+      "item-letter": "One letter {{rule}}",
+      "item-number": "One number {{rule}}",
+      "item-special": "One special character {{rule}}",
+      "item-minimum": "9 characters long",
+      "current-password": "Current password"
+    },
+    "availability": {
+      "wizard": {
+        "wizard-items": {
+          "intro": {
+            "label": "Intro",
+            "title": "Let's setup your availability. Are you ready?",
+            "alert": "You will need to finish your availability setup later"
+          },
+          "weekdays": {
+            "label": "Choose weekdays",
+            "title": "Tell us the days you usually see patients."
+          },
+          "duration": {
+            "label": "Appointment duration",
+            "title": "Let us know how long your sessions are."
+          },
+          "week-slots": {
+            "label": "Weekly time slots"
+          }
+        },
+        "intro": {
+          "options": {
+            "proceed": "Yes!",
+            "finish-later": "Set availability later"
+          }
+        },
+        "availability-days": {
+          "days": {
+            "mon": "Monday",
+            "tue": "Tuesday",
+            "wed": "Wednesday",
+            "thu": "Thursday",
+            "fri": "Friday"
+          },
+          "options": {
+            "all": "Include all days",
+            "weekends": "Don't include weekends",
+            "specific": "Select specific days"
+          }
+        },
+        "duration": {
+          "label": "Appointment duration",
+          "note": "If you have more than one type of appointment, please let us know the duration you use most often. You will be able to change this in the future without any issues!"
+        },
+        "hours": {
+          "no-session": "No session was found"
+        },
+        "modal-title": "Repeat your weekly availability",
+        "modal-info": "Please choose one of the options below. If you pick 'weekly,' your availability will be repeated until the end of the month. If you pick 'monthly,' it will be repeated until the end of the year.",
+        "complete": "Availability created with success"
+      },
+      "agenda": {
+        "status": {
+          "available": "Available",
+          "unavailable": "Unavailable",
+          "booked": "Booked",
+          "empty": "Empty",
+          "blocked": "Blocked",
+          "cancelled": "Cancelled",
+          "onhold": "On hold"
+        },
+        "therapist-edit-modal": {
+          "title": "Edit your availability"
+        }
+      }
+    },
+    "book-appointment": {
+      "title": "{{therapisName}}'s Open Appointments",
+      "description": "Quickly schedule your therapy session. Check available times and choose the best slot to book your appointment easily and conveniently.",
+      "confirmation-should-replicate": "Would you like to set this day as your default choice for future appointments?",
+      "recurrence-pattern": {
+        "month": "Weekly until month ends",
+        "year": "Weekly until year ends",
+        "single": "Only this appointment",
+        "all-future": "All future appointments"
+      },
+      "confirm-edit": "Please confirm that you want to change your appointment from {{previousDate}} to:",
+      "edit-recurrence-title": "Do you want to update only this appointment or all future appointments?",
+      "edit-appointment-title": "You are editing your appointment on {{formattedDate}} at {{startTime}}."
+    },
+    "booking-confirmation": {
+      "title": "Your Appointment with <strong>{{therapistName}}</strong> is confirmed 🎉",
+      "title-plain": "Your Appointment with {{therapistName}} is confirmed 🎉",
+      "subtitle": "We're excited to see you soon!",
+      "whats-next": "<strong>{{therapistName}}</strong> will reach out with additional details as the appointment date approaches.",
+      "advise": "Please be available a few minutes early.",
+      "reschedule": "You can reschedule your appointment up to 1 day before the session.",
+      "cancel": "To reschedule or cancel , please <strong>click here</strong>",
+      "help": "If you have any questions or need assistance, feel free to contact us at",
+      "thanks": "Thank you! We’re here to support you. Looking forward to your session!",
+      "cancel-or-edit": {
+        "title": "Need to make changes?",
+        "sub": "You can either reschedule or cancel your appointment here.",
+        "appointment-info": "Your appointment on {{date}} at {{startTime}}",
+        "donwload-ics": "Add to calendar 📅"
+      },
+      "no-appointments-title": "You dont have any appointments yet",
+      "no-appointments-link": "Click here to start booking an appointment"
+    },
+    "appointment-list": {
+      "date": "Date",
+      "starts": "Starts at",
+      "ends": "Ends at",
+      "modal": {
+        "title": "Are you sure you want to {{action}} this appointment"
+      },
+      "description": "Here you can set up your availability for appointments and share it with your patients. We will guide you through a simple process to define your available times, which will be replicated across the weeks or until the end of the year. The process is flexible, and you will be able to adjust the information at any time in the future.",
+      "guide": {
+        "step1": {
+          "title": "Decide if you want to start now or later",
+          "description": "If you prefer, you can return to this step later. We understand that it’s not always possible to set everything up immediately, so you will have the option to resume the process at a more convenient time."
+        },
+        "step2": {
+          "title": "Set your off days",
+          "description": "Let us know which days of the week you will not be available for appointments. These days will be blocked, but you can change them in the future, if necessary."
+        },
+        "step3": {
+          "title": "Session duration",
+          "description": "Provide the average duration of your appointments. If you offer more than one type of session, we will set a default now, and you can adjust the times later according to the patient and type of therapy."
+        },
+        "step4": {
+          "title": "Choose your available times",
+          "description": "In a visual and interactive way, you can select the times you will be available for appointments throughout the week. It’s a flexible process: if your preferences change, you can adjust your schedule at any time."
+        }
+      },
+      "session-past": "Past session"
+    },
+    "cancel-appointment": {
+      "title": "Cancel Appointment(s)",
+      "sub-title": "Please select the appointment(s) you want to cancel"
+    },
+    "edit-appointment": {
+      "title": "Edit Appointment",
+      "sub-title": "Please select the new date slot"
+    },
+    "add-patient": {
+      "title": "Add a New Patient",
+      "sub-title": "Fill out the form below with the patient’s details"
+    },
+    "dashboard": {
+      "title": "Dashboard",
+      "greeting": {
+        "headline": "Hello, {{name}}!",
+        "band": {
+          "morning": "Good morning",
+          "afternoon": "Good afternoon",
+          "evening": "Good evening"
+        }
+      },
+      "tiles": {
+        "action-center": "Action center",
+        "schedule": "Today's schedule",
+        "greeting": "Greeting",
+        "jupiter-insights": "Júpiter insights",
+        "notifications": "Notifications",
+        "quick-actions": "Quick actions",
+        "active-patients": "Active patients",
+        "billing-readiness": "Billing readiness",
+        "revenue": "Revenue estimate",
+        "session-analytics": "Session Analytics",
+        "pending-tasks": "Pending tasks",
+        "recent-patients": "Recent patients"
+      },
+      "tile": {
+        "close": "Close",
+        "hide": "Hide tile",
+        "layout-column": "Use column layout",
+        "layout-column-aria": "Switch tile to column layout",
+        "layout-row": "Use row layout",
+        "layout-row-aria": "Switch tile to row layout",
+        "read-more": "Read more",
+        "resize-down": "Reduce height",
+        "resize-down-aria": "Reduce tile height",
+        "resize-narrow": "Narrow",
+        "resize-narrow-aria": "Make tile narrower",
+        "resize-up": "Increase height",
+        "resize-up-aria": "Increase tile height",
+        "resize-wide": "Widen",
+        "resize-wide-aria": "Make tile wider",
+        "show": "Show tile",
+        "drag": "Drag to reorder",
+        "drag-aria": "Drag tile to reorder"
+      },
+      "customize": {
+        "open": "Customize",
+        "done": "Done",
+        "hint": "Drag tiles to reorder · click the eye icon to hide",
+        "organize": "Organize",
+        "reset": "Reset layout"
+      },
+      "widgets": {
+        "schedule": {
+          "title": "Today",
+          "title-week": "Week",
+          "title-label": "Today's schedule",
+          "title-week-label": "This week's schedule",
+          "range-aria-label": "Choose schedule range",
+          "count": "{{count}} sessions",
+          "empty": "No sessions scheduled for today",
+          "unknown-patient": "Unknown patient",
+          "sessions-today": "sessions today",
+          "sessions-week": "sessions this week",
+          "view-week": "View week",
+          "online": "Online",
+          "in-person": "In-person",
+          "min": "min",
+          "status": {
+            "live": "LIVE",
+            "done": "Done",
+            "confirmed": "Confirmed",
+            "pending": "Pending"
+          },
+          "info": {
+            "title": "Today's schedule",
+            "description": "Shows your booked sessions for today and this week, with live status tracking so you always know what's coming next.",
+            "future": "We'll surface prep notes per patient, smart conflict alerts, and one-tap rescheduling suggestions."
+          }
+        },
+        "jupiter-insights": {
+          "aria-label": "Júpiter AI insights carousel",
+          "dismiss": "Dismiss insight",
+          "empty": "No insights available at the moment",
+          "action-availability": "View availability",
+          "title-schedule": "Today's sessions",
+          "text-schedule": "You have {{count}} booked session(s) today. Keep it up!",
+          "title-patients": "Active patients",
+          "text-patients": "You currently have {{count}} active patient(s) on your roster.",
+          "subtitle": "AI co-pilot · learning your patterns",
+          "default-category": "Patient Care",
+          "category-daily-briefing": "Daily briefing",
+          "category-operations": "Operations",
+          "category-patient-care": "Patient Care",
+          "category-insights": "Insights",
+          "action-send-message": "Send message",
+          "action-view-profile": "View profile",
+          "mic": "Voice input",
+          "text-setup-availability": "Set up your schedule with Júpiter to start accepting bookings.",
+          "action-setup-availability": "Set up now",
+          "text-no-patients-yet": "You're all set — share your booking link with your first patients.",
+          "category-setup": "Setup",
+          "category-growth": "Growth",
+          "category-schedule": "Schedule",
+          "text-session-none-today": "No sessions today — a good time to catch up on notes.",
+          "text-session-count-today": "You have {{count}} session(s) today. Keep it up!",
+          "text-whatsapp-reminders": "Enable WhatsApp reminders to reduce no-shows in a few taps.",
+          "action-set-up-reminders": "Set up reminders",
+          "text-busy-day": "{{day}} looks like your busiest day this week. Keep that momentum!",
+          "action-view-schedule": "View schedule",
+          "text-week-cancellations": "{{count}} session(s) were cancelled this week. Consider reaching out to reschedule.",
+          "text-patient-milestone": "You've reached {{count}} active patients. Great milestone!",
+          "text-low-week-volume": "You have {{count}} session(s) this week. Opening more slots could help you grow.",
+          "text-billing-readiness-incomplete": "{{missing}} patient(s) still need session-cost details before future payment tools can fit your workflow.",
+          "text-billing-readiness-ready": "Your patient billing details are ready for future payment and invoicing flows.",
+          "action-review-patients": "Review patients",
+          "action-view-patients": "View patients",
+          "text-session-none-today-week": "No sessions today — you have {{count}} coming up this week. Check your schedule.",
+          "text-missed-rebooking": "{{name}} missed their last session and hasn't rebooked. A check-in might help.",
+          "text-dashboard-summary-fallback": "Júpiter is reading your dashboard. You have {{count}} session(s) booked this week.",
+          "info": {
+            "title": "Júpiter insights",
+            "description": "AI-generated observations about your practice based on your schedule, patients, and billing — personalised every session.",
+            "future": "Predictive scheduling recommendations, patient risk flags, and proactive clinical guidance tailored to your specialty."
+          }
+        },
+        "quick-actions": {
+          "title": "Quick Actions",
+          "descriptions": {
+            "add-patient": "Start a patient profile",
+            "availability-settings": "Working hours, time zone",
+            "fix-reminders-count": "{{count}} failed or queued",
+            "fix-reminders-setup": "Reminder settings",
+            "follow-up-cancellations": "{{count}} recovery item(s)",
+            "patients": "{{count}} active",
+            "setup-availability": "Create working hours",
+            "view-week": "{{count}} sessions"
+          },
+          "actions": {
+            "new-session": "New session",
+            "new-session-aria": "Open availability to book new session",
+            "patients": "My patients",
+            "patients-aria": "Navigate to patients list",
+            "add-patient": "Add patient",
+            "add-patient-aria": "Add a new patient",
+            "fix-reminders": "Fix reminders",
+            "follow-up-cancellations": "Follow up cancellations",
+            "notifications": "Notifications",
+            "notifications-aria": "View notifications",
+            "setup-availability": "Set up schedule",
+            "view-week": "View week",
+            "availability-settings": "Availability settings"
+          },
+          "info": {
+            "title": "Quick actions",
+            "description": "Shortcuts to the most relevant actions based on your current practice state. Psycron picks what matters most right now.",
+            "future": "Fully contextual action suggestions powered by Júpiter that adapt to your week, your patients, and your habits."
+          }
+        },
+        "active-patients": {
+          "label": "Active patients",
+          "title": "Latest patients",
+          "empty": "No patients added yet"
+        },
+        "billing-readiness": {
+          "label": "Billing readiness",
+          "status": {
+            "empty": "Prepare for future payment tools by adding patients first.",
+            "partial": "{{configured}} of {{total}} patients ready for future payments · {{missing}} to finish",
+            "ready": "Future payment setup is ready"
+          },
+          "details": "Add each patient's session cost now so Psycron can design payment and invoicing flows that match how your practice already works.",
+          "donut-meta": "{{configured}}/{{total}} ready",
+          "status-chip": {
+            "empty": "Action needed",
+            "partial": "In progress",
+            "ready": "Ready"
+          },
+          "teaser": {
+            "title": "Prepare for future payments",
+            "subtitle": "Track session costs now so future payment tools can fit your workflow from day one.",
+            "coming-soon": "Payment collection and invoicing will come later; this step only keeps your patient billing details ready."
+          },
+          "info": {
+            "title": "Billing readiness",
+            "description": "Add each patient's session cost now so Psycron can design payment and invoicing flows that match how your practice already works.",
+            "future": "Next, Psycron will move into payments by creating an automated payment system tailored to how you charge each patient."
+          }
+        },
+        "revenue": {
+          "title": "Revenue",
+          "title-with-month": "Revenue · {{month}}",
+          "estimate-chip": "Est.",
+          "completed": "Completed",
+          "configured": "Billing setup",
+          "sessions": "{{count}} session(s)",
+          "patients-ready": "{{configured}} ready · {{missing}} missing",
+          "info": {
+            "title": "Revenue estimate",
+            "description": "Estimates your monthly earnings based on the billing configurations you've set for active patients. Updated in real time.",
+            "future": "Psycron will use these revenue patterns to create an automated payment system tailored to your practice, with invoicing, collection, and payment tracking built around your workflow."
+          }
+        },
+        "notifications": {
+          "title": "Notifications · 24h",
+          "window": "Last 24h",
+          "sent": "Sent",
+          "failed": "Failed",
+          "queued": "Queued",
+          "view-feed": "View feed",
+          "info": {
+            "title": "Notifications",
+            "description": "Shows how many appointment reminders and confirmations were delivered to your patients in the last 24 hours.",
+            "future": "Channel performance over time, intelligent retry logic, and delivery failure alerts before patients miss sessions."
+          }
+        },
+        "action-center": {
+          "title": "Action center",
+          "count-chip": "{{count}} needs you",
+          "count-chip_other": "{{count}} need you",
+          "empty": "No operational alerts right now.",
+          "item-count": "{{count}} item(s)",
+          "summary-title": "{{count}} item needs attention",
+          "summary-title_other": "{{count}} items need attention",
+          "summary-body": "A quiet summary of unresolved operational work. Actions stay in the dedicated workspace.",
+          "breakdown-label": "Action center summary",
+          "view-all": "Open action center",
+          "view-all-meta": "Conflicts and recovery queue",
+          "items": {
+            "notification-failed": "Notification failed",
+            "patient-duplicate": "Patient duplicate",
+            "recovery-needed": "Recovery needed",
+            "schedule-conflict": "Schedule conflict"
+          },
+          "info": {
+            "title": "Action center",
+            "description": "Flags issues that require resolution — scheduling conflicts, failed notification deliveries, and cancellations awaiting follow-up.",
+            "future": "Automated conflict resolution proposals, one-click recovery workflows, and priority-ranked issue queues."
+          }
+        },
+        "session-analytics": {
+          "title": "Session Analytics",
+          "range-aria-label": "Choose analytics range",
+          "completion-rate": "Completion rate",
+          "blocked": "Admin blocks",
+          "blocked-hours": "{{hours}}h blocked",
+          "cancelled": "Cancelled",
+          "chart-aria-label": "Stacked bar chart showing sessions by day",
+          "completed": "Completed",
+          "insight-down": "Completion rate down {{delta}}% vs last {{period}} — cancellations need attention.",
+          "insight-empty": "No concluded sessions yet — comparison starts once data arrives.",
+          "insight-flat": "Completion rate steady vs last {{period}} — keep the reminder rhythm.",
+          "insight-source": "Júpiter",
+          "insight-summary": "{{completed}} of {{concluded}} concluded sessions completed.",
+          "insight-up": "Completion rate up {{delta}}% vs last {{period}} — reminders are working.",
+          "legend": {
+            "blocked": "Admin blocks",
+            "cancelled": "Cancelled",
+            "completed": "Completed",
+            "upcoming": "Upcoming"
+          },
+          "period": {
+            "month": "month",
+            "week": "week"
+          },
+          "sessions": "sessions",
+          "upcoming": "Upcoming",
+          "view-month": "Month",
+          "view-week": "Week",
+          "info": {
+            "title": "Session analytics",
+            "description": "Tracks your session completion rate, cancellations, and session volume over time — your practice health at a glance.",
+            "future": "Trend analysis, no-show prediction, and session pace benchmarks compared to similar practices."
+          }
+        },
+        "pending-tasks": {
+          "title": "Pending Tasks",
+          "cancellation-followups": "Cancellation follow-ups",
+          "descriptions": {
+            "cancellation-followups": "{{count}} need recovery",
+            "missing-billing": "{{count}} patient(s) to configure",
+            "missing-contact": "{{count}} patient(s) to update",
+            "reminder-delivery": "{{count}} need review",
+            "setup-availability": "Required before bookings"
+          },
+          "empty": "Nothing requires your attention right now.",
+          "missing-billing": "Patients missing billing",
+          "missing-contact": "Patients missing contact info",
+          "reminder-delivery": "Reminder delivery issues",
+          "setup-availability": "Finish schedule setup",
+          "empty-heading": "All clear",
+          "info": {
+            "title": "Pending tasks",
+            "description": "Surfaces admin items that need your attention to keep your practice running smoothly — from missing billing to unresolved cancellations.",
+            "future": "Priority scoring, task delegation for group practices, and completion streaks to keep your admin momentum."
+          }
+        },
+        "recent-patients": {
+          "title": "Recent Patients",
+          "activity": {
+            "cancelled": "Cancelled session",
+            "created": "Added",
+            "session": "Session activity",
+            "updated": "Updated"
+          },
+          "empty": "Recent patient activity will appear here.",
+          "view-all": "All",
+          "last-note": "last note",
+          "message-aria": "Send message to {{name}}",
+          "info": {
+            "title": "Recent patients",
+            "description": "Highlights the patients with the most recent activity in your caseload, so you can quickly pick up where you left off.",
+            "future": "Patient engagement scores, session frequency heatmaps, and proactive care alerts when a patient goes quiet."
+          }
+        },
+        "latest-patients": {
+          "info": {
+            "title": "Latest patients",
+            "description": "Shows the most recently added patients so you never lose track of new intakes and can start onboarding them right away.",
+            "future": "Automated onboarding checklists, intake form integration, and personalised welcome message templates."
+          }
+        },
+        "info-modal": {
+          "feedback-error": "We couldn't save this feedback. Please try again.",
+          "feedback-placeholder": "Share your thoughts on this widget...",
+          "feedback-submit": "Send feedback",
+          "feedback-thanks": "Thanks! Your input helps shape Psycron.",
+          "future-heading": "What's coming",
+          "tooltip": "About this widget"
+        }
+      }
+    },
+    "unsubscribe-preferences": {
+      "title": "Manage email preferences",
+      "description": "Enter your email address below to unsubscribe from Psycron marketing and waitlist communications.",
+      "disclaimer": "Note: transactional emails — such as appointment confirmations, account notifications, and security alerts — are required and cannot be unsubscribed from.",
+      "email-label": "Your email address",
+      "email-placeholder": "you@example.com",
+      "submit": "Unsubscribe",
+      "success-title": "You have been unsubscribed",
+      "success-description": "If this email was on our list, it has been removed. You will no longer receive marketing emails from Psycron.",
+      "back-home": "Back to homepage"
+    }
+  },
+  "chat": {
+    "greeting": "Hi! I’m Júpiter, your assistant to help set up your appointment schedule. Let’s build it together, step by step 🧘‍♀️! Shall we?",
+    "let-start": "What types of therapy do you offer?",
+    "system-instruction": "You are a kind assistant helping therapists build their schedule, step by step. Always respond with the next question and any information extracted so far. For example, if the question is regarding the reccurencePattern, you should explain that weekly it’s until the current month, and monthly is until the current year",
+    "error": "Oops! We couldn’t proceed  with your chat, please try again later"
+  },
+  "jupiter": {
+    "welcome": {
+      "title-line1": "I am Jupiter,",
+      "title-line2": "your Smart Assistant",
+      "subtitle": "I’ll help you set up your availability in just a few moments. Let’s make scheduling feel effortless.",
+      "cta": "Set up my schedule"
+    },
+    "specialty": {
+      "response": "What do you practice? Use the professional name for your work.",
+      "chip-occupational-therapist": "Occupational Therapist",
+      "chip-nutritionist": "Nutritionist",
+      "chip-other": "Other",
+      "chip-physiotherapist": "Physiotherapist",
+      "chip-psychiatrist": "Psychiatrist",
+      "chip-psychologist": "Psychologist",
+      "chip-speech-therapist": "Speech Therapist",
+      "continue": "Continue",
+      "other-placeholder": "Your specialty or professional title",
+      "acknowledged": "Got it! I'll set things up with that in mind.",
+      "error-rephrase": "I couldn't quite catch that — try using the professional name for what you practice.",
+      "error-rejected": "I'm not able to set up scheduling for that. If you have another specialty, I'd love to help you get started."
+    },
+    "calendar-choice": {
+      "msg1": "Hi! I’m Júpiter, your scheduling assistant. I’m here to help you set up your availability in a way that feels natural and effortless.",
+      "msg2": "Let’s start by setting up your calendar. How would you like to begin?",
+      "chip-google": "Connect Google Calendar",
+      "chip-manual": "Create manually",
+      "google-already-connected": "Your Google Calendar is already connected! Would you like to import your schedule from it?"
+    },
+    "working-days": {
+      "response": "Great! Which days do you usually work with your clients?",
+      "chip-mon": "Mon",
+      "chip-tue": "Tue",
+      "chip-wed": "Wed",
+      "chip-thu": "Thu",
+      "chip-fri": "Fri",
+      "chip-sat": "Sat",
+      "chip-sun": "Sun",
+      "back": "← Back",
+      "continue": "Continue",
+      "other-placeholder": "Or type your schedule..."
+    },
+    "time-range": {
+      "response": "Perfect! What time range works best for you on those days?",
+      "chip-1": "9:00 AM – 5:00 PM",
+      "chip-2": "10:00 AM – 6:00 PM",
+      "chip-3": "12:00 PM – 8:00 PM",
+      "chip-custom": "Custom",
+      "other-placeholder": "e.g. 8:30 AM – 4:00 PM"
+    },
+    "session-duration": {
+      "response": "How long is a typical session? You can always edit this later.",
+      "chip-45": "45 min",
+      "chip-60": "60 min",
+      "chip-custom": "Custom",
+      "other-placeholder": "e.g. 90 minutes"
+    },
+    "session-type": {
+      "response": "How do you usually conduct your sessions?",
+      "response-with-suggestion": "How do you usually conduct your sessions? I have a suggestion based on your specialty — pick what works best for you.",
+      "chip-online": "Online only",
+      "chip-in-person": "In person only",
+      "chip-both": "Both online and in person"
+    },
+    "timezone": {
+      "response": "Almost there! I’ll use your device’s timezone to schedule appointments accurately. This helps ensure your clients book at the right time for you. Sound good?",
+      "chip-yes": "Yes",
+      "chip-no": "No",
+      "follow-up": "No problem! Please select your timezone:",
+      "search-placeholder": "Search timezone..."
+    },
+    "recurrence-pattern": {
+      "response": "One last thing — how often would you like your availability to repeat?",
+      "chip-weekly": "Weekly (until end of month)",
+      "chip-monthly": "Monthly (until end of year)",
+      "summary-weekly": "Got it! Your slots will repeat every week until the end of this month. You can always extend from your dashboard.",
+      "summary-monthly": "Perfect! Your availability will repeat monthly until the end of the year — giving you full-year scheduling coverage.",
+      "value-weekly": "Weekly (until end of month)",
+      "value-monthly": "Monthly (until end of year)"
+    },
+    "preview": {
+      "title": "Your Availability Preview",
+      "label-days": "Working days:",
+      "label-hours": "Hours:",
+      "label-duration": "Duration:",
+      "label-recurrence": "Repeat:",
+      "label-session-type": "Session type:",
+      "label-timezone": "Timezone:",
+      "footer": "You can edit your availability anytime from your dashboard.",
+      "cta": "Publish Availability",
+      "loading": "Publishing...",
+      "reset": "Start over"
+    },
+    "post-publish": {
+      "page-title": "Availability",
+      "page-subtitle": "Manage your availability and scheduling preferences",
+      "success-toast": "Your availability is now live. Clients can start booking sessions with you right away.",
+      "welcome-toast": "Welcome to Psycron!",
+      "tip-title": "Jupiter’s tip",
+      "tip-text": "Your availability looks great. Adding a cancellation policy helps reduce no-shows and sets clear expectations with clients.",
+      "tip-cta": "Set cancellation policy",
+      "status-active-hours": "Active hours",
+      "status-bookings": "Upcoming bookings",
+      "status-this-week": "This week",
+      "status-booked-label": "{{percent}}% Booked",
+      "checklist-title": "Complete your availability",
+      "checklist-subtitle": "Enhance your scheduling setup for a better experience",
+      "checklist-session-types": "Define session types",
+      "checklist-session-types-desc": "Create different appointment types and durations",
+      "checklist-price": "Add session price",
+      "checklist-price-desc": "Set your consultation rates and payment terms",
+      "checklist-price-badge": "Recommended",
+      "checklist-buffer": "Add buffer time",
+      "checklist-buffer-desc": "Set time between appointments for preparation",
+      "checklist-cancel-policy": "Configure cancellation policy",
+      "checklist-cancel-desc": "Define how clients can cancel or reschedule",
+      "checklist-calendar-sync": "Sync with your existing calendar",
+      "checklist-calendar-desc": "Connect your calendar to prevent conflicts",
+      "checklist-recurrence": "Set recurrence style",
+      "checklist-recurrence-desc": "Choose how your schedule is generated and managed",
+      "checklist-specialty": "Add your specialty",
+      "checklist-specialty-desc": "Let patients know your area of practice",
+      "help-title": "Need help?",
+      "help-text": "Jupiter can guide you through completing your setup",
+      "help-cta": "Talk to Jupiter",
+      "banner-dismiss": "Dismiss",
+      "buffer-drawer-desc": "Buffer time adds a gap between sessions so you can prepare, take notes, or simply breathe between appointments.",
+      "buffer-drawer-title": "Buffer time",
+      "buffer-custom-input-helper": "Choose the buffer that feels best between sessions.",
+      "buffer-impact-day": "Adds about {{value}} on your daily schedule.",
+      "buffer-impact-empty": "We'll estimate the impact once future sessions are available.",
+      "buffer-impact-hours-value": "{{hours}}h",
+      "buffer-impact-hours-minutes-value": "{{hours}}h {{minutes}} min",
+      "buffer-impact-minutes-value": "{{minutes}} min",
+      "buffer-impact-title": "Impact preview",
+      "buffer-impact-week": "Adds about {{value}} across your working weekly hours.",
+      "buffer-input-label": "Minutes between sessions",
+      "buffer-jupiter-title": "Jupiter recommendation",
+      "buffer-range-helper": "Choose a buffer from 5 to 20 minutes. Jupiter will tailor a suggestion using your upcoming schedule.",
+      "buffer-jupiter-empty": "We’ll personalize this once upcoming sessions are available.",
+      "buffer-jupiter-thinking": "Jupiter is reviewing your upcoming schedule",
+      "buffer-jupiter-unavailable": "Jupiter couldn’t personalize this right now. You can still choose a buffer manually.",
+      "buffer-save": "Save",
+      "buffer-save-fail": "Could not save buffer time. Please try again.",
+      "buffer-save-success": "Buffer time saved successfully.",
+      "buffer-warning-overflow": "{{day}} may run past your configured end time with this buffer.",
+      "buffer-warning-soft-weekly": "This adds a noticeable amount of recovery time across the week, which can reduce stress but may lengthen your schedule.",
+      "buffer-warning-strong-weekly": "This adds a large amount of recovery time across the week and may noticeably extend your workload.",
+      "buffer-warning-title": "Schedule warning",
+      "checklist-action-configure": "Configure",
+      "checklist-action-edit": "Edit",
+      "checklist-action-soon": "Coming soon",
+      "checklist-action-view": "View",
+      "checklist-badge-recommended": "Recommended",
+      "checklist-duration": "Session duration",
+      "checklist-duration-desc": "Set the length of each appointment",
+      "checklist-progress-label": "{{count}} of {{total}} completed",
+      "checklist-session-type": "Session type",
+      "checklist-session-type-desc": "How do you conduct your sessions",
+      "checklist-timezone": "Time zone",
+      "checklist-timezone-desc": "Ensure all bookings use the correct time zone",
+      "checklist-working-hours": "Working hours",
+      "checklist-working-hours-desc": "Your available days and hours for appointments",
+      "tip-buffer-time": "Adding buffer time between sessions helps you prepare, take notes, and avoid running late. Even 5 minutes makes a difference.",
+      "tip-session-address": "Let your patients know where to find you. Add your clinic or office address so in-person sessions are easy to locate."
+    },
+    "google-calendar": {
+      "permissions-intro": "We’ll securely connect to your Google Calendar to:",
+      "permission-1": "Read your busy times",
+      "permission-2": "Prevent double bookings",
+      "permission-3": "Keep everything in sync",
+      "privacy-note": "We never edit or delete events without your permission.",
+      "back": "← Back",
+      "continue": "Continue",
+      "success-line1": "Perfect! 🎉",
+      "success-line2": "Your Google Calendar is now connected.",
+      "success-line3": "I’ll automatically block times when you’re already busy.",
+      "next-choice": "Would you like to:",
+      "chip-use-existing": "Use my existing schedule as availability",
+      "chip-define-hours": "Define specific working hours",
+      "define-hours-fallback": "Got it! Google Calendar import is coming soon. Let’s set your working hours manually for now.",
+      "importing": "Give me a moment — I’m importing your schedule from Google Calendar...",
+      "imported": "Done! I found your working days and hours. Just a couple more things to set up.",
+      "import-failed": "I couldn’t read your calendar schedule. Let’s set your working hours manually."
+    },
+    "errors": {
+      "network": "Something went wrong. Let’s try that again.",
+      "retry": "Try again",
+      "google-oauth-fail": "I couldn’t connect to Google Calendar. Please try again or set up manually.",
+      "google-oauth-cancel": "No problem! You can always connect your calendar later. Let’s set things up manually.",
+      "save-fail": "I couldn’t save your availability. Please try again.",
+      "session-timeout": "It looks like you’ve been away. Your progress is saved — pick up where you left off.",
+      "empty-days": "Please select at least one working day to continue.",
+      "invalid-time-range": "The end time must be after the start time.",
+      "invalid-input": "I didn’t quite get that. Could you try again?",
+      "ai-fallback": "Thanks! Let me process that for you.",
+      "ai-thinking": "Thinking...",
+      "no-timezone": "I couldn’t detect your timezone automatically. Please select it below.",
+      "publish-success": "All set! Your availability is live.",
+      "publish-redirect": "Redirecting to your dashboard..."
+    },
+    "subtitle": "Your scheduling assistant",
+    "days": {
+      "MONDAY": "Monday",
+      "TUESDAY": "Tuesday",
+      "WEDNESDAY": "Wednesday",
+      "THURSDAY": "Thursday",
+      "FRIDAY": "Friday",
+      "SATURDAY": "Saturday",
+      "SUNDAY": "Sunday"
+    }
+  },
+  "availability": {
+    "calendar": {
+      "legend-available": "Available",
+      "legend-busy": "Busy",
+      "legend-empty": "Unavailable",
+      "legend-full": "Full",
+      "legend-partial": "Partial",
+      "legend-today": "Today",
+      "page-title": "Availability",
+      "source-google": "Google",
+      "source-jupiter": "Júpiter",
+      "subtitle": "Your availability calendar",
+      "settings": "Availability settings"
+    },
+    "cancellation-recovery": {
+      "title": "Cancellation recovery",
+      "subtitle": "Review cancelled appointments, reopen slots, and jump into patient follow-up without cluttering the live calendar.",
+      "accessibility": {
+        "detail": "Recovery detail",
+        "queue": "Recovery queue"
+      },
+      "empty": "No cancelled appointments match your current filters.",
+      "empty-selection": "Choose a cancelled appointment to review its recovery details and next actions.",
+      "unknown-patient": "Unknown patient",
+      "queue": {
+        "title": "Recovery queue",
+        "subtitle": "Track cancelled appointments that still need therapist attention."
+      },
+      "stats": {
+        "total": "Total",
+        "pending-follow-up": "Pending",
+        "reopened": "Reopened"
+      },
+      "filters": {
+        "title": "Filters",
+        "summary-default": "Expand to refine the recovery queue.",
+        "summary-active": "{{count}} active filters",
+        "patient": "Patient",
+        "patient-placeholder": "Search by patient name",
+        "period": "Period",
+        "status": "Status",
+        "cancelled-by": "Cancelled by",
+        "reason": "Reason",
+        "reason-all": "All reasons",
+        "delivery": "Delivery",
+        "period-options": {
+          "all": "All",
+          "past": "Past",
+          "upcoming": "Upcoming"
+        },
+        "status-options": {
+          "all": "All",
+          "needs-action": "Needs action",
+          "resolved": "Resolved"
+        },
+        "cancelled-by-options": {
+          "all": "All",
+          "patient": "Patient",
+          "therapist": "Therapist",
+          "unknown": "Unknown"
+        },
+        "delivery-options": {
+          "all": "All",
+          "in-person": "In person",
+          "online": "Online",
+          "unknown": "Unknown"
+        }
+      },
+      "state": {
+        "pending-follow-up": "Pending follow-up",
+        "followed-up": "Followed up",
+        "reopened": "Reopened",
+        "rebooked": "Rebooked",
+        "archived": "Archived",
+        "overdue": "Overdue"
+      },
+      "cancelled-by": {
+        "patient": "Cancelled by patient",
+        "therapist": "Cancelled by therapist",
+        "unknown": "Cancelled by unknown source"
+      },
+      "delivery": {
+        "in-person": "In person",
+        "online": "Online",
+        "unknown": "Not provided"
+      },
+      "detail": {
+        "eyebrow": "Recovery detail",
+        "cancelled-at": "Cancelled at",
+        "cancelled-by": "Cancelled by",
+        "reason": "Reason",
+        "delivery": "Delivery mode",
+        "followed-up-at": "Followed up at",
+        "patient": "Patient",
+        "rebooked-appointment": "Rebooked appointment",
+        "recovery-state": "Recovery state",
+        "not-provided": "Not provided"
+      },
+      "actions": {
+        "rebook": "Rebook this patient",
+        "archive": "Mark as resolved",
+        "archive-all": "Mark all as resolved ({{count}})",
+        "more": "More actions",
+        "open-patient": "Open patient profile",
+        "reopen": "Set slot to available again",
+        "archive-success": "Recovery closed without further action.",
+        "archive-error": "Failed to close this recovery item. Please try again.",
+        "archive-all-success": "{{count}} recovery items marked as resolved.",
+        "archive-all-error": "Failed to resolve all recovery items. Please try again.",
+        "reopen-success": "Slot reopened successfully.",
+        "reopen-error": "Failed to reopen the slot. Please try again."
+      }
+    },
+    "week": {
+      "drawer": {
+        "address-override": "Session location",
+        "address-override-question": "Use a different location for this session?",
+        "address-reset": "Reset to default",
+        "address-save": "Save location",
+        "address-save-error": "Failed to save session location. Please try again.",
+        "address-saved": "Session location saved.",
+        "block-confirm": "Confirm block",
+        "block-confirm-body": "This slot will no longer be available for patients to book.",
+        "block-error": "Failed to block slot. Please try again.",
+        "block-reason-label": "Block reason",
+        "block-reason-placeholder": "Optional: Add a reason for blocking",
+        "block-slot": "Block slot",
+        "block-success": "Slot blocked successfully.",
+        "break-edit": "Edit break",
+        "break-edit-body": "This break is controlled by your global buffer-time setting. Update the minutes below to change future break blocks.",
+        "break-edit-save": "Save break",
+        "break-note": "Automatically blocked for rest between sessions.",
+        "break-note-label": "How this works",
+        "break-remove": "Remove",
+        "break-subtitle": "Scheduled break",
+        "break-title": "Break time",
+        "blocked-at": "Blocked on {{date}}",
+        "blocked-subtitle": "Patients cannot book this time slot",
+        "blocked-title": "Slot blocked",
+        "cancelled-at": "Cancelled on {{date}}",
+        "cancelled-reason-label": "Reason for cancellation",
+        "cancelled-by-patient": "This appointment was cancelled by the patient",
+        "cancelled-by-therapist": "This appointment was cancelled by the therapist",
+        "cancelled-subtitle": "This appointment was cancelled",
+        "cancelled-title": "Cancelled appointment",
+        "booking-link-copy-aria": "Copy booking link to clipboard",
+        "booking-link-hint": "Share this link to open the public booking page with this slot preselected when it is still available.",
+        "booking-link-label": "Booking link",
+        "booking-share-text": "Open this link to book the selected session.",
+        "booking-share-title": "Book this session on {{date}} at {{time}}",
+        "book-slot": "Book this slot",
+        "cancel": "Cancel",
+        "cancel-appointment": "Cancel appointment",
+        "cancel-back": "Go back",
+        "cancel-choice-sub": "Cancel this appointment permanently",
+        "cancel-confirm": "Confirm cancellation",
+        "cancel-custom-reason-label": "Additional details (optional)",
+        "cancel-error": "Failed to cancel appointment. Please try again.",
+        "cancel-reason-label": "Reason for cancellation",
+        "cancel-success": "Appointment cancelled successfully.",
+        "confirm-booking": "Confirm",
+        "confirmed": "Confirmed",
+        "date": "Date",
+        "edit": "Edit",
+        "edit-end-time": "End time",
+        "booking-error": "Failed to book appointment. Please try again.",
+        "booking-success": "Appointment booked successfully.",
+        "conflict-change-details": "Change contact details",
+        "conflict-confirm": "Book for {{name}}",
+        "conflict-multiple-body": "The phone and email match different patients. Update the contact details to continue.",
+        "conflict-single-body": "A patient with this contact is already registered:",
+        "conflict-title": "Patient already registered",
+        "existing-booking-body": "{{name}} already has a session booked on {{date}} at {{time}}. Would you like to add another session for this patient?",
+        "existing-booking-cancel": "Choose another patient",
+        "existing-booking-confirm": "Add another session",
+        "existing-booking-title": "Patient already has a session",
+        "edit-error": "Failed to save changes. Please try again.",
+        "edit-note": "Notes",
+        "edit-save": "Save changes",
+        "edit-start-time": "Start time",
+        "edit-success": "Slot updated successfully.",
+        "edit-success-booked": "Slot updated. Note: this session had an active booking.",
+        "let-patient-choose-address": "Let the patient choose the location?",
+        "location-choice-clinic": "Clinic",
+        "location-choice-custom": "Custom",
+        "location-choice-label": "Session location",
+        "session-delivery-in-person": "In person",
+        "session-delivery-in-person-subtitle": "At your clinic or the patient's location",
+        "session-delivery-label": "How will this session be held?",
+        "session-delivery-online": "Online",
+        "recurrence-all": "All future appointments",
+        "recurrence-end-month": "Until end of month",
+        "recurrence-end-year": "Until end of year",
+        "recurrence-label": "Repeat booking",
+        "recurrence-single": "This appointment only",
+        "session-delivery-online-subtitle": "Video call, phone, or messaging",
+        "location-choice-patient": "Patient",
+        "location-subtitle-clinic": "We will share your clinic address in the booking location",
+        "location-subtitle-custom": "We will share the custom address in the booking location",
+        "location-subtitle-patient": "You will allow your patient to choose an address in the booking location",
+        "minutes": "minutes",
+        "notes": "Notes",
+        "patient-email": "Patient's email",
+        "patient-timezone": "Patient's timezone",
+        "patient-timezone-placeholder": "Search by city, e.g. Sao Paulo",
+        "patient-first-name": "Patient's first name",
+        "patient-last-name": "Patient's last name",
+        "patient-search": {
+          "no-results": "No patients found",
+          "placeholder": "Search or type a new name",
+          "type-to-search": "Type at least 2 characters to search"
+        },
+        "patient-time": "Patient's local time",
+        "reschedule": "Reschedule",
+        "reschedule-choice-sub": "Move to a different time slot",
+        "reschedule-confirm": "Confirm reschedule",
+        "reschedule-error": "Failed to reschedule appointment. Please try again.",
+        "reschedule-no-slots": "No available slots to reschedule to. Try adjusting your working hours.",
+        "reschedule-select-prompt": "Select a new time slot for this appointment.",
+        "reschedule-success": "Appointment rescheduled successfully.",
+        "reopen-slot": "Set to available again",
+        "reopened-note-fallback-name": "this patient",
+        "reopened-note-label": "Previously cancelled",
+        "reopened-note-text": "Previously cancelled to {{name}} on {{date}}.",
+        "session-duration": "Duration: ",
+        "session-type": "Session type",
+        "share-address": "Share clinic address with patient",
+        "status-cancelled": "Cancelled",
+        "status-confirmed": "Confirmed",
+        "available-status-open": "Open for booking",
+        "your-time": "Your local time",
+        "appointment-address": "Appointment address",
+        "patient-phone": "Patient's phone",
+        "patient-provides-address": "Patient will provide the address",
+        "call-whatsapp": "Call on WhatsApp",
+        "call-phone": "Call patient",
+        "join-meet": "Join on Google Meet",
+        "join-zoom": "Join on Zoom",
+        "booked-section-session": "Session",
+        "booked-section-patient": "Patient",
+        "booked-section-location": "Location",
+        "booked-section-notes": "Notes",
+        "booked-date": "Date",
+        "booked-time": "Time",
+        "booked-duration": "Duration",
+        "booked-session-count": "Session {{count}} with {{name}}",
+        "booked-session-first": "First session with {{name}}",
+        "booked-email": "Email",
+        "booked-phone": "Phone",
+        "booked-online-session": "Online session",
+        "booked-hybrid": "Online / In person",
+        "booked-in-person": "In person",
+        "booked-google-sync": "Synced from Google Calendar",
+        "booked-profile-link": "Profile",
+        "booked-profile-coming-soon": "Patient profile — coming soon",
+        "booked-no-email": "No email provided",
+        "booked-no-phone": "No phone provided",
+        "booked-awaiting-address": "Awaiting patient address",
+        "booked-request-address": "Request address",
+        "booked-view-notifications": "View notifications",
+        "booked-past-disabled": "Past appointment — actions disabled",
+        "booked-copied": "Copied",
+        "booked-copy-aria": "Copy {{field}} to clipboard",
+        "booked-call-aria": "Call {{name}}",
+        "booked-whatsapp-aria": "Message {{name}} on WhatsApp",
+        "booked-email-aria": "Email {{name}}",
+        "source-manual": "Booked",
+        "unblock-confirm": "Confirm unblock",
+        "unblock-confirm-body": "This slot will become available for booking again.",
+        "unblock-error": "Failed to unblock slot. Please try again.",
+        "unblock-slot": "Unblock slot",
+        "unblock-success": "Slot unblocked successfully."
+      },
+      "buffer-label": "Buffer",
+      "legend-available": "Available",
+      "legend-blocked": "Blocked",
+      "legend-booked-google": "Google",
+      "legend-booked-jupiter": "Booked",
+      "legend-buffer": "Buffer",
+      "legend-cancelled": "Cancelled",
+      "next-week": "Next week",
+      "no-appointments": "No appointments",
+      "page-title": "Availability",
+      "prev-week": "Previous week",
+      "filter-clear": "Clear filters",
+      "filter-delivery-in-person": "In person",
+      "filter-delivery-online": "Online",
+      "filter-hide-free": "Hide free slots",
+      "filter-label-cancelled": "Cancelled slots",
+      "filter-label-free": "Free slots",
+      "filter-section-delivery": "Delivery",
+      "filter-section-session-type": "Session type",
+      "filter-section-source": "Source",
+      "filter-section-status": "Slot status",
+      "filter-section-time": "Time of day",
+      "filter-show-free": "Show free slots",
+      "filter-source-google": "Google",
+      "filter-source-jupiter": "Jupiter",
+      "filter-time-afternoon": "Afternoon",
+      "filter-time-evening": "Evening",
+      "filter-time-morning": "Morning",
+      "filters": "Filters",
+      "collapse-day": "Show less",
+      "expand-day": "+{{count}} more",
+      "blocked-hover-label": "Blocked slot",
+      "show-available-slots": "Show available times ({{count}})",
+      "slot": "slot",
+      "slots": "slots",
+      "title": "Week Schedule",
+      "settings": "Settings",
+      "default-blocked-day": {
+        "body": "{{day}} is closed by your default availability settings. Open only this date as a full day, part of the day, or selected time slots.",
+        "confirm": "Open this day",
+        "end-time": "End time",
+        "error": "Could not open this day. Please try again.",
+        "open-full-day": "Open full day",
+        "open-full-day-desc": "Create all available slots for this date using your usual working hours.",
+        "open-part-day": "Open part of day",
+        "open-part-day-desc": "Choose a custom time range for this specific date only.",
+        "open-specific-slots": "Open specific slots",
+        "open-specific-slots-desc": "Select only the exact times you want to make available.",
+        "start-time": "Start time",
+        "success": "This day is now available.",
+        "title": "Open this closed day?"
+      },
+      "day-header": {
+        "actions": "Day actions",
+        "block-all": "Block all available slots",
+        "block-all-confirm": "Block all {{count}} available slots on {{day}}? Patients won't be able to book these times.",
+        "booked-warning": "This day has {{count}} booked appointment(s). Blocking the day will only affect the remaining available slots.",
+        "block-all-error": "Failed to block slots. Please try again.",
+        "block-all-success": "All available slots blocked successfully.",
+        "summary": "{{total}} total · {{available}} available · {{booked}} booked · {{blocked}} blocked · {{cancelled}} cancelled",
+        "unblock-all": "Unblock all blocked slots",
+        "unblock-all-confirm": "Unblock all {{count}} blocked slots on {{day}}? These slots will become available for booking.",
+        "unblock-all-error": "Failed to unblock slots. Please try again.",
+        "unblock-all-success": "All blocked slots unblocked successfully."
+      }
+    },
+    "gate": {
+      "deleted-notice": "You no longer have availability set up. Head to Jupiter to create a new one."
+    },
+    "settings": {
+      "google-calendar-connect-btn": "Connect Google Calendar",
+      "google-calendar-connect-error": "Could not start Google Calendar connection. Please try again.",
+      "first-publish-alert": "Your availability is live! Complete the checklist below to optimize your setup.",
+      "google-calendar-connected": "Your Google Calendar is connected.",
+      "google-calendar-desc": "Sync your Google Calendar to import your existing schedule, block busy times automatically, and keep your Psycron sessions in sync.",
+      "google-calendar-drawer-title": "Google Calendar",
+      "live-alert": "Your availability is now live. Clients can start booking sessions with you right away.",
+      "page-title": "Availability Settings",
+      "save-error": "Could not save settings. Please try again.",
+      "save-success": "Settings saved successfully.",
+      "session-duration-desc": "Set the default length for each appointment.",
+      "session-duration-drawer-title": "Session duration",
+      "session-type-both": "Both",
+      "session-type-desc": "Choose how you conduct your sessions.",
+      "session-type-drawer-title": "Session type",
+      "session-type-in-person": "In person",
+      "session-type-online": "Online",
+      "session-address-desc": "Enter your clinic or office address so patients can find you.",
+      "session-type-address-hint": "In-person sessions require a clinic address. You'll be prompted to add it after saving.",
+      "session-address-drawer-title": "Session address",
+      "session-address-title": "Clinic address",
+      "specialty-drawer-title": "Your specialty",
+      "specialty-desc": "Choose the broad field you work in. You can add your specific approach below.",
+      "specialty-psychology": "Psychology",
+      "specialty-psychiatry": "Psychiatry",
+      "specialty-physiotherapy": "Physiotherapy",
+      "specialty-nutrition": "Nutrition",
+      "specialty-coaching": "Coaching",
+      "specialty-occupational-therapy": "Occupational therapy",
+      "specialty-speech-therapy": "Speech therapy",
+      "specialty-social-work": "Social work",
+      "specialty-other": "Other",
+      "specialty-detail-label": "Specific approach or method (optional)",
+      "specialty-detail-helper": "e.g. Cognitive Behavioural Therapy, EMDR — used to improve your profile",
+      "feature-disabled-tooltip": "This feature is coming soon",
+      "jupiter-cta-disabled-tooltip": "Júpiter is not available yet — we're rolling this out gradually",
+      "jupiter-help-action": "Talk to Júpiter",
+      "jupiter-help-description": "Júpiter can guide you through completing your setup",
+      "jupiter-help-title": "Need help?",
+      "talk-to-jupiter": "Edit with Jupiter",
+      "timezone-desc": "All bookings will be displayed and scheduled in this time zone.",
+      "timezone-drawer-title": "Time zone",
+      "timezone-input-label": "Time zone",
+      "timezone-warning-body": "Your existing appointments won't move — they'll continue at the same UTC time but displayed in the new time zone.",
+      "timezone-warning-confirm": "Change time zone",
+      "timezone-warning-title": "Change time zone?",
+      "working-hours-days-label": "Working days",
+      "working-hours-desc": "Set your available days and the time range for appointments.",
+      "working-hours-drawer-title": "Working hours",
+      "working-hours-end-label": "End",
+      "recurrence-consistent": "Consistent",
+      "recurrence-consistent-desc": "Your schedule repeats the same days and hours every week, generated one month at a time. Best for a consistent, predictable routine.",
+      "recurrence-flexible": "Flexible",
+      "recurrence-flexible-desc": "Slots are generated for the full month at once. Best if your availability varies — you can edit individual slots without rebuilding your entire schedule.",
+      "recurrence-pattern-desc": "Changing this will regenerate your open availability slots using the new pattern. Any already-booked appointments will remain exactly as scheduled.",
+      "recurrence-pattern-drawer-title": "Recurrence pattern",
+      "working-hours-start-label": "Start",
+      "working-hours-time-label": "Time range"
+    }
+  },
+  "conflicts": {
+    "title": "Conflict panel",
+    "subtitle": "Review and resolve booking and patient conflicts.",
+    "empty": "No conflicts match your current filters.",
+    "filters": {
+      "title": "Filters",
+      "summary-default": "Refine the queue by status or conflict type.",
+      "summary-active": "{{count}} active filter",
+      "summary-active_other": "{{count}} active filters",
+      "status": "Status",
+      "type": "Type",
+      "open": "Open",
+      "all-statuses": "All statuses",
+      "all-types": "All types"
+    },
+    "queue": {
+      "eyebrow": "Operations",
+      "title": "Conflict queue",
+      "subtitle": "Review the items that still need your decision."
+    },
+    "layout": {
+      "expand-queue": "Expand queue",
+      "collapse-queue": "Collapse queue"
+    },
+    "accessibility": {
+      "queue": "Conflict queue",
+      "detail": "Conflict detail"
+    },
+    "status": {
+      "open": "Open",
+      "resolved": "Resolved",
+      "dismissed": "Dismissed"
+    },
+    "types": {
+      "patient-duplicate": "Patient duplicate",
+      "slot-replication": "Slot replication"
+    },
+    "patient-duplicate": {
+      "title": "Possible duplicate patient",
+      "and": "and",
+      "summary": {
+        "phone-and-email": "Matches existing patient records by phone {{phone}} and email {{email}}. Review: {{candidates}}.",
+        "phone-only": "Matches existing patient records by phone {{phone}}. Review: {{candidates}}.",
+        "email-only": "Matches existing patient records by email {{email}}. Review: {{candidates}}.",
+        "generic": "Matches an existing patient record. Review: {{candidates}}."
+      },
+      "match": {
+        "phone-and-email": "Phone {{phone}} and email {{email}}",
+        "phone-only": "Phone {{phone}}",
+        "email-only": "Email {{email}}",
+        "generic": "Existing patient details"
+      }
+    },
+    "detail": {
+      "incoming-patient": "Incoming patient",
+      "existing-patient": "Existing patient",
+      "matched-by": "Matched by",
+      "candidate-records": "Candidate records",
+      "conflicting-details": "Conflicting details",
+      "conflicting-date": "Conflicting date",
+      "conflicting-time": "Conflicting time",
+      "recurrence-pattern": "Recurrence pattern",
+      "preferred-contact": "Preferred contact",
+      "additional-candidates": "{{count}} more possible match is still queued for review.",
+      "additional-candidates_other": "{{count}} more possible matches are still queued for review.",
+      "not-provided": "Not provided"
+    },
+    "merge-review": {
+      "title": "Choose what to keep",
+      "description": "Bookings, cancellations, and notifications will be combined automatically. Choose the profile details that should remain on the surviving patient.",
+      "primary": "Keep from {{name}}",
+      "secondary": "Use from {{name}}",
+      "confirm": "Confirm merge",
+      "fields": {
+        "firstName": "First name",
+        "lastName": "Last name",
+        "contacts": {
+          "email": "Email",
+          "phone": "Phone",
+          "whatsapp": "WhatsApp"
+        },
+        "billing": "Billing",
+        "preferredContact": "Preferred contact",
+        "timeZone": "Timezone",
+        "address": "Address"
+      }
+    },
+    "resolution": {
+      "title": "Resolution history",
+      "completed-at": "Completed on {{date}}.",
+      "actions": {
+        "auto-dismissed-stale": "Psycron closed this because the duplicate records are no longer active.",
+        "dismissed": "The therapist dismissed this conflict without changing patient records.",
+        "keep-existing": "The therapist kept the existing patient record and did not merge records.",
+        "keep-new": "The therapist kept the new patient record and did not merge records.",
+        "marked-resolved": "The therapist marked this conflict as resolved.",
+        "merged": "The therapist merged the duplicate patient records.",
+        "merge-reconciled": "Psycron closed this because another merge already handled the duplicate patient.",
+        "unknown": "This conflict was closed."
+      },
+      "sources": {
+        "primary": "Kept from {{name}}",
+        "secondary": "Changed to {{name}}"
+      }
+    },
+    "actions": {
+      "recommended-title": "Recommended resolution",
+      "recommended-hint": "Merge both records and keep one patient as the source of truth.",
+      "alternatives-title": "Other options",
+      "alternatives-hint": "Use one record only if you do not want to merge them now.",
+      "merge": "Merge patients",
+      "keep-existing": "Keep existing patient",
+      "keep-new": "Keep new patient",
+      "dismiss": "Dismiss",
+      "mark-resolved": "Mark resolved",
+      "error": "We couldn't update this conflict. Please try again."
+    }
+  },
+  "action-center": {
+    "title": "Action center",
+    "subtitle": "Resolve the operational items that need your attention today.",
+    "tabs": {
+      "aria-label": "Action center sections",
+      "conflicts": "Conflicts",
+      "recovery": "Recovery"
+    }
+  },
+  "notifications": {
+    "title": "Notifications",
+    "subtitle": "Track outbound patient communication across WhatsApp, email, and SMS.",
+    "empty": "No notifications match your current filters.",
+    "load-more": "Load more",
+    "queue": {
+      "title": "Notification feed",
+      "subtitle": "A delivery timeline for patient communication."
+    },
+    "layout": {
+      "expand-feed": "Expand feed",
+      "collapse-feed": "Collapse feed"
+    },
+    "accessibility": {
+      "page": "Notifications workspace",
+      "queue": "Notification feed",
+      "detail": "Notification detail"
+    },
+    "stats": {
+      "total": "Total",
+      "failed": "Failed",
+      "delivered": "Delivered",
+      "sent": "Sent"
+    },
+    "search": {
+      "placeholder": "Search patient or message"
+    },
+    "sort": {
+      "label": "Sort",
+      "options": {
+        "newest": "Newest first",
+        "oldest": "Oldest first",
+        "status": "Status"
+      }
+    },
+    "filters": {
+      "title": "Filters",
+      "summary-default": "Refine the feed by channel, status, type, or date.",
+      "summary-active": "{{count}} active filter",
+      "summary-active_other": "{{count}} active filters",
+      "channel": "Channel",
+      "status": "Status",
+      "message-type": "Message type",
+      "date-range": "Date range",
+      "from": "From",
+      "to": "To",
+      "all-channels": "All channels",
+      "all-statuses": "All statuses",
+      "all-types": "All types",
+      "active": "Active",
+      "archived": "Archived"
+    },
+    "channels": {
+      "whatsapp": "WhatsApp",
+      "email": "Email",
+      "sms": "SMS",
+      "icalendar": "Calendar invite"
+    },
+    "statuses": {
+      "pending": "Pending",
+      "sent": "Sent",
+      "delivered": "Delivered",
+      "failed": "Failed"
+    },
+    "message-types": {
+      "appointment_confirmation": "Appointment confirmation",
+      "appointment_updated": "Appointment updated",
+      "reminder": "Reminder",
+      "conflict": "Conflict",
+      "account_setup": "Account setup",
+      "daily_schedule_summary": "Daily schedule summary",
+      "unknown": "Notification"
+    },
+    "bulk": {
+      "resend-eligible": "Re-notify eligible",
+      "action": "Notify again"
+    },
+    "card": {
+      "appointment": "Appointment: {{value}}",
+      "delivered-at": "Sent at {{value}}",
+      "failed": "Failed delivery"
+    },
+    "patient-settings": {
+      "action": "Patient notification settings",
+      "title": "Patient Notification Preferences",
+      "subtitle": "Configure which channels this patient receives notifications on.",
+      "subtitle-named": "Configure which channels {{name}} receives notifications on.",
+      "save-success": "Patient notification preferences saved.",
+      "save-error": "Could not save patient notification preferences."
+    },
+    "settings": {
+      "action": "Setup notifications",
+      "title": "Notification Preferences",
+      "subtitle": "Control which channels are used for each type of patient communication.",
+      "save-success": "Notification preferences saved.",
+      "save-error": "Could not save notification preferences. Please try again.",
+      "appointment-confirmation": {
+        "title": "Appointment Confirmation",
+        "description": "Sent to the patient when a new appointment is booked."
+      },
+      "reminder": {
+        "title": "Appointment Reminders",
+        "description": "Sent to the patient before the appointment.",
+        "toggle": "Enable reminders",
+        "lead-time": {
+          "label": "Send reminder",
+          "30m": "30 min before",
+          "1h": "1 hour before",
+          "2h": "2 hours before",
+          "24h": "24 hours before",
+          "48h": "48 hours before"
+        }
+      },
+      "appointment-updated": {
+        "title": "Appointment Updated",
+        "description": "Sent to the patient when an appointment is rescheduled or modified."
+      },
+      "calendar-invite": {
+        "title": "Calendar Invite",
+        "description": "Attach a .ics calendar file to email confirmations and reminders.",
+        "toggle": "Include calendar attachment"
+      }
+    },
+    "context": {
+      "channel-status": "{{channel}} notification is {{status}}.",
+      "sent-at": "Sent at {{value}}.",
+      "delivered-at": "Delivered at {{value}}.",
+      "appointment": "Appointment: {{value}}.",
+      "session": "Session: {{value}}.",
+      "calendar-invite-attached": "Calendar invite attached.",
+      "error": "Delivery error: {{value}}"
+    },
+    "detail": {
+      "title": "Communication details",
+      "patient": "Patient",
+      "unknown-patient": "Unknown patient",
+      "message-type": "Message type",
+      "channel": "Channel",
+      "status": "Status",
+      "sent-at": "Sent at",
+      "delivered-at": "Delivered at",
+      "appointment": "Appointment",
+      "ics": "Calendar invite",
+      "ics-attached": "Attached",
+      "ics-empty": "Not attached",
+      "message": "Message",
+      "context": "Context",
+      "error": "Delivery error",
+      "payload": "Payload"
+    },
+    "retry": {
+      "action": "Retry notification",
+      "action-short": "Retry",
+      "success": "Notification sent again.",
+      "error": "We could not send this notification again. Please try again."
+    },
+    "resend": {
+      "action": "Notify again",
+      "action-short": "Notify again"
+    },
+    "archive": {
+      "action": "Archive",
+      "success": "Notification archived.",
+      "error": "Could not archive this notification."
+    }
+  }
 }

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -2102,6 +2102,10 @@
       "unknown": "Notification",
       "whatsapp_action_required": "WhatsApp follow-up required"
     },
+    "whatsapp-action-required": {
+      "title": "Manual follow-up required",
+      "body": "WhatsApp delivery failed and this patient has no email address on file. Please contact them directly to confirm or reschedule the appointment."
+    },
     "bulk": {
       "resend-eligible": "Re-notify eligible",
       "action": "Notify again"

--- a/src/assets/locales/pt/translation.json
+++ b/src/assets/locales/pt/translation.json
@@ -1270,6 +1270,14 @@
       "success-title": "Você foi removido da lista",
       "success-description": "Se este email estava na nossa lista, ele foi removido. Você não receberá mais emails de marketing do Psycron.",
       "back-home": "Voltar ao início"
+    },
+    "auth": {
+      "whatsapp-otp": {
+        "title": "Verificação em dois passos",
+        "description": "Introduza o código de 6 dígitos enviado para o seu WhatsApp.",
+        "label": "Código de verificação",
+        "submit": "Verificar"
+      }
     }
   },
   "chat": {
@@ -2091,7 +2099,8 @@
       "conflict": "Conflito",
       "account_setup": "Configuração da conta",
       "daily_schedule_summary": "Resumo diário da agenda",
-      "unknown": "Notificação"
+      "unknown": "Notificação",
+      "whatsapp_action_required": "Acompanhamento WhatsApp necessário"
     },
     "bulk": {
       "resend-eligible": "Renotificar elegíveis",

--- a/src/assets/locales/pt/translation.json
+++ b/src/assets/locales/pt/translation.json
@@ -2102,6 +2102,10 @@
       "unknown": "Notificação",
       "whatsapp_action_required": "Acompanhamento WhatsApp necessário"
     },
+    "whatsapp-action-required": {
+      "title": "Acompanhamento manual necessário",
+      "body": "A entrega via WhatsApp falhou e este paciente não tem e-mail cadastrado. Entre em contato diretamente para confirmar ou reagendar a consulta."
+    },
     "bulk": {
       "resend-eligible": "Renotificar elegíveis",
       "action": "Notificar novamente"

--- a/src/assets/locales/pt/translation.json
+++ b/src/assets/locales/pt/translation.json
@@ -1,2178 +1,2189 @@
 {
-	"public": {
-		"powered-by": "Desenvolvido por Psycron"
-	},
-	"booking": {
-		"page": {
-			"title": "Agendar Sessão"
-		},
-		"calendar": {
-			"title": "Selecione uma data e horário",
-			"subtitle": "Escolha primeiro o dia, depois selecione o horário que funciona melhor para você.",
-			"booking-greeting": "Olá, escolha o seu agendamento.",
-			"detail-title": "Escolha uma data",
-			"view-month": "Mês",
-			"view-week": "Semana",
-			"pick-a-day": "Selecione uma data no calendário para ver o que está disponível.",
-			"no-date-title": "Nenhuma data selecionada ainda",
-			"no-date-body": "Comece escolhendo um dos dias destacados no calendário.",
-			"no-times-title": "Sem horários neste dia",
-			"no-times-body": "Tente outra data destacada ou ajuste o filtro por período do dia.",
-			"available-count": "horários disponíveis",
-			"sidebar-description": "Escolha o dia e o horário que funcionam melhor para você.",
-			"duration-heading": "Duração da sessão",
-			"duration-pending": "Selecione um horário para visualizar a duração.",
-			"location-pending": "Escolha uma data e um horário para visualizar o local da sessão.",
-			"date-heading": "Dia selecionado",
-			"date-pending": "Escolha uma data no calendário.",
-			"agenda-title": "Agendamentos",
-			"agenda-main-title": "Calendário",
-			"agenda-subtitle": "Toque em um dia para focar apenas nos agendamentos daquela data.",
-			"agenda-greeting": "Olá, {{name}}, confira seus agendamentos.",
-			"agenda-greeting-fallback": "Olá, confira seus agendamentos.",
-			"agenda-sidebar-description": "Uma visão da sua jornada com acesso rápido a sessões futuras, concluídas e canceladas.",
-			"agenda-overview-title": "Resumo",
-			"agenda-overview-fallback": "Resumo",
-			"agenda-overview-heading": "Resumo",
-			"agenda-overview-heading-fallback": "Resumo",
-			"active-days": "Dias ativos",
-			"day-appointments": "agendamentos neste dia",
-			"selected-day-section": "Agendamentos do dia",
-			"next-appointments-section": "Próximos agendamentos",
-			"no-appointments-title": "Nada agendado para este dia",
-			"no-appointments-body": "Escolha outra data destacada para revisar seus agendamentos.",
-			"no-next-appointments": "Seus próximos agendamentos confirmados aparecerão aqui."
-		},
-		"filter": {
-			"from": "De",
-			"label-date-range": "Período",
-			"label-time-of-day": "Período do dia",
-			"time-all": "Qualquer horário",
-			"time-morning": "Manhã (antes do meio-dia)",
-			"time-afternoon": "Tarde (12–17h)",
-			"time-evening": "Noite (após 17h)",
-			"time-of-day": "Período do dia",
-			"to": "Até",
-			"weeks-1": "Próxima semana",
-			"weeks-2": "Próximas 2 semanas",
-			"weeks-4": "Próximo mês",
-			"weeks-12": "Próximos 3 meses",
-			"weeks-all": "Todos disponíveis"
-		},
-		"slot": {
-			"booked": "Reservado",
-			"taken": "Ocupado"
-		},
-		"drawer": {
-			"aria-label": "Agendar consulta",
-			"title": "Confirmar agendamento"
-		},
-		"confirm": "Confirmar",
-		"error": "Algo deu errado. Por favor, tente novamente.",
-		"no-slots": "Nenhum horário disponível corresponde aos seus filtros.",
-		"form": {
-			"address-fallback": "O endereço aparecerá aqui após você preenchê-lo acima.",
-			"email": "E-mail",
-			"first-name": "Nome",
-			"last-name": "Sobrenome",
-			"notify-email": "Notificar por e-mail",
-			"notify-fallback": "Preencha seus dados de contato acima para ativar as notificações.",
-			"notify-whatsapp": "Notificar por WhatsApp",
-			"section-notifications": "Notificações",
-			"section-personal": "Seus dados",
-			"section-recurrence": "Recorrência",
-			"your-address": "Endereço da sessão"
-		},
-		"notifications": {
-			"description": "Enviaremos um lembrete antes de cada sessão.",
-			"email": "Notificar por e-mail",
-			"fallback-note": "Adicione seus dados de contato acima para ativar os lembretes.",
-			"title": "Lembretes",
-			"whatsapp": "Notificar por WhatsApp"
-		},
-		"recurrence": {
-			"biweekly": "A cada 2 semanas",
-			"monthly": "Todo mês",
-			"not-yet": "Ainda não — decidir depois",
-			"single": "Sessão única",
-			"title": "Com que frequência você gostaria de se encontrar?",
-			"weekly": "Toda semana"
-		},
-		"confirmation": {
-			"title": "Agendamento confirmado!",
-			"subtitle": "Ótimo, {{name}}! Sua sessão foi confirmada.",
-			"date": "Data",
-			"time": "Horário",
-			"your-agenda": "Sua agenda pessoal",
-			"agenda-description": "Use este link para ver e gerenciar seus próximos agendamentos.",
-			"copy-link": "Copiar link"
-		},
-		"appointments": {
-			"title": "Seus agendamentos",
-			"subtitle": "Veja e gerencie suas sessões agendadas.",
-			"upcoming": "Próximas",
-			"past": "Anteriores",
-			"cancelled": "Canceladas",
-			"no-upcoming": "Você não possui agendamentos futuros.",
-			"no-upcoming-title": "Nenhuma sessão futura",
-			"no-past": "As sessões concluídas aparecerão aqui após seus atendimentos.",
-			"no-past-title": "Ainda não há sessões anteriores",
-			"no-cancelled": "Os agendamentos cancelados aparecerão aqui para sua referência.",
-			"no-cancelled-title": "Nenhum agendamento cancelado",
-			"therapist-fallback": "Seu terapeuta"
-		},
-		"patient-drawer": {
-			"aria-label": "Detalhes do agendamento do paciente",
-			"role": "Seu agendamento",
-			"available-title": "Confirmar e agendar",
-			"available-subtitle": "Revise este horário antes de concluir o agendamento.",
-			"available-badge": "Disponível",
-			"confirmed-title": "Seu agendamento",
-			"confirmed-badge": "Confirmado",
-			"completed-title": "Agendamento concluído",
-			"completed-badge": "Concluído",
-			"cancelled-title": "Agendamento cancelado",
-			"cancelled-badge": "Cancelado",
-			"cancelled-notice": "Este agendamento foi cancelado em {{date}}.",
-			"therapist-section": "Terapeuta",
-			"details-section": "Detalhes da sessão",
-			"contact-section": "Contato",
-			"reschedule-section": "Escolha um novo horário",
-			"specialty-fallback": "Detalhes da especialidade em breve",
-			"when": "{{date}} às {{time}}",
-			"when-label": "Quando",
-			"duration": "{{minutes}} min",
-			"duration-label": "Duração",
-			"session-type-label": "Tipo de sessão",
-			"session-online": "Sessão online",
-			"session-in-person": "Sessão presencial",
-			"location-label": "Local",
-			"location-online": "Sessão online",
-			"location-in-person": "O local presencial será confirmado pelo terapeuta.",
-			"location-address": "{{address}}",
-			"awaiting-address": "Aguardando o endereço da sessão",
-			"call-therapist": "Ligar para terapeuta",
-			"copy-phone": "Copiar telefone",
-			"cancel": "Cancelar agendamento",
-			"reschedule": "Reagendar",
-			"confirm-reschedule": "Confirmar reagendamento",
-			"reschedule-success": "Agendamento reagendado com sucesso.",
-			"reschedule-error": "Não foi possível reagendar este agendamento. Tente novamente.",
-			"no-reschedule-slots": "Nenhum outro horário disponível foi encontrado agora.",
-			"book-new": "Agendar nova sessão",
-			"session-completed": "Sessão concluída"
-		},
-		"cancel": {
-			"button": "Cancelar agendamento",
-			"reason-prompt": "Por favor, informe o motivo do cancelamento.",
-			"reason-label": "Motivo",
-			"reason": {
-				"emergency": "Emergência pessoal",
-				"schedule-conflict": "Conflito de agenda",
-				"financial": "Motivos financeiros",
-				"mental-health": "Não me sinto pronto(a)",
-				"other": "Outro"
-			},
-			"custom-reason": "Conte mais (opcional)",
-			"confirm": "Confirmar cancelamento",
-			"success": "Seu agendamento foi cancelado.",
-			"error": "Algo deu errado. Por favor, tente novamente."
-		}
-	},
-	"common": {
-		"back": "Voltar",
-		"cancel": "Cancelar",
-		"close": "Fechar",
-		"layout": {
-			"collapse-queue": "Recolher",
-			"expand-queue": "Expandir"
-		},
-		"loading": "Carregando...",
-		"required": "Obrigatório",
-		"save": "Salvar",
-		"saving": "Salvando...",
-		"today": "Hoje"
-	},
-	"patients": {
-		"list": {
-			"title": "Central de Pacientes",
-			"subtitle": "Busque, filtre e gerencie a sua lista de pacientes.",
-			"search-label": "Busca",
-			"search-placeholder": "Buscar por nome, email ou telefone",
-			"status-label": "Status",
-			"status-all": "Todos os pacientes",
-			"status-active": "Ativo",
-			"status-inactive": "Inativo",
-			"sort-label": "Ordenar por",
-			"sort-name": "Nome (A-Z)",
-			"sort-name-desc": "Nome (Z-A)",
-			"sort-last-appointment-asc": "Último atendimento (mais antigo primeiro)",
-			"sort-last-appointment": "Último atendimento",
-			"sort-total-sessions-asc": "Total de sessões (menor primeiro)",
-			"sort-total-sessions": "Total de sessões",
-			"columns": {
-				"patient": "Paciente",
-				"contact": "Contato",
-				"preferred-contact": "Contato preferido",
-				"timezone": "Fuso horário",
-				"billing": "Cobrança",
-				"recovery": "Recuperação",
-				"last-appointment": "Último atendimento",
-				"sessions": "Sessões",
-				"status": "Status"
-			},
-			"empty": {
-				"initial-title": "Você ainda não tem pacientes",
-				"initial-body": "Quando você adicionar ou agendar seu primeiro paciente, ele aparecerá aqui como parte da sua Central de Pacientes.",
-				"filtered-title": "Nenhum paciente corresponde a estes filtros",
-				"filtered-body": "Tente ajustar a busca ou os filtros para encontrar o paciente que você procura."
-			},
-			"clear-search": "Limpar busca",
-			"billing": {
-				"none": "Não definido",
-				"per-session-short": "/ sessão",
-				"monthly-short": "/ mês"
-			},
-			"not-available": "Não informado",
-			"no-appointments": "Sem atendimentos ainda",
-			"contact-method-not-set": "Não definido",
-			"possible-duplicate": "Possível duplicata",
-			"cancellation-follow-up-needed": "{{count}} precisa de acompanhamento",
-			"cancellation-follow-up-needed_other": "{{count}} precisam de acompanhamento",
-			"cancellation-follow-up-tooltip": "{{count}} sessão cancelada não tem acompanhamento, remarcação, arquivamento ou reabertura registrados.",
-			"cancellation-follow-up-tooltip_other": "{{count}} sessões canceladas não têm acompanhamento, remarcação, arquivamento ou reabertura registrados.",
-			"cancellation-follow-up-none": "Sem cancelamentos",
-			"cancellation-follow-up-resolved": "Resolvido",
-			"cancelled-sessions-notice": "{{count}} sessão cancelada",
-			"cancelled-sessions-notice_other": "{{count}} sessões canceladas"
-		},
-		"profile": {
-			"subtitle": "Revise contatos, preferências de cuidado e histórico de sessões.",
-			"member-since": "Paciente desde {{date}}",
-			"unknown-patient": "paciente desconhecido",
-			"merged-note": "Este registro foi mesclado em {{patientId}} e fica disponível para histórico de auditoria.",
-			"not-found": "Não conseguimos carregar este paciente. Ele pode ter sido arquivado ou mesclado em outro registro.",
-			"actions": {
-				"call": "Ligar",
-				"edit": "Editar paciente",
-				"open-sessions": "Abrir página de sessões",
-				"whatsapp": "WhatsApp",
-				"email": "Email"
-			},
-			"edit": {
-				"title": "Editar dados do paciente",
-				"description": "Atualize contatos, preferências de atendimento, fuso horário e endereço.",
-				"save": "Salvar alterações"
-			},
-			"session-drawer": {
-				"title": "Detalhes da sessão",
-				"open-label": "Abrir detalhes da sessão de {{date}}",
-				"status": "Status",
-				"delivery": "Formato da sessão",
-				"cancelled-at": "Cancelado em",
-				"cancellation-reason": "Motivo do cancelamento",
-				"cancelled-by": "Cancelado por",
-				"cancelled-by-patient": "Paciente",
-				"cancelled-by-therapist": "Terapeuta",
-				"cancelled-by-unknown": "Não informado",
-				"notification": "Notificação",
-				"notification-sent": "Notificação enviada",
-				"notification-not-sent": "Notificação não enviada",
-				"cancel-confirm": "Confirmar cancelamento",
-				"cancel-custom-reason": "Descreva o motivo",
-				"cancel-error": "Não foi possível cancelar esta sessão. Tente novamente.",
-				"cancel-reason-prompt": "Por que você está cancelando esta sessão?",
-				"cancel-session": "Cancelar sessão",
-				"cancel-success": "Sessão cancelada com sucesso.",
-				"cancelled-title": "Sessão cancelada",
-				"completed-title": "Sessão concluída",
-				"notify": "Notificar paciente",
-				"notify-error": "Não foi possível enviar a notificação. Tente novamente.",
-				"notify-sending": "A enviar notificação…",
-				"notify-success": "Paciente notificado com sucesso.",
-				"read-only": "Sessões canceladas estão disponíveis apenas para consulta.",
-				"reschedule": "Reagendar",
-				"reschedule-confirm": "Confirmar remarcação",
-				"reschedule-error": "Não foi possível reagendar este agendamento. Tente novamente.",
-				"reschedule-no-slots": "Não há horários disponíveis para remarcar. Tente ajustar os seus horários de trabalho.",
-				"reschedule-prompt": "Selecione um novo horário para esta consulta.",
-				"reschedule-success": "Agendamento reagendado com sucesso.",
-				"role": "Sessão do paciente",
-				"upcoming-title": "Sessão agendada",
-				"update-error": "Não foi possível atualizar esta sessão. Tente novamente.",
-				"update-no-change": "Nenhuma alteração foi feita — o horário da sessão é o mesmo.",
-				"update-success": "Sessão atualizada com sucesso."
-			},
-			"status": {
-				"active": "Ativo",
-				"archived": "Arquivado",
-				"merged": "Mesclado"
-			},
-			"stats": {
-				"total": "Total de sessões",
-				"upcoming": "Próximas",
-				"completed": "Concluídas",
-				"cancelled": "Canceladas"
-			},
-			"notifications": {
-				"label": "Notificações",
-				"reminders-off": "Lembretes desativados"
-			},
-			"sections": {
-				"billing": "Cobrança",
-				"details": "Dados do paciente",
-				"timeline": "Linha do tempo"
-			},
-			"billing": {
-				"model": "Modelo de cobrança",
-				"category": "Categoria de cobrança",
-				"amount": "Preço",
-				"currency": "Moeda",
-				"models": {
-					"per-session": "Pago por sessão",
-					"monthly": "Pago mensalmente"
-				},
-				"categories": {
-					"standard": "Padrão",
-					"social": "Atendimento social",
-					"pro-bono": "Pro bono"
-				},
-				"category-descriptions": {
-					"standard": "Atendimento pago normalmente, pela tarifa acordada.",
-					"social": "Atendimento com valor reduzido ou apoio social, acompanhado separadamente.",
-					"pro_bono": "Atendimento gratuito, sem expectativa de pagamento."
-				}
-			},
-			"share": {
-				"title": "Sua página de sessões",
-				"text": "Use este link para ver e gerir as suas sessões agendadas.",
-				"link-label": "Link público de sessões"
-			},
-			"preferred-contact": {
-				"phone": "Telefone",
-				"whatsapp": "WhatsApp",
-				"google-meet": "Google Meet",
-				"zoom": "Zoom",
-				"not-set": "Não definido"
-			},
-			"next-session": "Próxima sessão",
-			"last-session": "Última sessão concluída",
-			"no-upcoming-session": "Nenhuma próxima sessão agendada",
-			"no-completed-session": "Nenhuma sessão concluída ainda",
-			"no-sessions": "Nenhuma sessão foi agendada para este paciente ainda.",
-			"delivery": {
-				"online": "Online",
-				"in-person": "Presencial",
-				"not-set": "Formato não definido"
-			},
-			"sessions": {
-				"upcoming": "Próxima",
-				"completed": "Concluída",
-				"cancelled": "Cancelada"
-			}
-		}
-	},
-	"auth": {
-		"error": {
-			"login-failed": "Email ou senha inválidos. Por favor, verifique suas credenciais e tente novamente.",
-			"registration-failed": "Não foi possível completar o cadastro. Por favor, verifique suas informações e tente novamente.",
-			"password-reset-request": "Se este email estiver cadastrado, você receberá instruções para redefinir sua senha.",
-			"password-reset-failed": "Não foi possível redefinir a senha. O link pode ter expirado. Por favor, solicite um novo.",
-			"session-expired": "Sua sessão expirou. Por favor, faça login novamente.",
-			"rate-limited": "Muitas tentativas. Por favor, aguarde um momento antes de tentar novamente.",
-			"generic": "Algo deu errado. Por favor, tente novamente mais tarde."
-		},
-		"success": {
-			"password-reset-request": "Se este email estiver cadastrado, você receberá instruções para redefinir sua senha em breve.",
-			"password-reset": "Sua senha foi alterada com sucesso. Você já pode fazer login.",
-			"logout": "Você saiu com sucesso."
-		},
-		"continue-google": "Continuar com Google",
-		"continue-email": "Continue com seu e-mail"
-	},
-	"globals": {
-		"email": "Email",
-		"name": "Nome",
-		"password": "Senha",
-		"phone": "Telefone",
-		"whatsapp": "Whatsapp",
-		"address": "Endereço",
-		"patients": "Pacientes",
-		"patient": "Paciente",
-		"registered-patients": "Pacientes registrados",
-		"patients-manager": "Genrecie seus pacientes",
-		"billing-manager": "Gerencie seus pagamentos",
-		"subscription-manager": "Gerencie sua assinatura",
-		"appointments": "Atendimentos",
-		"appointments-manager": "Gerencie seus atendimentos",
-		"change-language": "Mude o idioma",
-		"help": "Centro de suporte",
-		"logout": "Sair",
-		"plan": "Plano",
-		"cancel": "Cancelar",
-		"delete": "Excluir",
-		"edit": "Alterar",
-		"date-time-format": "{{format}}",
-		"time-remaining": {
-			"days": "Em {{count}} dia(s)",
-			"hours": "Em {{count}} horas(s)",
-			"minutes": "Em {{count}} minuto(s)",
-			"less-than-a-minute": "Sessão {{status}}"
-		},
-		"in-progress": "Em andamento",
-		"paused": "Pausada",
-		"proceed": "Continuar",
-		"resume": "Retomar",
-		"reason": "Motivo",
-		"global-reason": "Motivo geral",
-		"custom-reason": "Descreva o motivo",
-		"select": "Selecione",
-		"unselect": "Desmarcar",
-		"error": {
-			"already-subscribed": "Você já está na nossa lista de espera",
-			"internal-server-error": "Algo aconteceu errado, tente novamente mais tarde",
-			"invalid-user": "Email ou senha invalidos"
-		},
-		"success": {
-			"subscribed": "Você foi inscrito com sucesso. Por favor verifique o seu -mail!"
-		},
-		"date": "Data",
-		"time": "Hora",
-		"at": "às",
-		"date-time": "Data e Hora: ",
-		"therapist": "Terapeuta",
-		"appointment-status": {
-			"booked": "Confirmado",
-			"available": "Disponível",
-			"onhold": "Em espera",
-			"blocked": "Bloqueado",
-			"cancelled": "Cancelado"
-		},
-		"contacts": "Contatos",
-		"starts": "Começa às",
-		"ends": "Termina às",
-		"time-range": {
-			"time-from-to": "das {{start}} às {{end}}",
-			"time-range-date": "{{date}} das {{start}} às {{end}}",
-			"your-time": "Seu horário local",
-			"patient-time": "Horário do paciente",
-			"therapist-time": "Horário do terapeuta"
-		},
-		"notification": {
-			"email": "Enviar e-mail",
-			"phone": "Ligar",
-			"whatsapp": "Enviar WhatsApp"
-		},
-		"cancellation-title": "Por favor nos informe o motivo do cancelamento da sua consulta",
-		"cancellation-reason": {
-			"1": "Emergência (Questão Pessoal/Saúde)",
-			"2": "Conflito de Agenda",
-			"3": "Problemas Financeiros",
-			"4": "Questões de Saúde Mental",
-			"5": "Não Comparecimento",
-			"6": "Consulta Encerrada",
-			"7": "Outro"
-		},
-		"cancellation-other-title": "Por favor especifique o motivo",
-		"status": "Disponibilidade",
-		"close": "Fechar",
-		"read-only": "Apenas leitura",
-		"auth-method": "Método de autenticação",
-		"privacy-policy": "Política de Privacidade",
-		"terms-of-service": "Termos de Uso",
-		"privacy": "Privacidade",
-		"previous": "Anterior",
-		"next": "Próximo"
-	},
-	"components": {
-		"form": {
-			"confirm-password": "Confirmar senha",
-			"keep-loggedin": "Mantenha-me online",
-			"not-valid": "Alguns campos estão faltando",
-			"signup": {
-				"sign-up": "Cadastra-se",
-				"title-email": "Crie sua conta ",
-				"title": "Crie a sua conta Psycron",
-				"first-name": "Nome",
-				"firstName": "Nome",
-				"last-name": "Sobrenome",
-				"lastName": "Sobrenome",
-				"already-have-acc": "Você já tem uma conta?",
-				"signin-here-link": "Clique aqui para entrar"
-			},
-			"signin": {
-				"sign-in": "Entrar",
-				"title": "Olá de volta!",
-				"dont-have-acc": "Você ainda não tem uma conta?",
-				"signup-here-link": "Cadastre-se aqui",
-				"forgot-password": "Esqueceu a sua senha?"
-			},
-			"validation": {
-				"required": "{{name}} é um campo obrigatório",
-				"invalid": "{{name}} não é válido",
-				"characters": "Senha deve conter no mínimo {{numChar}} caracteres",
-				"pass-rules": "Sua senha deve conter ao menos uma letra maiúscula, uma letra minúscula, um número e um caractere especial (@€#$+...) ",
-				"at-least-one-contact": "Informe um email ou número de telefone",
-				"match": "{{name}} precisa coincidir"
-			},
-			"address-form": {
-				"search": "Procure o endereço aqui",
-				"search-note": "Você pode começar pesquisando o indereço aqui, ou então preencher os campos abaixo",
-				"street": "Rua",
-				"number": "Nº",
-				"hood": "Localidade / bairro",
-				"more-info": "Complemento",
-				"city": "Cidade",
-				"state": "Estado",
-				"zip": "Cep",
-				"country": "País",
-				"more-info-bttn": "Adicione um complemento"
-			},
-			"add-patient": {
-				"name": "Adicionar paciente"
-			},
-			"contacts-form": {
-				"contact-via": "Entrar em contato via {{method}}?",
-				"contact-via-same": "O número é o mesmo para o Whatsapp?"
-			},
-			"preferred-contact": {
-				"coming-soon": "Integração em breve — cole o link da sessão por enquanto",
-				"label": "Plataforma preferida para sessão",
-				"value-phone": "Número de telefone",
-				"value-url": "Link da reunião (URL)",
-				"type": {
-					"google_meet": "Google Meet",
-					"phone": "Ligação",
-					"whatsapp": "WhatsApp",
-					"zoom": "Zoom"
-				}
-			},
-			"consent": {
-				"terms": "Eu concordo com a <privacyLink>Política de Privacidade</privacyLink> e os <termsLink>Termos de Uso</termsLink>",
-				"marketing": "Eu concordo em receber <marketingLink>comunicações de marketing.</marketingLink>",
-				"info": "Ao continuar, você automaticamente aceita as <privacyLink>Política de Privacidade</privacyLink> e os <termsLink>Termos de Uso</termsLink> da Psycron."
-			}
-		},
-		"input": {
-			"phone-input": {
-				"select-label": "País",
-				"phone-num-label": "Número de {{registerName}}",
-				"phone-number-guide": "Por favor, forneça seu número de telefone com o código da cidade",
-				"invalid": "Número de telefone inválido",
-				"valid": "Número de telefone válido"
-			},
-			"text": {
-				"first-name": "Seu primeiro nome",
-				"last-name": "Seu último sobrenome",
-				"email": "Seu e-mail"
-			}
-		},
-		"navbar": {
-			"action-center": "Central de ações",
-			"dashboard": "Painel",
-			"conflicts": "Conflitos",
-			"notifications": "Notificações",
-			"user-settings": "Configurações",
-			"test": "Testes"
-		},
-		"user-details": {
-			"edit": "Editar detalhes",
-			"edit-contacts": "Editar contatos",
-			"edit-success": "Dados atualizados",
-			"add-contacts": "Adicione seu {{contactValue}}",
-			"change": "Alterar {{name}}",
-			"save": "Salvar",
-			"address-not-found": "Nenhum endereço cadastrado. Adicione suas informações.",
-			"detail-not-found": "{{detail}} não cadastrado ainda",
-			"no-changes": "Selecione uma secção para editar antes de guardar.",
-			"delete": {
-				"title": "Excluir conta",
-				"description": "Sua conta será desativada e seus dados ficarão anônimos dentro de 30 dias. Você pode entrar em contato com nosso suporte técnico para mais detalhes.",
-				"confirmation": "Excluir"
-			},
-			"section": {
-				"title": {
-					"account": "Conta",
-					"clinic": "Endereço do Consultório",
-					"contact": "Contatos",
-					"patients": "Pacientes",
-					"security": "Segurança & Privacidade",
-					"subscription": "Assinatura"
-				},
-				"local": "Email e Senha",
-				"security": {
-					"google-mgmt": "Gerenciada por Google - A sua senha é seguramente guardada através do sistema de autênticação da Google e nós não tem acesso.",
-					"accepted": "Ao criar sua conta na Psycron, você concordou com nossos <privacyLink>Política de Privacidade</privacyLink> e <termsLink>Termos de Uso</termsLink>.",
-					"accepted-info": "Você pode revisar esses documentos a qualquer momento.",
-					"marketing": "Receber comunicações de marketing e news"
-				},
-				"clinic": {
-					"add-address": "Adicionar endereço do consultório",
-					"address-label": "Endereço",
-					"edit-address": "Editar endereço",
-					"title-empty": "Adicione o endereço do seu consultório para que os pacientes o recebam na confirmação de consulta."
-				},
-				"contact": {
-					"title-empty": "Adicione seu número para receber notificações em SMS ou WhatsApp."
-				}
-			}
-		},
-		"dashboard": {
-			"card": {
-				"delay-notification": "Pausar o cronômetro vai atrasar todos os seus compromissos de hoje pelo tempo da pausa.",
-				"delay-confirmation": "Você tem certeza que quer pausar o cronômetro?",
-				"pause": "Pausar cronômetro",
-				"session-progress": "Progresso da sessão:"
-			},
-			"availability-card": {
-				"first-availability": "Crie sua disponibilidade de agenda aqui"
-			}
-		},
-		"appointments": {
-			"card-title": "Consultas do dia",
-			"manager": "Gerenciador de consultas"
-		},
-		"patients-table": {
-			"name": "Nome do paciente",
-			"next-session": "Próxima sessão",
-			"payment-status": "Status de pagamento",
-			"sessions-month": "Sessões por mês",
-			"value": "Valor por sessão",
-			"discount": "Desconto?",
-			"discount-val": "Valor do desconto",
-			"amount": "Valor total",
-			"currency": "Moeda",
-			"latest-payment": "Último pagamento",
-			"manage": "Veja paciente"
-		},
-		"progress": {
-			"received": "Você já recebeu {{progress}}% dos seus pagamentos 🥳",
-			"missing": "Faltam {{progress}}% dos seus pagamentos",
-			"not-received": "Você não recebeu nenhum pagamento ainda",
-			"received-all": "Você recebeu 100% dos seus pagamentos para este período 🥳 😎"
-		},
-		"c2-action": {
-			"join-waitlist": "Junte-se à nossa <strong>lista de espera</strong> para simplificar sua prática de terapia e focar mais em seus pacientes.",
-			"email": "Seu email",
-			"join-now": "Inscreva-se"
-		},
-		"hero": {
-			"heading": "Transforme sua prática de terapia com essa solução completa",
-			"helper": "Gerencie facilmente seus agendamentos, pagamentos, prontuários, faturamento e muito mais."
-		},
-		"header": {
-			"join": "Inscreva-se",
-			"benefits": "Utilidades",
-			"contact": "Contato",
-			"language": "Idioma"
-		},
-		"link": {
-			"navigate": {
-				"back": "Voltar",
-				"next": "Prosseguir",
-				"finish": "Finalizar",
-				"confirm": "Confirmar",
-				"cancel": "Cancelar"
-			}
-		},
-		"footer": {
-			"contact": "Quer entrar em contato? <a>Você pode nos encontrar aqui</a>",
-			"find-me": "Você pode nos encontrar aqui",
-			"credit": {
-				"illustration": "Ilustrações por <owner>Icons 8</owner> de <page>Ouch!</page>"
-			}
-		},
-		"share-button": {
-			"alert": {
-				"success": "Compartilhado com sucesso!",
-				"success-copy": "Link copiado com sucesso!",
-				"error": "Erro ao compartilhar, tente novamente mais tarde.",
-				"error-copy": "Erro ao copiar o link, tente novamente mais tarde."
-			},
-			"tooltip-tile": "Compartilhar com {{with}}",
-			"share-with-name": "com {{name}}",
-			"share-with-patients": "com seus pacientes",
-			"share-infos": {
-				"availability": {
-					"title": "{{therapistName}} compartilhou com você a disponibilidade",
-					"text": "Entre aqui para agendar o seu horário"
-				}
-			}
-		},
-		"agenda": {
-			"modal": "Você está marcando a sua consulta para {{appointment}}",
-			"your-details": "Seus detalhes",
-			"next-week": "Próxima semana",
-			"previous-week": "Semana anterior",
-			"today": "Hoje",
-			"Month": "Mês",
-			"appointment-details": {
-				"title": "Detalhes da sessão",
-				"mailto-subject": "🔔 Sobre sua consulta com {{therapistName}} 🔔",
-				"whatsapp-subject": "Olá, tudo bem? Estou enviando essa mensagem sobre sua consulta comigo, {{therapisName}}",
-				"next-sessions": "Outras sessões",
-				"edit-patient-details": "Alterar detalhes do paciente",
-				"edit-patient-appointment": "Alterar sessão",
-				"edit-availability": "Alterar disponibilidade",
-				"text-status": "Esse horário está {{status}}"
-			},
-			"edit-appointment": {
-				"title": "Editar consulta",
-				"confirmation": "Tem certeza de que quer reagendar esta consulta?"
-			},
-			"cancel-appointment": {
-				"title": "Cancelar consulta(s)",
-				"select-all": "{{select}} Todas",
-				"global-reason": "Por favor, selecione um motivo geral:",
-				"confirmation": "Você tem certeza que deseja cancelar todas as consultas?",
-				"review": "Revise as datas que você selecionou"
-			},
-			"book-appointment": {
-				"title": "Agendando sua consulta"
-			}
-		}
-	},
-	"page": {
-		"landing": {
-			"seo": {
-				"title": "Psycron - Aplicativo Inovador de Gestão para Terapeutas",
-				"description": "Transforme sua prática de terapia com essa solução completa. Com esse app você pode gerenciar facilmente seus agendamentos, pagamentos, prontuários, faturamento e muito mais.",
-				"ogTitle": "Psycron - Aplicativo Inovador de Gestão para Terapeutas",
-				"ogDescription": "Transforme sua prática de terapia com essa solução completa. Com esse app você pode gerenciar facilmente seus agendamentos, pagamentos, prontuários, faturamento e muito mais."
-			},
-			"values": {
-				"all-in-one": "Solução completa",
-				"text": "Do agendamento de consultas ao processamento de pagamentos, manutenção de prontuários e faturamento, ajudamos você nas tarefas diárias para que tenha muito mais tempo para cuidar dos seus pacientes. Nossa solução pode transformar a gestão da sua prática, integrando tudo em uma única plataforma intuitiva.",
-				"text-focus": "Agora você pode focar no que realmente importa e deixar o resto com a gente."
-			},
-			"benefits": {
-				"increased-efficiency": {
-					"name": "Mais eficiência",
-					"description": "Perca menos tempo em tarefas administrativas. Automatize lembretes, agendamento de consultas e gerencie seus prontuários de forma integrada. Foque mais nos seus pacientes, não nos processos"
-				},
-				"better-patient-management": {
-					"name": "Maior gestão de pacientes",
-					"description": "Acompanhe facilmente o histórico e as consultas dos pacientes. Auxilie seu atendimento com registros organizados e atualizados."
-				},
-				"reduced-administrative-burden": {
-					"name": "Elimine a carga administrativa",
-					"description": "Simplificamos o fluxo do trabalho para você"
-				},
-				"enhanced-financial-control": {
-					"name": "Maior controle financeiro",
-					"description": "Assuma o controle das suas finanças com faturamento seguro e eficiente"
-				}
-			},
-			"ct-action": {
-				"heading": "Você quer revolucionar a sua prática de trabalho?",
-				"join-waitlist": "<strong>Junte-se à nossa lista de espera</strong> hoje e <strong>e se antecipe</strong> para <strong>experimentar</strong> uma gestão de prática terapêutica <strong>inovadora</strong>. <strong>Desbloqueie</strong> <strong>novos níveis</strong> de <strong>eficiência</strong> e <strong>cuidado ao paciente</strong> com <strong>um produto feito para você</strong>."
-			}
-		},
-		"not-found": {
-			"title": "Oops, algo deu errado!",
-			"sub-title": "Mas relaxa que já estamos correndo atrás disso!",
-			"note": "Pois é... prometo que estamos :)"
-		},
-		"unsubscribe": {
-			"title": "Até logo, {{email}}!",
-			"body-text": "Agradecemos por fazer parte da nossa jornada. Embora a gente fique triste em ver você partir, entendemos completamente sua decisão. Continuaremos trabalhando duro para oferecer o melhor que podemos e, lembre-se, estaremos sempre com as portas abertas para você, sempre que quiser voltar.",
-			"see-you": "Esperamos você de volta logo logo! ❤️",
-			"confirm": "Clique aqui para completar"
-		},
-		"reset-password": {
-			"reset": "Resetar senha",
-			"change-password": "Alterar senha",
-			"password-rule": "A sua senha deve conter no mínimo:",
-			"password-example": "Exemplo:",
-			"item-letter": "Uma letra {{rule}}",
-			"item-number": "Um número {{rule}}",
-			"item-special": "Um caractere especial {{rule}}",
-			"item-minimum": "9 dígitos",
-			"current-password": "Senha atual"
-		},
-		"availability": {
-			"wizard": {
-				"wizard-items": {
-					"intro": {
-						"label": "Introdução",
-						"title": "Vamos configurar sua disponibilidade. Podemos começar?",
-						"alert": "Você vai precisar finalizar a sua configuração de disponibilidade depois"
-					},
-					"weekdays": {
-						"label": "Escolha os dias da semana",
-						"title": "Por favor nos informe os dias no qual você costuma atender os seus pacientes."
-					},
-					"duration": {
-						"label": "Duração da consulta",
-						"title": "Por favor nos informe quanto tempo dura a sua consulta."
-					},
-					"week-slots": {
-						"label": "Horários em uma semana"
-					}
-				},
-				"intro": {
-					"options": {
-						"proceed": "Sim!",
-						"finish-later": "Deixar para depois"
-					}
-				},
-				"availability-days": {
-					"days": {
-						"mon": "Segunda",
-						"tue": "Terça",
-						"wed": "Quarta",
-						"thu": "Quinta",
-						"fri": "Sexta"
-					},
-					"options": {
-						"all": "Incluir todos os dias",
-						"weekends": "Excluir fins de semana",
-						"specific": "Selecionar dias específicos"
-					}
-				},
-				"duration": {
-					"label": "Duração da consulta",
-					"note": "Caso você tenha mais de um tipo de consulta, nos informe a duração que você mais utiliza. Você poderá alterar isso no futuro, sem maiores problemas!"
-				},
-				"hours": {
-					"no-session": "Nenhuma sessão disponível"
-				},
-				"modal-title": "Repita sua disponibilidade semanal",
-				"modal-info": "Por favor, escolha uma das opções abaixo. Se você selecionar 'semanal,' sua disponibilidade será repetida até o final do mês. Se escolher 'mensal,' ela será repetida até o final do ano.",
-				"complete": "Sessão de disponibilidade concluída!"
-			},
-			"agenda": {
-				"status": {
-					"available": "Disponível",
-					"unavailable": "Indisponível",
-					"booked": "Reservado",
-					"empty": "Vazio",
-					"blocked": "Bloqueado",
-					"cancelled": "Cancelado",
-					"onhold": "Em espera"
-				},
-				"therapist-edit-modal": {
-					"title": "Altere sua disponibilidade"
-				}
-			}
-		},
-		"book-appointment": {
-			"title": "Horários Disponíveis de {{therapisName}}",
-			"description": "Agende facilmente sua consulta. Veja os horários disponíveis e escolha o melhor momento para marcar sua sessão de forma rápida e prática.",
-			"confirmation-should-replicate": "Deseja usar esse dia como sua escolha padrão para futuras consultas?",
-			"recurrence-pattern": {
-				"month": "Toda semana até o fim do mês",
-				"year": "Toda semana até o fim do ano",
-				"single": "Apenas esta consulta",
-				"all-future": "Todas as próximas consultas"
-			},
-			"confirm-edit": "Por favor, confirme que deseja alterar sua consulta de {{previousDate}} para:",
-			"edit-recurrence-title": "Você deseja alterar apenas esta consulta ou todas as próximas?",
-			"edit-appointment-title": "Você está alterando a sua consulta do dia {{formattedDate}} às {{startTime}}."
-		},
-		"booking-confirmation": {
-			"title": "Sua consulta com <strong>{{therapistName}}</strong> está confirmada 🎉",
-			"title-plain": "Sua consulta com {{therapistName}} está confirmada 🎉",
-			"subtitle": "Estamos ansiosos para te ver em breve!",
-			"whats-next": "<strong>{{therapistName}}</strong> entrará em contato com mais detalhes quando estiver perto da consulta",
-			"advise": "Pedimos para que você esteja disponível alguns minutos antes da consula começar",
-			"reschedule": "Você pode remarcar a sua consulta até 1 dia de antecedência.",
-			"cancel": "Para remarcar ou cancelar, por favor <strong>clique aqui</strong>",
-			"help": "Caso tenha alguma dúvida ou precise de ajuda, entre em contato conosco via ",
-			"thanks": "Estamos aqui para te apoiar. Aguardamos sua consulta!",
-			"cancel-or-edit": {
-				"title": "Deseja fazer alguma mudança?",
-				"sub": "Você pode reagendar ou cancelar esta sessão agora.",
-				"appointment-info": "Sua consulta no dia {{date}} às {{startTime}}",
-				"donwload-ics": "Adicione ao seu calendário 📅"
-			},
-			"no-appointments-title": "Você ainda não tem nenhuma consulta marcada",
-			"no-appointments-link": "Clique aqui para agendar suas consultas"
-		},
-		"appointment-list": {
-			"date": "Data",
-			"starts": "Começa",
-			"ends": "Termina",
-			"modal": {
-				"title": "Tem certeza que você deseja {{action}} esta sessão?"
-			},
-			"description": "Aqui você poderá configurar seus horários para consultas e compartilhá-los com seus pacientes. Vamos guiar você por um processo simples para definir seus horários de atendimento, de maneira que eles sejam replicados ao longo das semanas ou até o final do ano. O processo é flexível e você poderá ajustar as informações a qualquer momento no futuro.",
-			"guide": {
-				"step1": {
-					"title": "Decida se quer começar agora ou depois",
-					"description": "Se preferir, você pode voltar a esta etapa mais tarde. Sabemos que nem sempre é possível configurar tudo de imediato, então você terá a opção de retomar o processo no momento que for mais conveniente."
-				},
-				"step2": {
-					"title": "Defina seus dias de folga",
-					"description": "Nos informe quais dias da semana você não estará disponível para consultas. Esses dias ficarão bloqueados, mas poderão ser alterados no futuro, se necessário."
-				},
-				"step3": {
-					"title": "Duração da sessão",
-					"description": "Informe a duração média das suas consultas. Caso ofereça mais de um tipo de sessão, vamos definir um padrão agora e você poderá ajustar os tempos conforme o paciente e o tipo de terapia."
-				},
-				"step4": {
-					"title": "Escolha seus horários",
-					"description": "De maneira visual e interativa, você poderá selecionar os horários em que estará disponível para consultas ao longo da semana. É um processo flexível: se suas preferências mudarem, você pode ajustar seus horários a qualquer momento."
-				}
-			},
-			"session-past": "Consulta passada"
-		},
-		"cancel-appointment": {
-			"title": "Cancelamento de Consulta(s)",
-			"sub-title": "Por favor selecione a(s) consulta(s) que você quer cancelar"
-		},
-		"edit-appointment": {
-			"title": "Altere a Consulta",
-			"sub-title": "Por favor selecione a data que deseja alterar"
-		},
-		"add-patient": {
-			"title": "Adicione um Novo Paciente",
-			"sub-title": "Preencha o formulário abaixo com os detalhes da pessoa"
-		},
-		"dashboard": {
-			"title": "Dashboard",
-			"greeting": {
-				"headline": "Olá, {{name}}!",
-				"band": {
-					"morning": "Bom dia",
-					"afternoon": "Boa tarde",
-					"evening": "Boa noite"
-				}
-			},
-			"tiles": {
-				"action-center": "Central de ações",
-				"schedule": "Agenda de hoje",
-				"greeting": "Saudação",
-				"jupiter-insights": "Insights da Júpiter",
-				"notifications": "Notificações",
-				"quick-actions": "Ações rápidas",
-				"active-patients": "Pacientes ativos",
-				"billing-readiness": "Cobrança configurada",
-				"revenue": "Receita estimada",
-				"session-analytics": "Análise de sessões",
-				"pending-tasks": "Tarefas pendentes",
-				"recent-patients": "Pacientes recentes"
-			},
-			"tile": {
-				"close": "Fechar",
-				"hide": "Ocultar bloco",
-				"layout-column": "Usar layout em coluna",
-				"layout-column-aria": "Alternar bloco para layout em coluna",
-				"layout-row": "Usar layout em linha",
-				"layout-row-aria": "Alternar bloco para layout em linha",
-				"read-more": "Ler mais",
-				"resize-down": "Reduzir altura",
-				"resize-narrow": "Estreitar",
-				"resize-narrow-aria": "Tornar o bloco mais estreito",
-				"resize-down-aria": "Reduzir altura do bloco",
-				"resize-up": "Aumentar altura",
-				"resize-wide": "Alargar",
-				"resize-wide-aria": "Tornar o bloco mais largo",
-				"resize-up-aria": "Aumentar altura do bloco",
-				"show": "Mostrar bloco",
-				"drag": "Arrastar para reordenar",
-				"drag-aria": "Arrastar tile para reordenar"
-			},
-			"customize": {
-				"open": "Personalizar",
-				"done": "Concluído",
-				"hint": "Arraste os blocos para reordenar · clique no ícone de olho para ocultar",
-				"organize": "Organizar",
-				"reset": "Redefinir layout"
-			},
-			"widgets": {
-				"schedule": {
-					"title": "Hoje",
-					"title-week": "Semana",
-					"title-label": "Agenda de hoje",
-					"title-week-label": "Agenda desta semana",
-					"range-aria-label": "Escolher período da agenda",
-					"count": "{{count}} sessões",
-					"empty": "Nenhuma sessão agendada para hoje",
-					"unknown-patient": "Paciente desconhecido",
-					"sessions-today": "sessões hoje",
-					"sessions-week": "sessões esta semana",
-					"view-week": "Ver semana",
-					"online": "Online",
-					"in-person": "Presencial",
-					"min": "min",
-					"status": {
-						"live": "AO VIVO",
-						"done": "Concluído",
-						"confirmed": "Confirmado",
-						"pending": "Pendente"
-					},
-					"info": {
-						"title": "Agenda de hoje",
-						"description": "Mostra suas sessões agendadas para hoje e esta semana, com rastreamento de status em tempo real.",
-						"future": "Notas de preparação por paciente, alertas de conflito inteligentes e sugestões de reagendamento em um toque."
-					}
-				},
-				"jupiter-insights": {
-					"aria-label": "Carrossel de insights da Júpiter",
-					"dismiss": "Dispensar insight",
-					"empty": "Nenhum insight disponível no momento",
-					"action-availability": "Ver disponibilidade",
-					"title-schedule": "Sessões de hoje",
-					"text-schedule": "Você tem {{count}} sessão(ões) agendada(s) hoje. Continue assim!",
-					"title-patients": "Pacientes ativos",
-					"text-patients": "Você tem atualmente {{count}} paciente(s) ativo(s) na sua lista.",
-					"subtitle": "Co-piloto de IA · aprendendo seus padrões",
-					"default-category": "Cuidado ao Paciente",
-					"category-daily-briefing": "Resumo do dia",
-					"category-operations": "Operações",
-					"category-patient-care": "Cuidado ao Paciente",
-					"category-insights": "Insights",
-					"action-send-message": "Enviar mensagem",
-					"action-view-profile": "Ver perfil",
-					"mic": "Entrada de voz",
-					"text-setup-availability": "Configure sua agenda com a Júpiter para começar a receber agendamentos.",
-					"action-setup-availability": "Configurar agora",
-					"text-no-patients-yet": "Tudo pronto — compartilhe seu link de agendamento com seus primeiros pacientes.",
-					"category-setup": "Configuração",
-					"category-growth": "Crescimento",
-					"category-schedule": "Agenda",
-					"text-session-none-today": "Nenhuma sessão hoje — um bom momento para revisar suas anotações.",
-					"text-session-count-today": "Você tem {{count}} sessão(ões) hoje. Continue assim!",
-					"text-whatsapp-reminders": "Ative os lembretes por WhatsApp para reduzir faltas em poucos toques.",
-					"action-set-up-reminders": "Configurar lembretes",
-					"text-busy-day": "{{day}} parece ser seu dia mais movimentado desta semana. Mantenha o ritmo!",
-					"action-view-schedule": "Ver agenda",
-					"text-week-cancellations": "{{count}} sessão(ões) cancelada(s) esta semana. Considere entrar em contato para reagendar.",
-					"text-patient-milestone": "Você chegou a {{count}} pacientes ativos. Grande conquista!",
-					"text-low-week-volume": "Você tem {{count}} sessão(ões) esta semana. Abrir mais horários pode ajudar seu crescimento.",
-					"text-billing-readiness-incomplete": "{{missing}} paciente(s) ainda precisam do valor das sessões para que futuros pagamentos se encaixem no seu fluxo.",
-					"text-billing-readiness-ready": "Os dados de cobrança dos pacientes estão prontos para futuros fluxos de pagamento e cobrança.",
-					"action-review-patients": "Revisar pacientes",
-					"action-view-patients": "Ver pacientes",
-					"text-session-none-today-week": "Nenhuma sessão hoje — você tem {{count}} sessão(ões) esta semana. Veja sua agenda.",
-					"text-missed-rebooking": "{{name}} faltou à última sessão e não reagendou. Um contato pode ajudar.",
-					"text-dashboard-summary-fallback": "A Júpiter está lendo seu painel. Você tem {{count}} sessão(ões) agendada(s) esta semana.",
-					"info": {
-						"title": "Insights da Júpiter",
-						"description": "Observações geradas por IA sobre sua prática com base em agenda, pacientes e cobrança — personalizadas a cada sessão.",
-						"future": "Recomendações preditivas de agenda, alertas de risco por paciente e orientação clínica proativa adaptada à sua especialidade."
-					}
-				},
-				"quick-actions": {
-					"title": "Ações Rápidas",
-					"descriptions": {
-						"add-patient": "Criar perfil de paciente",
-						"availability-settings": "Horários, fuso horário",
-						"fix-reminders-count": "{{count}} com falha ou em fila",
-						"fix-reminders-setup": "Configurações de lembrete",
-						"follow-up-cancellations": "{{count}} item(ns) de recuperação",
-						"patients": "{{count}} ativos",
-						"setup-availability": "Criar horários de atendimento",
-						"view-week": "{{count}} sessões"
-					},
-					"actions": {
-						"new-session": "Nova sessão",
-						"new-session-aria": "Abrir disponibilidade para nova sessão",
-						"patients": "Meus pacientes",
-						"patients-aria": "Ir para lista de pacientes",
-						"add-patient": "Adicionar paciente",
-						"add-patient-aria": "Adicionar novo paciente",
-						"fix-reminders": "Ajustar lembretes",
-						"follow-up-cancellations": "Acompanhar cancelamentos",
-						"notifications": "Notificações",
-						"notifications-aria": "Ver notificações",
-						"setup-availability": "Configurar agenda",
-						"view-week": "Ver semana",
-						"availability-settings": "Configurações de agenda"
-					},
-					"info": {
-						"title": "Ações rápidas",
-						"description": "Atalhos para as ações mais relevantes com base no estado atual da sua prática. O Psycron escolhe o que importa mais agora.",
-						"future": "Sugestões de ações totalmente contextuais com a Júpiter que se adaptam à sua semana, seus pacientes e seus hábitos."
-					}
-				},
-				"active-patients": {
-					"label": "Pacientes ativos",
-					"title": "Últimos pacientes",
-					"empty": "Nenhum paciente adicionado ainda"
-				},
-				"billing-readiness": {
-					"label": "Cobrança configurada",
-					"status": {
-						"empty": "Prepare as futuras ferramentas de pagamento adicionando pacientes primeiro.",
-						"partial": "{{configured}} de {{total}} pacientes prontos para pagamentos futuros · {{missing}} pendentes",
-						"ready": "Configuração pronta para pagamentos futuros"
-					},
-					"details": "Adicione o valor das sessões agora para que a Psycron crie fluxos de pagamento e cobrança alinhados à forma como sua prática já funciona.",
-					"donut-meta": "{{configured}}/{{total}} prontos",
-					"status-chip": {
-						"empty": "Ação necessária",
-						"partial": "Em progresso",
-						"ready": "Pronto"
-					},
-					"teaser": {
-						"title": "Prepare pagamentos futuros",
-						"subtitle": "Registre os valores das sessões agora para que as futuras ferramentas de pagamento se encaixem no seu fluxo desde o primeiro dia.",
-						"coming-soon": "Cobrança e pagamentos virão depois; por enquanto, isso só mantém os dados de cobrança dos pacientes prontos."
-					},
-					"info": {
-						"title": "Prontidão de cobrança",
-						"description": "Adicione o valor de cada sessão do paciente agora para que a Psycron possa criar fluxos de pagamento e faturamento alinhados à forma como sua prática já funciona.",
-						"future": "Em seguida, a Psycron avançará para pagamentos criando um sistema automatizado adaptado à forma como você cobra cada paciente."
-					}
-				},
-				"revenue": {
-					"title": "Receita",
-					"title-with-month": "Receita · {{month}}",
-					"estimate-chip": "Est.",
-					"completed": "Concluídas",
-					"configured": "Cobrança",
-					"sessions": "{{count}} sessão(ões)",
-					"patients-ready": "{{configured}} prontos · {{missing}} pendentes",
-					"info": {
-						"title": "Estimativa de receita",
-						"description": "Estima seus ganhos mensais com base nas configurações de cobrança definidas para pacientes ativos. Atualizado em tempo real.",
-						"future": "A Psycron usará esses padrões de receita para criar um sistema automatizado de pagamentos adaptado à sua prática, com faturas, cobrança e acompanhamento de pagamentos integrados ao seu fluxo."
-					}
-				},
-				"notifications": {
-					"title": "Notificações · 24h",
-					"window": "Últimas 24h",
-					"sent": "Enviadas",
-					"failed": "Falharam",
-					"queued": "Em fila",
-					"view-feed": "Ver feed",
-					"info": {
-						"title": "Notificações",
-						"description": "Mostra quantos lembretes e confirmações de consultas foram entregues aos seus pacientes nas últimas 24 horas.",
-						"future": "Desempenho de canal ao longo do tempo, lógica de reenvio inteligente e alertas de falha antes que os pacientes percam sessões."
-					}
-				},
-				"action-center": {
-					"title": "Central de ações",
-					"count-chip": "{{count}} precisa de você",
-					"count-chip_other": "{{count}} precisam de você",
-					"empty": "Nenhum alerta operacional agora.",
-					"item-count": "{{count}} item(ns)",
-					"summary-title": "{{count}} item precisa de atenção",
-					"summary-title_other": "{{count}} itens precisam de atenção",
-					"summary-body": "Um resumo discreto do trabalho operacional em aberto. As ações ficam no espaço dedicado.",
-					"breakdown-label": "Resumo da central de ações",
-					"view-all": "Abrir central de ações",
-					"view-all-meta": "Conflitos e fila de recuperação",
-					"items": {
-						"notification-failed": "Notificação falhou",
-						"patient-duplicate": "Paciente duplicado",
-						"recovery-needed": "Recuperação necessária",
-						"schedule-conflict": "Conflito na agenda"
-					},
-					"info": {
-						"title": "Central de ações",
-						"description": "Sinaliza problemas que precisam de resolução — conflitos de agenda, falhas de entrega de notificações e cancelamentos aguardando acompanhamento.",
-						"future": "Propostas automáticas de resolução de conflitos, fluxos de recuperação com um clique e filas de problemas ordenadas por prioridade."
-					}
-				},
-				"session-analytics": {
-					"title": "Análise de sessões",
-					"range-aria-label": "Escolher período da análise",
-					"completion-rate": "Taxa de conclusão",
-					"blocked": "Bloqueios admin",
-					"blocked-hours": "{{hours}}h bloqueadas",
-					"cancelled": "Canceladas",
-					"chart-aria-label": "Gráfico de barras empilhadas com sessões por dia",
-					"completed": "Concluídas",
-					"insight-down": "Taxa de conclusão caiu {{delta}}% vs {{period}} anterior — vale acompanhar os cancelamentos.",
-					"insight-empty": "Ainda não há sessões encerradas — a comparação começa quando houver dados.",
-					"insight-flat": "Taxa de conclusão estável vs {{period}} anterior — mantenha o ritmo dos lembretes.",
-					"insight-source": "Júpiter",
-					"insight-summary": "{{completed}} de {{concluded}} sessões encerradas foram concluídas.",
-					"insight-up": "Taxa de conclusão subiu {{delta}}% vs {{period}} anterior — os lembretes estão funcionando.",
-					"legend": {
-						"blocked": "Bloqueios admin",
-						"cancelled": "Canceladas",
-						"completed": "Concluídas",
-						"upcoming": "Próximas"
-					},
-					"period": {
-						"month": "mês",
-						"week": "semana"
-					},
-					"sessions": "sessões",
-					"upcoming": "Próximas",
-					"view-month": "Mês",
-					"view-week": "Semana",
-					"info": {
-						"title": "Análise de sessões",
-						"description": "Acompanha sua taxa de conclusão de sessões, cancelamentos e volume ao longo do tempo — a saúde da sua prática em tempo real.",
-						"future": "Análise de tendências, previsão de faltas e benchmarks de ritmo comparados a práticas semelhantes."
-					}
-				},
-				"pending-tasks": {
-					"title": "Tarefas Pendentes",
-					"cancellation-followups": "Acompanhar cancelamentos",
-					"descriptions": {
-						"cancellation-followups": "{{count}} precisam de recuperação",
-						"missing-billing": "{{count}} paciente(s) para configurar",
-						"missing-contact": "{{count}} paciente(s) para atualizar",
-						"reminder-delivery": "{{count}} exigem revisão",
-						"setup-availability": "Obrigatório antes das reservas"
-					},
-					"empty": "Nenhuma tarefa pendente no momento.",
-					"missing-billing": "Pacientes sem cobrança",
-					"missing-contact": "Pacientes sem contato",
-					"reminder-delivery": "Problemas nos lembretes",
-					"setup-availability": "Concluir agenda",
-					"empty-heading": "Tudo certo",
-					"info": {
-						"title": "Tarefas pendentes",
-						"description": "Exibe itens administrativos que precisam de atenção para manter sua prática funcionando — desde cobrança faltante até cancelamentos não resolvidos.",
-						"future": "Pontuação de prioridade, delegação de tarefas para práticas em grupo e sequências de conclusão para manter o ritmo."
-					}
-				},
-				"recent-patients": {
-					"title": "Pacientes Recentes",
-					"activity": {
-						"cancelled": "Sessão cancelada",
-						"created": "Adicionado",
-						"session": "Atividade de sessão",
-						"updated": "Atualizado"
-					},
-					"empty": "Atividades recentes dos pacientes aparecerão aqui.",
-					"view-all": "Todos",
-					"last-note": "última nota",
-					"message-aria": "Enviar mensagem para {{name}}",
-					"info": {
-						"title": "Pacientes recentes",
-						"description": "Destaca os pacientes com atividade mais recente na sua lista, para que você possa retomar rapidamente de onde parou.",
-						"future": "Pontuações de engajamento, mapas de frequência de sessões e alertas proativos quando um paciente some."
-					}
-				},
-				"latest-patients": {
-					"info": {
-						"title": "Últimos pacientes",
-						"description": "Mostra os pacientes adicionados mais recentemente para você nunca perder o controle de novos ingressos e iniciar o onboarding imediatamente.",
-						"future": "Checklists de onboarding automatizados, integração com formulários de admissão e modelos de mensagem de boas-vindas personalizados."
-					}
-				},
-				"info-modal": {
-					"feedback-error": "Não foi possível salvar este feedback. Tente novamente.",
-					"feedback-placeholder": "Compartilhe sua opinião sobre este widget...",
-					"feedback-submit": "Enviar feedback",
-					"feedback-thanks": "Obrigado! Sua opinião ajuda a moldar o Psycron.",
-					"future-heading": "O que vem por aí",
-					"tooltip": "Sobre este widget"
-				}
-			}
-		}
-	},
-	"chat": {
-		"greeting": "Olá! Eu sou a Júpiter, sua assistente para configurar sua agenda de atendimentos. Vamos construir isso juntos, passo a passo 🧘‍♀️! Vamos?",
-		"let-start": "Quais tipos de terapia você oferece?",
-		"system-instruction": "Você é uma assistente gentil que ajuda terapeutas a montar sua agenda passo a passo. Sempre responda com a próxima pergunta e os dados extraídos até o momento. Por exemplo, se a pergunta for sobre reccurencePattern, você deve explicar que weekly significa até o fim do mês e monthly até o fim do ano",
-		"error": "Oops! Não foi possível continuar a conversa. Tente novamente."
-	},
-	"jupiter": {
-		"welcome": {
-			"title-line1": "Eu sou a Júpiter,",
-			"title-line2": "sua Assistente Inteligente",
-			"subtitle": "Vou te ajudar a configurar sua disponibilidade em poucos momentos. Vamos tornar o agendamento simples e rápido.",
-			"cta": "Configurar minha agenda"
-		},
-		"specialty": {
-			"response": "Qual é a sua área de atuação? Use o nome profissional do que você pratica.",
-			"chip-occupational-therapist": "Terapeuta Ocupacional",
-			"chip-nutritionist": "Nutricionista",
-			"chip-other": "Outro",
-			"chip-physiotherapist": "Fisioterapeuta",
-			"chip-psychiatrist": "Psiquiatra",
-			"chip-psychologist": "Psicólogo(a)",
-			"chip-speech-therapist": "Fonoaudiólogo(a)",
-			"continue": "Continuar",
-			"other-placeholder": "Sua especialidade ou título profissional",
-			"acknowledged": "Entendido! Vou configurar tudo levando isso em conta.",
-			"error-rephrase": "Não consegui identificar bem — tente usar o nome profissional do que você pratica.",
-			"error-rejected": "Não consigo configurar agendamentos para isso. Se você tem outra especialidade, adoraria te ajudar a começar."
-		},
-		"calendar-choice": {
-			"msg1": "Olá! Eu sou a Júpiter, sua assistente de agendamento via IA. Estou aqui para te ajudar a configurar sua disponibilidade de forma simples e natural.",
-			"msg2": "Vamos começar configurando sua agenda. Como você prefere?",
-			"chip-google": "Conectar Google Agenda",
-			"chip-manual": "Criar manualmente",
-			"google-already-connected": "Sua Google Agenda já está conectada! Você gostaria de importar sua agenda dela?"
-		},
-		"working-days": {
-			"response": "Ótimo! Em quais dias você costuma atender seus clientes?",
-			"chip-mon": "Seg",
-			"chip-tue": "Ter",
-			"chip-wed": "Qua",
-			"chip-thu": "Qui",
-			"chip-fri": "Sex",
-			"chip-sat": "Sáb",
-			"chip-sun": "Dom",
-			"back": "← Voltar",
-			"continue": "Continuar",
-			"other-placeholder": "Ou digite sua rotina..."
-		},
-		"time-range": {
-			"response": "Perfeito! Qual faixa de horário funciona melhor para você nesses dias?",
-			"chip-1": "09:00 – 17:00",
-			"chip-2": "10:00 – 18:00",
-			"chip-3": "12:00 – 20:00",
-			"chip-custom": "Personalizado",
-			"other-placeholder": "ex: 08:30 – 16:00"
-		},
-		"session-duration": {
-			"response": "Qual a duração de uma sessão? Você pode alterar isso depois.",
-			"chip-45": "45 min",
-			"chip-60": "60 min",
-			"chip-custom": "Personalizado",
-			"other-placeholder": "ex: 90 minutos"
-		},
-		"session-type": {
-			"response": "Como você costuma realizar suas sessões?",
-			"response-with-suggestion": "Como você costuma realizar suas sessões? Tenho uma sugestão com base na sua especialidade — escolha o que funciona melhor para você.",
-			"chip-online": "Apenas online",
-			"chip-in-person": "Apenas presencial",
-			"chip-both": "Online e presencial"
-		},
-		"timezone": {
-			"response": "Quase lá! Vou usar o fuso horário do seu dispositivo para agendar consultas com precisão. Assim, seus clientes sempre vão agendar no horário certo. Tudo bem?",
-			"chip-yes": "Sim",
-			"chip-no": "Não",
-			"follow-up": "Sem problema! Selecione seu fuso horário:",
-			"search-placeholder": "Buscar fuso horário..."
-		},
-		"recurrence-pattern": {
-			"response": "Última pergunta — com qual frequência você quer que sua disponibilidade se repita?",
-			"chip-weekly": "Semanal (até o fim do mês)",
-			"chip-monthly": "Mensal (até o fim do ano)",
-			"summary-weekly": "Entendido! Seus horários vão se repetir toda semana até o fim deste mês. Você pode estender a qualquer momento pelo painel.",
-			"summary-monthly": "Perfeito! Sua disponibilidade vai se repetir mensalmente até o fim do ano — cobrindo todo o seu calendário anual.",
-			"value-weekly": "Semanal (até o fim do mês)",
-			"value-monthly": "Mensal (até o fim do ano)"
-		},
-		"preview": {
-			"title": "Resumo da sua Disponibilidade",
-			"label-days": "Dias de atendimento:",
-			"label-hours": "Horário:",
-			"label-duration": "Duração:",
-			"label-recurrence": "Repetição:",
-			"label-session-type": "Tipo de sessão:",
-			"label-timezone": "Fuso horário:",
-			"footer": "Você pode editar sua disponibilidade a qualquer momento no painel.",
-			"cta": "Publicar Disponibilidade",
-			"loading": "Publicando...",
-			"reset": "Recomeçar"
-		},
-		"post-publish": {
-			"page-title": "Disponibilidade",
-			"page-subtitle": "Gerencie sua disponibilidade e preferências de agendamento",
-			"success-toast": "Sua disponibilidade está ativa. Seus clientes já podem agendar sessões com você.",
-			"welcome-toast": "Bem-vindo ao Psycron!",
-			"tip-title": "Dica da Júpiter",
-			"tip-text": "Sua disponibilidade está ótima. Adicionar uma política de cancelamento ajuda a reduzir faltas e define expectativas claras com seus clientes.",
-			"tip-cta": "Configurar política de cancelamento",
-			"status-active-hours": "Horas ativas",
-			"status-bookings": "Agendamentos futuros",
-			"status-this-week": "Esta semana",
-			"status-booked-label": "{{percent}}% Agendado",
-			"checklist-title": "Complete sua disponibilidade",
-			"checklist-subtitle": "Melhore sua configuração de agendamento para uma experiência melhor",
-			"checklist-session-types": "Definir tipos de sessão",
-			"checklist-session-types-desc": "Crie diferentes tipos e durações de consultas",
-			"checklist-price": "Adicionar preço da sessão",
-			"checklist-price-desc": "Defina seus valores e condições de pagamento",
-			"checklist-price-badge": "Recomendado",
-			"checklist-buffer": "Adicionar intervalo entre sessões",
-			"checklist-buffer-desc": "Defina um tempo entre consultas para preparação",
-			"checklist-cancel-policy": "Configurar política de cancelamento",
-			"checklist-cancel-desc": "Defina como clientes podem cancelar ou remarcar",
-			"checklist-calendar-sync": "Sincronizar com sua agenda existente",
-			"checklist-calendar-desc": "Conecte sua agenda para evitar conflitos",
-			"checklist-recurrence": "Definir estilo de recorrência",
-			"checklist-recurrence-desc": "Escolha como sua agenda é gerada e gerenciada",
-			"checklist-specialty": "Adicionar sua especialidade",
-			"checklist-specialty-desc": "Informe os pacientes sobre sua área de atuação",
-			"help-title": "Precisa de ajuda?",
-			"help-text": "A Júpiter pode te ajudar a completar sua configuração",
-			"help-cta": "Falar com a Júpiter",
-			"banner-dismiss": "Fechar",
-			"buffer-drawer-desc": "O tempo de intervalo adiciona uma pausa entre as sessões para que possa se preparar, fazer anotações ou simplesmente respirar entre os atendimentos.",
-			"buffer-drawer-title": "Tempo de intervalo",
-			"buffer-custom-input-helper": "Escolha o intervalo que fizer mais sentido entre as sessões.",
-			"buffer-impact-day": "Adiciona cerca de {{value}} na sua agenda diária.",
-			"buffer-impact-empty": "Vamos estimar o impacto assim que existirem sessões futuras disponíveis.",
-			"buffer-impact-hours-value": "{{hours}}h",
-			"buffer-impact-hours-minutes-value": "{{hours}}h {{minutes}} min",
-			"buffer-impact-minutes-value": "{{minutes}} min",
-			"buffer-impact-title": "Pré-visualização do impacto",
-			"buffer-impact-week": "Adiciona cerca de {{value}} ao longo das suas horas semanais de trabalho.",
-			"buffer-input-label": "Minutos entre sessões",
-			"buffer-jupiter-title": "Recomendação da Júpiter",
-			"buffer-range-helper": "Escolha um intervalo entre 5 e 20 minutos. A Júpiter vai adaptar uma sugestão com base na sua agenda futura.",
-			"buffer-jupiter-empty": "Vamos personalizar isto assim que existirem sessões futuras.",
-			"buffer-jupiter-thinking": "A Júpiter está a analisar a sua agenda futura",
-			"buffer-jupiter-unavailable": "A Júpiter não conseguiu personalizar isto agora. Ainda pode escolher o intervalo manualmente.",
-			"buffer-save": "Salvar",
-			"buffer-save-fail": "Não foi possível salvar o tempo de intervalo. Tente novamente.",
-			"buffer-save-success": "Tempo de intervalo salvo com sucesso.",
-			"buffer-warning-overflow": "{{day}} pode ultrapassar o seu horário de término configurado com este intervalo.",
-			"buffer-warning-soft-weekly": "Isto adiciona um tempo de recuperação perceptível ao longo da semana, o que pode reduzir o stress, mas alongar a sua agenda.",
-			"buffer-warning-strong-weekly": "Isto adiciona um grande volume de tempo de recuperação ao longo da semana e pode aumentar visivelmente a sua carga horária.",
-			"buffer-warning-title": "Aviso de agenda",
-			"checklist-action-configure": "Configurar",
-			"checklist-action-edit": "Editar",
-			"checklist-action-soon": "Em breve",
-			"checklist-action-view": "Ver",
-			"checklist-badge-recommended": "Recomendado",
-			"checklist-duration": "Duração da sessão",
-			"checklist-duration-desc": "Defina a duração de cada consulta",
-			"checklist-progress-label": "{{count}} de {{total}} concluídos",
-			"checklist-session-type": "Tipo de sessão",
-			"checklist-session-type-desc": "Como você conduz suas sessões",
-			"checklist-timezone": "Fuso horário",
-			"checklist-timezone-desc": "Garanta que todas as reservas usem o fuso horário correto",
-			"checklist-working-hours": "Horário de trabalho",
-			"checklist-working-hours-desc": "Seus dias e horários disponíveis para atendimentos",
-			"tip-buffer-time": "Adicionar um intervalo entre sessões ajuda você a se preparar, fazer anotações e evitar atrasos. Apenas 5 minutos já fazem diferença.",
-			"tip-session-address": "Deixe seus pacientes saberem onde encontrá-lo. Adicione o endereço da sua clínica ou consultório para que as sessões presenciais sejam fáceis de localizar."
-		},
-		"google-calendar": {
-			"permissions-intro": "Vamos conectar sua Google Agenda com segurança para:",
-			"permission-1": "Ler seus horários ocupados",
-			"permission-2": "Evitar agendamentos duplicados",
-			"permission-3": "Manter tudo sincronizado",
-			"privacy-note": "Nós nunca editamos ou excluímos eventos sem sua permissão.",
-			"back": "← Voltar",
-			"continue": "Continuar",
-			"success-line1": "Perfeito! 🎉",
-			"success-line2": "Sua Google Agenda está conectada.",
-			"success-line3": "Vou bloquear automaticamente os horários em que você já estiver ocupado.",
-			"next-choice": "Você gostaria de:",
-			"chip-use-existing": "Usar minha agenda atual como disponibilidade",
-			"chip-define-hours": "Definir horários de trabalho específicos",
-			"define-hours-fallback": "Entendido! A importação do Google Agenda estará disponível em breve. Por enquanto, vamos definir seus horários manualmente.",
-			"importing": "Um momento — estou importando sua agenda do Google Agenda...",
-			"imported": "Pronto! Encontrei seus dias e horários de trabalho. Só mais algumas configurações.",
-			"import-failed": "Não consegui ler sua agenda. Vamos definir seus horários de trabalho manualmente."
-		},
-		"errors": {
-			"network": "Algo deu errado. Vamos tentar de novo.",
-			"retry": "Tentar novamente",
-			"google-oauth-fail": "Não consegui conectar à Google Agenda. Tente novamente ou configure manualmente.",
-			"google-oauth-cancel": "Sem problema! Você pode conectar sua agenda depois. Vamos configurar manualmente.",
-			"save-fail": "Não consegui salvar sua disponibilidade. Tente novamente.",
-			"session-timeout": "Parece que você se ausentou. Seu progresso foi salvo — continue de onde parou.",
-			"empty-days": "Selecione pelo menos um dia de atendimento para continuar.",
-			"invalid-time-range": "O horário final deve ser depois do horário inicial.",
-			"invalid-input": "Não entendi bem. Pode tentar de novo?",
-			"ai-fallback": "Obrigado! Deixa eu processar isso para você.",
-			"ai-thinking": "Pensando...",
-			"no-timezone": "Não consegui detectar seu fuso horário automaticamente. Por favor, selecione abaixo.",
-			"publish-success": "Tudo certo! Sua disponibilidade está no ar.",
-			"publish-redirect": "Redirecionando para seu painel..."
-		},
-		"subtitle": "Seu assistente de agendamento",
-		"days": {
-			"MONDAY": "Segunda-feira",
-			"TUESDAY": "Terça-feira",
-			"WEDNESDAY": "Quarta-feira",
-			"THURSDAY": "Quinta-feira",
-			"FRIDAY": "Sexta-feira",
-			"SATURDAY": "Sábado",
-			"SUNDAY": "Domingo"
-		}
-	},
-	"availability": {
-		"calendar": {
-			"legend-available": "Disponível",
-			"legend-busy": "Ocupado",
-			"legend-empty": "Indisponível",
-			"legend-full": "Completo",
-			"legend-partial": "Parcial",
-			"legend-today": "Hoje",
-			"page-title": "Disponibilidade",
-			"source-google": "Google",
-			"source-jupiter": "Júpiter",
-			"subtitle": "Seu calendário de disponibilidade",
-			"settings": "Definições de disponibilidade"
-		},
-		"cancellation-recovery": {
-			"title": "Recuperação de cancelamentos",
-			"subtitle": "Revise consultas canceladas, reabra horários e avance no acompanhamento do paciente sem poluir o calendário ao vivo.",
-			"accessibility": {
-				"detail": "Detalhe de recuperação",
-				"queue": "Fila de recuperação"
-			},
-			"empty": "Nenhuma consulta cancelada corresponde aos filtros atuais.",
-			"empty-selection": "Escolha uma consulta cancelada para revisar os detalhes de recuperação e as próximas ações.",
-			"unknown-patient": "Paciente desconhecido",
-			"queue": {
-				"title": "Fila de recuperação",
-				"subtitle": "Acompanhe cancelamentos que ainda precisam de atenção do terapeuta."
-			},
-			"stats": {
-				"total": "Total",
-				"pending-follow-up": "Pendentes",
-				"reopened": "Reabertos"
-			},
-			"filters": {
-				"title": "Filtros",
-				"summary-default": "Expanda para refinar a fila de recuperação.",
-				"summary-active": "{{count}} filtros ativos",
-				"patient": "Paciente",
-				"patient-placeholder": "Busque pelo nome do paciente",
-				"period": "Período",
-				"status": "Estado",
-				"cancelled-by": "Cancelado por",
-				"reason": "Motivo",
-				"reason-all": "Todos os motivos",
-				"delivery": "Modalidade",
-				"period-options": {
-					"all": "Todos",
-					"past": "Passado",
-					"upcoming": "Futuros"
-				},
-				"status-options": {
-					"all": "Todos",
-					"needs-action": "Precisa de ação",
-					"resolved": "Resolvidos"
-				},
-				"cancelled-by-options": {
-					"all": "Todos",
-					"patient": "Paciente",
-					"therapist": "Terapeuta",
-					"unknown": "Desconhecido"
-				},
-				"delivery-options": {
-					"all": "Todas",
-					"in-person": "Presencial",
-					"online": "Online",
-					"unknown": "Desconhecida"
-				}
-			},
-			"state": {
-				"archived": "Arquivado",
-				"followed-up": "Acompanhado",
-				"overdue": "Atrasado",
-				"pending-follow-up": "Aguardando acompanhamento",
-				"rebooked": "Reagendado",
-				"reopened": "Reaberto"
-			},
-			"cancelled-by": {
-				"patient": "Cancelado pelo paciente",
-				"therapist": "Cancelado pelo terapeuta",
-				"unknown": "Cancelado por origem desconhecida"
-			},
-			"delivery": {
-				"in-person": "Presencial",
-				"online": "Online",
-				"unknown": "Não informado"
-			},
-			"detail": {
-				"eyebrow": "Detalhe da recuperação",
-				"cancelled-at": "Cancelado em",
-				"cancelled-by": "Cancelado por",
-				"reason": "Motivo",
-				"delivery": "Modalidade",
-				"followed-up-at": "Acompanhado em",
-				"patient": "Paciente",
-				"rebooked-appointment": "Agendamento remarcado",
-				"recovery-state": "Estado da recuperação",
-				"not-provided": "Não informado"
-			},
-			"actions": {
-				"rebook": "Reagendar este paciente",
-				"archive": "Marcar como resolvido",
-				"archive-all": "Marcar todos como resolvidos ({{count}})",
-				"more": "Mais ações",
-				"open-patient": "Abrir perfil do paciente",
-				"reopen": "Tornar horário disponível novamente",
-				"archive-success": "Recuperação fechada sem nova ação.",
-				"archive-error": "Não foi possível fechar este item de recuperação. Tente novamente.",
-				"archive-all-success": "{{count}} itens de recuperação marcados como resolvidos.",
-				"archive-all-error": "Não foi possível resolver todos os itens de recuperação. Tente novamente.",
-				"reopen-success": "Horário reaberto com sucesso.",
-				"reopen-error": "Não foi possível reabrir o horário. Tente novamente."
-			}
-		},
-		"week": {
-			"drawer": {
-				"address-override": "Local da sessão",
-				"address-override-question": "Usar um local diferente para esta sessão?",
-				"address-reset": "Repor padrão",
-				"address-save": "Guardar local",
-				"address-save-error": "Falha ao guardar o local da sessão. Tente novamente.",
-				"address-saved": "Local da sessão guardado.",
-				"block-confirm": "Confirmar bloqueio",
-				"block-confirm-body": "Este horário não estará mais disponível para agendamentos de pacientes.",
-				"block-error": "Falha ao bloquear o horário. Tente novamente.",
-				"block-reason-label": "Motivo do bloqueio",
-				"block-reason-placeholder": "Opcional: Adicione um motivo para o bloqueio",
-				"block-slot": "Bloquear horário",
-				"block-success": "Horário bloqueado com sucesso.",
-				"break-edit": "Editar pausa",
-				"break-edit-body": "Esta pausa é controlada pela sua definição global de buffer. Atualize os minutos abaixo para alterar os próximos blocos de pausa.",
-				"break-edit-save": "Guardar pausa",
-				"break-note": "Bloqueado automaticamente para descanso entre sessões.",
-				"break-note-label": "Como funciona",
-				"break-remove": "Remover",
-				"break-subtitle": "Pausa agendada",
-				"break-title": "Tempo de pausa",
-				"blocked-at": "Bloqueado em {{date}}",
-				"blocked-subtitle": "Pacientes não podem agendar este horário",
-				"blocked-title": "Horário bloqueado",
-				"cancelled-at": "Cancelado em {{date}}",
-				"cancelled-reason-label": "Motivo do cancelamento",
-				"cancelled-by-patient": "Esta consulta foi cancelada pelo paciente",
-				"cancelled-by-therapist": "Esta consulta foi cancelada pelo terapeuta",
-				"cancelled-subtitle": "Esta consulta foi cancelada",
-				"cancelled-title": "Consulta cancelada",
-				"booking-link-copy-aria": "Copiar link de agendamento para a área de transferência",
-				"booking-link-hint": "Partilhe este link para abrir a página pública de agendamento com este horário pré-selecionado enquanto ele ainda estiver disponível.",
-				"booking-link-label": "Link de agendamento",
-				"booking-share-text": "Abra este link para agendar a sessão selecionada.",
-				"booking-share-title": "Agendar esta sessão em {{date}} às {{time}}",
-				"book-slot": "Agendar este horário",
-				"cancel": "Cancelar",
-				"cancel-appointment": "Cancelar consulta",
-				"cancel-back": "Voltar",
-				"cancel-choice-sub": "Cancelar esta consulta permanentemente",
-				"cancel-confirm": "Confirmar cancelamento",
-				"cancel-custom-reason-label": "Detalhes adicionais (opcional)",
-				"cancel-error": "Falha ao cancelar a consulta. Tente novamente.",
-				"cancel-reason-label": "Motivo do cancelamento",
-				"cancel-success": "Consulta cancelada com sucesso.",
-				"confirm-booking": "Confirmar",
-				"confirmed": "Confirmado",
-				"date": "Data",
-				"edit": "Editar",
-				"edit-end-time": "Horário de término",
-				"booking-error": "Falha ao agendar a consulta. Tente novamente.",
-				"booking-success": "Consulta agendada com sucesso.",
-				"conflict-change-details": "Alterar dados de contacto",
-				"conflict-confirm": "Agendar para {{name}}",
-				"conflict-multiple-body": "O telefone e o email correspondem a pacientes diferentes. Atualize os dados de contacto para continuar.",
-				"conflict-single-body": "Já existe um paciente registado com este contacto:",
-				"conflict-title": "Paciente já registado",
-				"existing-booking-body": "{{name}} já tem uma sessão agendada em {{date}} às {{time}}. Deseja adicionar outra sessão para este paciente?",
-				"existing-booking-cancel": "Escolher outro paciente",
-				"existing-booking-confirm": "Adicionar outra sessão",
-				"existing-booking-title": "Paciente já tem sessão agendada",
-				"edit-error": "Falha ao salvar as alterações. Tente novamente.",
-				"edit-note": "Notas",
-				"edit-save": "Salvar alterações",
-				"edit-start-time": "Horário de início",
-				"edit-success": "Horário atualizado com sucesso.",
-				"edit-success-booked": "Horário atualizado. Atenção: esta sessão tinha uma reserva ativa.",
-				"let-patient-choose-address": "Deixar o paciente escolher o local?",
-				"location-choice-clinic": "Consultório",
-				"location-choice-custom": "Personalizado",
-				"location-choice-label": "Local da sessão",
-				"session-delivery-in-person": "Presencial",
-				"session-delivery-in-person-subtitle": "No seu consultório ou endereço do paciente",
-				"session-delivery-label": "Como será realizada esta sessão?",
-				"session-delivery-online": "Online",
-				"recurrence-all": "Todos os agendamentos futuros",
-				"recurrence-end-month": "Até o fim do mês",
-				"recurrence-end-year": "Até o fim do ano",
-				"recurrence-label": "Repetir agendamento",
-				"recurrence-single": "Apenas este agendamento",
-				"session-delivery-online-subtitle": "Videochamada, telefone ou mensagens",
-				"location-choice-patient": "Paciente",
-				"location-subtitle-clinic": "Vamos partilhar o endereço do consultório na localização da consulta",
-				"location-subtitle-custom": "Vamos partilhar o endereço personalizado na localização da consulta",
-				"location-subtitle-patient": "Vai permitir que o seu paciente escolha o endereço na localização da consulta",
-				"minutes": "minutos",
-				"notes": "Notas",
-				"patient-email": "Email do paciente",
-				"patient-timezone": "Fuso horário do paciente",
-				"patient-timezone-placeholder": "Pesquise por cidade, ex: Sao Paulo",
-				"patient-first-name": "Nome do paciente",
-				"patient-last-name": "Sobrenome do paciente",
-				"patient-search": {
-					"no-results": "Nenhum paciente encontrado",
-					"placeholder": "Pesquise ou digite um novo nome",
-					"type-to-search": "Digite pelo menos 2 caracteres para pesquisar"
-				},
-				"patient-time": "Horário local do paciente",
-				"reschedule": "Remarcar",
-				"reschedule-choice-sub": "Mover para outro horário disponível",
-				"reschedule-confirm": "Confirmar remarcação",
-				"reschedule-error": "Falha ao remarcar a consulta. Tente novamente.",
-				"reschedule-no-slots": "Não há horários disponíveis para remarcar. Tente ajustar os seus horários de trabalho.",
-				"reschedule-select-prompt": "Selecione um novo horário para esta consulta.",
-				"reschedule-success": "Consulta remarcada com sucesso.",
-				"reopen-slot": "Tornar disponível novamente",
-				"reopened-note-fallback-name": "este paciente",
-				"reopened-note-label": "Cancelamento anterior",
-				"reopened-note-text": "Anteriormente cancelada para {{name}} em {{date}}.",
-				"session-duration": "Duração: ",
-				"session-type": "Tipo de sessão",
-				"share-address": "Partilhar endereço do consultório com o paciente",
-				"status-cancelled": "Cancelado",
-				"status-confirmed": "Confirmado",
-				"available-status-open": "Aberto para agendamento",
-				"your-time": "Seu horário local",
-				"appointment-address": "Endereço da consulta",
-				"patient-phone": "Telefone do paciente",
-				"patient-provides-address": "O paciente irá fornecer o endereço",
-				"call-whatsapp": "Ligar pelo WhatsApp",
-				"call-phone": "Ligar para o paciente",
-				"join-meet": "Entrar no Google Meet",
-				"join-zoom": "Entrar no Zoom",
-				"booked-section-session": "Sessão",
-				"booked-section-patient": "Paciente",
-				"booked-section-location": "Localização",
-				"booked-section-notes": "Notas",
-				"booked-date": "Data",
-				"booked-time": "Hora",
-				"booked-duration": "Duração",
-				"booked-session-count": "Sessão {{count}} com {{name}}",
-				"booked-session-first": "Primeira sessão com {{name}}",
-				"booked-email": "Email",
-				"booked-phone": "Telefone",
-				"booked-online-session": "Sessão online",
-				"booked-hybrid": "Online / Presencial",
-				"booked-in-person": "Presencial",
-				"booked-google-sync": "Sincronizado do Google Agenda",
-				"booked-profile-link": "Perfil",
-				"booked-profile-coming-soon": "Perfil do paciente — em breve",
-				"booked-no-email": "Nenhum email fornecido",
-				"booked-no-phone": "Nenhum telefone fornecido",
-				"booked-awaiting-address": "Aguardando endereço do paciente",
-				"booked-request-address": "Solicitar endereço",
-				"booked-view-notifications": "Ver notificações",
-				"booked-past-disabled": "Consulta passada — ações desativadas",
-				"booked-copied": "Copiado",
-				"booked-copy-aria": "Copiar {{field}} para a área de transferência",
-				"booked-call-aria": "Ligar para {{name}}",
-				"booked-whatsapp-aria": "Enviar mensagem para {{name}} no WhatsApp",
-				"booked-email-aria": "Enviar email para {{name}}",
-				"source-manual": "Agendado",
-				"unblock-confirm": "Confirmar desbloqueio",
-				"unblock-confirm-body": "Este horário ficará disponível para agendamentos novamente.",
-				"unblock-error": "Falha ao desbloquear o horário. Tente novamente.",
-				"unblock-slot": "Desbloquear horário",
-				"unblock-success": "Horário desbloqueado com sucesso."
-			},
-			"buffer-label": "Buffer",
-			"legend-available": "Disponível",
-			"legend-blocked": "Bloqueado",
-			"legend-booked-google": "Google",
-			"legend-booked-jupiter": "Agendado",
-			"legend-buffer": "Buffer",
-			"legend-cancelled": "Cancelado",
-			"next-week": "Próxima semana",
-			"no-appointments": "Sem agendamentos",
-			"page-title": "Disponibilidade",
-			"prev-week": "Semana anterior",
-			"collapse-day": "Ver menos",
-			"expand-day": "+{{count}} mais",
-			"show-available-slots": "Ver horários disponíveis ({{count}})",
-			"slot": "horário",
-			"slots": "horários",
-			"filter-clear": "Limpar filtros",
-			"filter-delivery-in-person": "Presencial",
-			"filter-delivery-online": "Online",
-			"filter-hide-free": "Ocultar horários livres",
-			"filter-label-cancelled": "Horários cancelados",
-			"filter-label-free": "Horários livres",
-			"filter-section-delivery": "Modalidade",
-			"filter-section-session-type": "Tipo de sessão",
-			"filter-section-source": "Origem",
-			"filter-section-status": "Status do horário",
-			"filter-section-time": "Período do dia",
-			"filter-show-free": "Mostrar horários livres",
-			"filter-source-google": "Google",
-			"filter-source-jupiter": "Júpiter",
-			"filter-time-afternoon": "Tarde",
-			"filter-time-evening": "Noite",
-			"filter-time-morning": "Manhã",
-			"filters": "Filtros",
-			"blocked-hover-label": "Horário bloqueado",
-			"title": "Agenda da Semana",
-			"settings": "Definições",
-			"default-blocked-day": {
-				"body": "{{day}} está fechado pelas suas definições padrão de disponibilidade. Abra apenas esta data como dia completo, parte do dia ou horários específicos.",
-				"confirm": "Abrir este dia",
-				"end-time": "Hora de fim",
-				"error": "Não foi possível abrir este dia. Tente novamente.",
-				"open-full-day": "Abrir dia completo",
-				"open-full-day-desc": "Crie todos os horários disponíveis para esta data usando o seu horário habitual.",
-				"open-part-day": "Abrir parte do dia",
-				"open-part-day-desc": "Escolha um intervalo de horas personalizado apenas para esta data.",
-				"open-specific-slots": "Abrir horários específicos",
-				"open-specific-slots-desc": "Selecione apenas os horários exatos que quer disponibilizar.",
-				"start-time": "Hora de início",
-				"success": "Este dia agora está disponível.",
-				"title": "Abrir este dia fechado?"
-			},
-			"day-header": {
-				"actions": "Ações do dia",
-				"block-all": "Bloquear todos os horários disponíveis",
-				"block-all-confirm": "Bloquear todos os {{count}} horários disponíveis em {{day}}? Os pacientes não poderão agendar nesses horários.",
-				"booked-warning": "Este dia tem {{count}} agendamento(s). O bloqueio do dia afetará apenas os horários ainda disponíveis.",
-				"block-all-error": "Falha ao bloquear os horários. Tente novamente.",
-				"block-all-success": "Todos os horários disponíveis foram bloqueados.",
-				"summary": "{{total}} no total · {{available}} disponíveis · {{booked}} agendados · {{blocked}} bloqueados · {{cancelled}} cancelados",
-				"unblock-all": "Desbloquear todos os horários bloqueados",
-				"unblock-all-confirm": "Desbloquear todos os {{count}} horários bloqueados em {{day}}? Esses horários ficarão disponíveis para agendamento.",
-				"unblock-all-error": "Falha ao desbloquear os horários. Tente novamente.",
-				"unblock-all-success": "Todos os horários bloqueados foram desbloqueados."
-			}
-		},
-		"gate": {
-			"deleted-notice": "Você não tem mais disponibilidade configurada. Fale com a Júpiter para criar uma nova."
-		},
-		"settings": {
-			"google-calendar-connect-btn": "Conectar Google Agenda",
-			"google-calendar-connect-error": "Não foi possível iniciar a conexão com o Google Agenda. Tente novamente.",
-			"first-publish-alert": "A sua disponibilidade está ativa! Complete o checklist abaixo para otimizar a sua configuração.",
-			"google-calendar-connected": "Seu Google Agenda está conectado.",
-			"google-calendar-desc": "Sincronize seu Google Agenda para importar sua agenda existente, bloquear horários ocupados automaticamente e manter suas sessões no Psycron sincronizadas.",
-			"google-calendar-drawer-title": "Google Agenda",
-			"live-alert": "Sua disponibilidade está ativa. Seus clientes já podem agendar sessões com você.",
-			"page-title": "Configurações de Disponibilidade",
-			"save-error": "Não foi possível salvar. Tente novamente.",
-			"save-success": "Configurações salvas com sucesso.",
-			"session-duration-desc": "Defina a duração padrão de cada atendimento.",
-			"session-duration-drawer-title": "Duração da sessão",
-			"session-type-both": "Ambos",
-			"session-type-desc": "Escolha como você conduz suas sessões.",
-			"session-type-drawer-title": "Tipo de sessão",
-			"session-type-in-person": "Presencial",
-			"session-type-online": "Online",
-			"session-address-desc": "Insira o endereço da sua clínica ou consultório para que os pacientes possam encontrá-lo.",
-			"session-type-address-hint": "Atendimentos presenciais exigem um endereço de clínica. Você será solicitado a adicioná-lo após salvar.",
-			"session-address-drawer-title": "Endereço do atendimento",
-			"session-address-title": "Endereço da clínica",
-			"specialty-drawer-title": "Sua especialidade",
-			"specialty-desc": "Escolha a área de atuação principal. Você pode detalhar sua abordagem específica abaixo.",
-			"specialty-psychology": "Psicologia",
-			"specialty-psychiatry": "Psiquiatria",
-			"specialty-physiotherapy": "Fisioterapia",
-			"specialty-nutrition": "Nutrição",
-			"specialty-coaching": "Coaching",
-			"specialty-occupational-therapy": "Terapia ocupacional",
-			"specialty-speech-therapy": "Fonoaudiologia",
-			"specialty-social-work": "Serviço social",
-			"specialty-other": "Outro",
-			"specialty-detail-label": "Abordagem ou método específico (opcional)",
-			"specialty-detail-helper": "ex: Terapia Cognitivo-Comportamental, EMDR — usado para melhorar seu perfil",
-			"feature-disabled-tooltip": "Esta funcionalidade está a chegar em breve",
-			"jupiter-cta-disabled-tooltip": "A Júpiter ainda não está disponível — estamos a lançar gradualmente",
-			"jupiter-help-action": "Falar com a Júpiter",
-			"jupiter-help-description": "A Júpiter pode guiá-lo a completar as suas configurações",
-			"jupiter-help-title": "Precisa de ajuda?",
-			"talk-to-jupiter": "Editar com a Júpiter",
-			"timezone-desc": "Todos os agendamentos serão exibidos e criados neste fuso horário.",
-			"timezone-drawer-title": "Fuso horário",
-			"timezone-input-label": "Fuso horário",
-			"timezone-warning-body": "Seus agendamentos existentes não serão movidos — continuarão no mesmo horário UTC, mas exibidos no novo fuso horário.",
-			"timezone-warning-confirm": "Alterar fuso horário",
-			"timezone-warning-title": "Alterar fuso horário?",
-			"working-hours-days-label": "Dias de trabalho",
-			"working-hours-desc": "Defina seus dias disponíveis e o horário para atendimentos.",
-			"working-hours-drawer-title": "Horário de trabalho",
-			"working-hours-end-label": "Fim",
-			"recurrence-consistent": "Consistente",
-			"recurrence-consistent-desc": "Sua agenda repete os mesmos dias e horários toda semana, gerada mês a mês. Ideal para uma rotina previsível e consistente.",
-			"recurrence-flexible": "Flexível",
-			"recurrence-flexible-desc": "Os slots são gerados para o mês inteiro de uma vez. Ideal se sua disponibilidade varia — você pode editar slots individuais sem reconstruir toda a agenda.",
-			"recurrence-pattern-desc": "Alterar isso vai regenerar seus slots de disponibilidade abertos com o novo padrão. Todos os agendamentos já confirmados permanecem exatamente como estão.",
-			"recurrence-pattern-drawer-title": "Padrão de recorrência",
-			"working-hours-start-label": "Início",
-			"working-hours-time-label": "Intervalo de horário"
-		}
-	},
-	"conflicts": {
-		"title": "Painel de conflitos",
-		"subtitle": "Revise e resolva conflitos de agenda e de pacientes.",
-		"empty": "Nenhum conflito corresponde aos filtros atuais.",
-		"filters": {
-			"title": "Filtros",
-			"summary-default": "Refine a fila por status ou tipo de conflito.",
-			"summary-active": "{{count}} filtro ativo",
-			"summary-active_other": "{{count}} filtros ativos",
-			"status": "Status",
-			"type": "Tipo",
-			"open": "Em aberto",
-			"all-statuses": "Todos os status",
-			"all-types": "Todos os tipos"
-		},
-		"queue": {
-			"eyebrow": "Operação",
-			"title": "Fila de conflitos",
-			"subtitle": "Revise os itens que ainda precisam da sua decisão."
-		},
-		"layout": {
-			"expand-queue": "Expandir fila",
-			"collapse-queue": "Recolher fila"
-		},
-		"accessibility": {
-			"queue": "Fila de conflitos",
-			"detail": "Detalhe do conflito"
-		},
-		"status": {
-			"open": "Em aberto",
-			"resolved": "Resolvido",
-			"dismissed": "Dispensado"
-		},
-		"types": {
-			"patient-duplicate": "Paciente duplicado",
-			"slot-replication": "Replicação de horário"
-		},
-		"patient-duplicate": {
-			"title": "Possível paciente duplicado",
-			"and": "e",
-			"summary": {
-				"phone-and-email": "Corresponde a registros existentes pelo telefone {{phone}} e pelo email {{email}}. Revisar: {{candidates}}.",
-				"phone-only": "Corresponde a registros existentes pelo telefone {{phone}}. Revisar: {{candidates}}.",
-				"email-only": "Corresponde a registros existentes pelo email {{email}}. Revisar: {{candidates}}.",
-				"generic": "Corresponde a um registro de paciente existente. Revisar: {{candidates}}."
-			},
-			"match": {
-				"phone-and-email": "Telefone {{phone}} e email {{email}}",
-				"phone-only": "Telefone {{phone}}",
-				"email-only": "Email {{email}}",
-				"generic": "Dados de paciente existentes"
-			}
-		},
-		"detail": {
-			"incoming-patient": "Paciente recebido",
-			"existing-patient": "Paciente existente",
-			"matched-by": "Detectado por",
-			"candidate-records": "Registros candidatos",
-			"conflicting-details": "Detalhes em conflito",
-			"conflicting-date": "Data em conflito",
-			"conflicting-time": "Hora em conflito",
-			"recurrence-pattern": "Padrão de recorrência",
-			"preferred-contact": "Contato preferido",
-			"additional-candidates": "{{count}} outro possível registro ainda está na fila para revisão.",
-			"additional-candidates_other": "{{count}} outros possíveis registros ainda estão na fila para revisão.",
-			"not-provided": "Não informado"
-		},
-		"merge-review": {
-			"title": "Escolha o que manter",
-			"description": "Agendamentos, cancelamentos e notificações serão combinados automaticamente. Escolha os dados de perfil que devem permanecer no paciente principal.",
-			"primary": "Manter de {{name}}",
-			"secondary": "Usar de {{name}}",
-			"confirm": "Confirmar união",
-			"fields": {
-				"firstName": "Nome",
-				"lastName": "Sobrenome",
-				"contacts": {
-					"email": "Email",
-					"phone": "Telefone",
-					"whatsapp": "WhatsApp"
-				},
-				"billing": "Cobrança",
-				"preferredContact": "Contato preferido",
-				"timeZone": "Fuso horário",
-				"address": "Endereço"
-			}
-		},
-		"resolution": {
-			"title": "Histórico da resolução",
-			"completed-at": "Concluído em {{date}}.",
-			"actions": {
-				"auto-dismissed-stale": "O Psycron fechou este conflito porque os registros duplicados não estão mais ativos.",
-				"dismissed": "O terapeuta dispensou este conflito sem alterar os registros de pacientes.",
-				"keep-existing": "O terapeuta manteve o paciente existente e não uniu os registros.",
-				"keep-new": "O terapeuta manteve o novo paciente e não uniu os registros.",
-				"marked-resolved": "O terapeuta marcou este conflito como resolvido.",
-				"merged": "O terapeuta uniu os registros de pacientes duplicados.",
-				"merge-reconciled": "O Psycron fechou este conflito porque outra união já tratou o paciente duplicado.",
-				"unknown": "Este conflito foi fechado."
-			},
-			"sources": {
-				"primary": "Mantido de {{name}}",
-				"secondary": "Alterado para {{name}}"
-			}
-		},
-		"actions": {
-			"recommended-title": "Resolução recomendada",
-			"recommended-hint": "Una ambos os registros e mantenha um único paciente como fonte principal.",
-			"alternatives-title": "Outras opções",
-			"alternatives-hint": "Use apenas um registro se não quiser unir os dois agora.",
-			"merge": "Unir pacientes",
-			"keep-existing": "Manter paciente existente",
-			"keep-new": "Manter novo paciente",
-			"dismiss": "Dispensar",
-			"mark-resolved": "Marcar como resolvido",
-			"error": "Não foi possível atualizar este conflito. Tente novamente."
-		}
-	},
-	"action-center": {
-		"title": "Central de ações",
-		"subtitle": "Resolva os itens operacionais que precisam da sua atenção hoje.",
-		"tabs": {
-			"aria-label": "Seções da central de ações",
-			"conflicts": "Conflitos",
-			"recovery": "Recuperação"
-		}
-	},
-	"notifications": {
-		"title": "Notificações",
-		"subtitle": "Acompanhe comunicações enviadas aos pacientes por WhatsApp, email e SMS.",
-		"empty": "Nenhuma notificação corresponde aos filtros atuais.",
-		"load-more": "Carregar mais",
-		"queue": {
-			"title": "Feed de notificações",
-			"subtitle": "Uma linha do tempo de entrega para a comunicação com pacientes."
-		},
-		"layout": {
-			"expand-feed": "Expandir feed",
-			"collapse-feed": "Recolher feed"
-		},
-		"accessibility": {
-			"page": "Área de notificações",
-			"queue": "Feed de notificações",
-			"detail": "Detalhe da notificação"
-		},
-		"stats": {
-			"total": "Total",
-			"failed": "Falhas",
-			"delivered": "Entregues",
-			"sent": "Enviados"
-		},
-		"search": {
-			"placeholder": "Buscar paciente ou mensagem"
-		},
-		"sort": {
-			"label": "Ordenar",
-			"options": {
-				"newest": "Mais recentes primeiro",
-				"oldest": "Mais antigas primeiro",
-				"status": "Status"
-			}
-		},
-		"filters": {
-			"title": "Filtros",
-			"summary-default": "Refine o feed por canal, status, tipo ou data.",
-			"summary-active": "{{count}} filtro ativo",
-			"summary-active_other": "{{count}} filtros ativos",
-			"channel": "Canal",
-			"status": "Status",
-			"message-type": "Tipo de mensagem",
-			"date-range": "Período",
-			"from": "De",
-			"to": "Até",
-			"all-channels": "Todos os canais",
-			"all-statuses": "Todos os status",
-			"all-types": "Todos os tipos",
-			"active": "Ativo",
-			"archived": "Arquivado"
-		},
-		"channels": {
-			"whatsapp": "WhatsApp",
-			"email": "Email",
-			"sms": "SMS",
-			"icalendar": "Convite de calendário"
-		},
-		"statuses": {
-			"pending": "Pendente",
-			"sent": "Enviada",
-			"delivered": "Entregue",
-			"failed": "Falhou"
-		},
-		"message-types": {
-			"appointment_confirmation": "Confirmação de consulta",
-			"appointment_updated": "Consulta atualizada",
-			"reminder": "Lembrete",
-			"conflict": "Conflito",
-			"account_setup": "Configuração da conta",
-			"daily_schedule_summary": "Resumo diário da agenda",
-			"unknown": "Notificação"
-		},
-		"bulk": {
-			"resend-eligible": "Renotificar elegíveis",
-			"action": "Notificar novamente"
-		},
-		"card": {
-			"appointment": "Consulta: {{value}}",
-			"delivered-at": "Enviada em {{value}}",
-			"failed": "Falha na entrega"
-		},
-		"patient-settings": {
-			"action": "Preferências de notificação do paciente",
-			"title": "Preferências de Notificação do Paciente",
-			"subtitle": "Configure quais canais este paciente recebe notificações.",
-			"subtitle-named": "Configure quais canais {{name}} recebe notificações.",
-			"save-success": "Preferências de notificação do paciente salvas.",
-			"save-error": "Não foi possível salvar as preferências do paciente."
-		},
-		"settings": {
-			"action": "Configurar notificações",
-			"title": "Preferências de Notificações",
-			"subtitle": "Controle quais canais são usados para cada tipo de comunicação com o paciente.",
-			"save-success": "Preferências de notificação salvas.",
-			"save-error": "Não foi possível salvar as preferências. Tente novamente.",
-			"appointment-confirmation": {
-				"title": "Confirmação de Consulta",
-				"description": "Enviada ao paciente quando uma nova consulta é agendada."
-			},
-			"reminder": {
-				"title": "Lembretes de Consulta",
-				"description": "Enviado ao paciente antes da consulta.",
-				"toggle": "Ativar lembretes",
-				"lead-time": {
-					"label": "Enviar lembrete",
-					"30m": "30 min antes",
-					"1h": "1 hora antes",
-					"2h": "2 horas antes",
-					"24h": "24 horas antes",
-					"48h": "48 horas antes"
-				}
-			},
-			"appointment-updated": {
-				"title": "Consulta Atualizada",
-				"description": "Enviada ao paciente quando uma consulta é remarcada ou alterada."
-			},
-			"calendar-invite": {
-				"title": "Convite de Calendário",
-				"description": "Anexa um arquivo .ics às confirmações e lembretes por e-mail.",
-				"toggle": "Incluir anexo de calendário"
-			}
-		},
-		"context": {
-			"channel-status": "Notificação por {{channel}} está {{status}}.",
-			"sent-at": "Enviada em {{value}}.",
-			"delivered-at": "Entregue em {{value}}.",
-			"appointment": "Consulta: {{value}}.",
-			"session": "Sessão: {{value}}.",
-			"calendar-invite-attached": "Convite de calendário anexado.",
-			"error": "Erro de entrega: {{value}}"
-		},
-		"detail": {
-			"title": "Detalhes da comunicação",
-			"patient": "Paciente",
-			"unknown-patient": "Paciente desconhecido",
-			"message-type": "Tipo de mensagem",
-			"channel": "Canal",
-			"status": "Status",
-			"sent-at": "Enviada em",
-			"delivered-at": "Entregue em",
-			"appointment": "Consulta",
-			"ics": "Convite de calendário",
-			"ics-attached": "Anexado",
-			"ics-empty": "Não anexado",
-			"message": "Mensagem",
-			"context": "Contexto",
-			"error": "Erro de entrega",
-			"payload": "Payload"
-		},
-		"retry": {
-			"action": "Tentar novamente",
-			"action-short": "Tentar",
-			"success": "Notificação enviada novamente.",
-			"error": "Não foi possível enviar esta notificação novamente. Tente novamente."
-		},
-		"resend": {
-			"action": "Notificar novamente",
-			"action-short": "Notificar novamente"
-		},
-		"archive": {
-			"action": "Arquivar",
-			"success": "Notificação arquivada.",
-			"error": "Não foi possível arquivar esta notificação."
-		}
-	}
+  "public": {
+    "powered-by": "Desenvolvido por Psycron"
+  },
+  "booking": {
+    "page": {
+      "title": "Agendar Sessão"
+    },
+    "calendar": {
+      "title": "Selecione uma data e horário",
+      "subtitle": "Escolha primeiro o dia, depois selecione o horário que funciona melhor para você.",
+      "booking-greeting": "Olá, escolha o seu agendamento.",
+      "detail-title": "Escolha uma data",
+      "view-month": "Mês",
+      "view-week": "Semana",
+      "pick-a-day": "Selecione uma data no calendário para ver o que está disponível.",
+      "no-date-title": "Nenhuma data selecionada ainda",
+      "no-date-body": "Comece escolhendo um dos dias destacados no calendário.",
+      "no-times-title": "Sem horários neste dia",
+      "no-times-body": "Tente outra data destacada ou ajuste o filtro por período do dia.",
+      "available-count": "horários disponíveis",
+      "sidebar-description": "Escolha o dia e o horário que funcionam melhor para você.",
+      "duration-heading": "Duração da sessão",
+      "duration-pending": "Selecione um horário para visualizar a duração.",
+      "location-pending": "Escolha uma data e um horário para visualizar o local da sessão.",
+      "date-heading": "Dia selecionado",
+      "date-pending": "Escolha uma data no calendário.",
+      "agenda-title": "Agendamentos",
+      "agenda-main-title": "Calendário",
+      "agenda-subtitle": "Toque em um dia para focar apenas nos agendamentos daquela data.",
+      "agenda-greeting": "Olá, {{name}}, confira seus agendamentos.",
+      "agenda-greeting-fallback": "Olá, confira seus agendamentos.",
+      "agenda-sidebar-description": "Uma visão da sua jornada com acesso rápido a sessões futuras, concluídas e canceladas.",
+      "agenda-overview-title": "Resumo",
+      "agenda-overview-fallback": "Resumo",
+      "agenda-overview-heading": "Resumo",
+      "agenda-overview-heading-fallback": "Resumo",
+      "active-days": "Dias ativos",
+      "day-appointments": "agendamentos neste dia",
+      "selected-day-section": "Agendamentos do dia",
+      "next-appointments-section": "Próximos agendamentos",
+      "no-appointments-title": "Nada agendado para este dia",
+      "no-appointments-body": "Escolha outra data destacada para revisar seus agendamentos.",
+      "no-next-appointments": "Seus próximos agendamentos confirmados aparecerão aqui."
+    },
+    "filter": {
+      "from": "De",
+      "label-date-range": "Período",
+      "label-time-of-day": "Período do dia",
+      "time-all": "Qualquer horário",
+      "time-morning": "Manhã (antes do meio-dia)",
+      "time-afternoon": "Tarde (12–17h)",
+      "time-evening": "Noite (após 17h)",
+      "time-of-day": "Período do dia",
+      "to": "Até",
+      "weeks-1": "Próxima semana",
+      "weeks-2": "Próximas 2 semanas",
+      "weeks-4": "Próximo mês",
+      "weeks-12": "Próximos 3 meses",
+      "weeks-all": "Todos disponíveis"
+    },
+    "slot": {
+      "booked": "Reservado",
+      "taken": "Ocupado"
+    },
+    "drawer": {
+      "aria-label": "Agendar consulta",
+      "title": "Confirmar agendamento"
+    },
+    "confirm": "Confirmar",
+    "error": "Algo deu errado. Por favor, tente novamente.",
+    "no-slots": "Nenhum horário disponível corresponde aos seus filtros.",
+    "form": {
+      "address-fallback": "O endereço aparecerá aqui após você preenchê-lo acima.",
+      "email": "E-mail",
+      "first-name": "Nome",
+      "last-name": "Sobrenome",
+      "notify-email": "Notificar por e-mail",
+      "notify-fallback": "Preencha seus dados de contato acima para ativar as notificações.",
+      "notify-whatsapp": "Notificar por WhatsApp",
+      "section-notifications": "Notificações",
+      "section-personal": "Seus dados",
+      "section-recurrence": "Recorrência",
+      "your-address": "Endereço da sessão"
+    },
+    "notifications": {
+      "description": "Enviaremos um lembrete antes de cada sessão.",
+      "email": "Notificar por e-mail",
+      "fallback-note": "Adicione seus dados de contato acima para ativar os lembretes.",
+      "title": "Lembretes",
+      "whatsapp": "Notificar por WhatsApp"
+    },
+    "recurrence": {
+      "biweekly": "A cada 2 semanas",
+      "monthly": "Todo mês",
+      "not-yet": "Ainda não — decidir depois",
+      "single": "Sessão única",
+      "title": "Com que frequência você gostaria de se encontrar?",
+      "weekly": "Toda semana"
+    },
+    "confirmation": {
+      "title": "Agendamento confirmado!",
+      "subtitle": "Ótimo, {{name}}! Sua sessão foi confirmada.",
+      "date": "Data",
+      "time": "Horário",
+      "your-agenda": "Sua agenda pessoal",
+      "agenda-description": "Use este link para ver e gerenciar seus próximos agendamentos.",
+      "copy-link": "Copiar link"
+    },
+    "appointments": {
+      "title": "Seus agendamentos",
+      "subtitle": "Veja e gerencie suas sessões agendadas.",
+      "upcoming": "Próximas",
+      "past": "Anteriores",
+      "cancelled": "Canceladas",
+      "no-upcoming": "Você não possui agendamentos futuros.",
+      "no-upcoming-title": "Nenhuma sessão futura",
+      "no-past": "As sessões concluídas aparecerão aqui após seus atendimentos.",
+      "no-past-title": "Ainda não há sessões anteriores",
+      "no-cancelled": "Os agendamentos cancelados aparecerão aqui para sua referência.",
+      "no-cancelled-title": "Nenhum agendamento cancelado",
+      "therapist-fallback": "Seu terapeuta"
+    },
+    "patient-drawer": {
+      "aria-label": "Detalhes do agendamento do paciente",
+      "role": "Seu agendamento",
+      "available-title": "Confirmar e agendar",
+      "available-subtitle": "Revise este horário antes de concluir o agendamento.",
+      "available-badge": "Disponível",
+      "confirmed-title": "Seu agendamento",
+      "confirmed-badge": "Confirmado",
+      "completed-title": "Agendamento concluído",
+      "completed-badge": "Concluído",
+      "cancelled-title": "Agendamento cancelado",
+      "cancelled-badge": "Cancelado",
+      "cancelled-notice": "Este agendamento foi cancelado em {{date}}.",
+      "therapist-section": "Terapeuta",
+      "details-section": "Detalhes da sessão",
+      "contact-section": "Contato",
+      "reschedule-section": "Escolha um novo horário",
+      "specialty-fallback": "Detalhes da especialidade em breve",
+      "when": "{{date}} às {{time}}",
+      "when-label": "Quando",
+      "duration": "{{minutes}} min",
+      "duration-label": "Duração",
+      "session-type-label": "Tipo de sessão",
+      "session-online": "Sessão online",
+      "session-in-person": "Sessão presencial",
+      "location-label": "Local",
+      "location-online": "Sessão online",
+      "location-in-person": "O local presencial será confirmado pelo terapeuta.",
+      "location-address": "{{address}}",
+      "awaiting-address": "Aguardando o endereço da sessão",
+      "call-therapist": "Ligar para terapeuta",
+      "copy-phone": "Copiar telefone",
+      "cancel": "Cancelar agendamento",
+      "reschedule": "Reagendar",
+      "confirm-reschedule": "Confirmar reagendamento",
+      "reschedule-success": "Agendamento reagendado com sucesso.",
+      "reschedule-error": "Não foi possível reagendar este agendamento. Tente novamente.",
+      "no-reschedule-slots": "Nenhum outro horário disponível foi encontrado agora.",
+      "book-new": "Agendar nova sessão",
+      "session-completed": "Sessão concluída"
+    },
+    "cancel": {
+      "button": "Cancelar agendamento",
+      "reason-prompt": "Por favor, informe o motivo do cancelamento.",
+      "reason-label": "Motivo",
+      "reason": {
+        "emergency": "Emergência pessoal",
+        "schedule-conflict": "Conflito de agenda",
+        "financial": "Motivos financeiros",
+        "mental-health": "Não me sinto pronto(a)",
+        "other": "Outro"
+      },
+      "custom-reason": "Conte mais (opcional)",
+      "confirm": "Confirmar cancelamento",
+      "success": "Seu agendamento foi cancelado.",
+      "error": "Algo deu errado. Por favor, tente novamente."
+    }
+  },
+  "common": {
+    "back": "Voltar",
+    "cancel": "Cancelar",
+    "close": "Fechar",
+    "layout": {
+      "collapse-queue": "Recolher",
+      "expand-queue": "Expandir"
+    },
+    "loading": "Carregando...",
+    "required": "Obrigatório",
+    "save": "Salvar",
+    "saving": "Salvando...",
+    "today": "Hoje"
+  },
+  "patients": {
+    "list": {
+      "title": "Central de Pacientes",
+      "subtitle": "Busque, filtre e gerencie a sua lista de pacientes.",
+      "search-label": "Busca",
+      "search-placeholder": "Buscar por nome, email ou telefone",
+      "status-label": "Status",
+      "status-all": "Todos os pacientes",
+      "status-active": "Ativo",
+      "status-inactive": "Inativo",
+      "sort-label": "Ordenar por",
+      "sort-name": "Nome (A-Z)",
+      "sort-name-desc": "Nome (Z-A)",
+      "sort-last-appointment-asc": "Último atendimento (mais antigo primeiro)",
+      "sort-last-appointment": "Último atendimento",
+      "sort-total-sessions-asc": "Total de sessões (menor primeiro)",
+      "sort-total-sessions": "Total de sessões",
+      "columns": {
+        "patient": "Paciente",
+        "contact": "Contato",
+        "preferred-contact": "Contato preferido",
+        "timezone": "Fuso horário",
+        "billing": "Cobrança",
+        "recovery": "Recuperação",
+        "last-appointment": "Último atendimento",
+        "sessions": "Sessões",
+        "status": "Status"
+      },
+      "empty": {
+        "initial-title": "Você ainda não tem pacientes",
+        "initial-body": "Quando você adicionar ou agendar seu primeiro paciente, ele aparecerá aqui como parte da sua Central de Pacientes.",
+        "filtered-title": "Nenhum paciente corresponde a estes filtros",
+        "filtered-body": "Tente ajustar a busca ou os filtros para encontrar o paciente que você procura."
+      },
+      "clear-search": "Limpar busca",
+      "billing": {
+        "none": "Não definido",
+        "per-session-short": "/ sessão",
+        "monthly-short": "/ mês"
+      },
+      "not-available": "Não informado",
+      "no-appointments": "Sem atendimentos ainda",
+      "contact-method-not-set": "Não definido",
+      "possible-duplicate": "Possível duplicata",
+      "cancellation-follow-up-needed": "{{count}} precisa de acompanhamento",
+      "cancellation-follow-up-needed_other": "{{count}} precisam de acompanhamento",
+      "cancellation-follow-up-tooltip": "{{count}} sessão cancelada não tem acompanhamento, remarcação, arquivamento ou reabertura registrados.",
+      "cancellation-follow-up-tooltip_other": "{{count}} sessões canceladas não têm acompanhamento, remarcação, arquivamento ou reabertura registrados.",
+      "cancellation-follow-up-none": "Sem cancelamentos",
+      "cancellation-follow-up-resolved": "Resolvido",
+      "cancelled-sessions-notice": "{{count}} sessão cancelada",
+      "cancelled-sessions-notice_other": "{{count}} sessões canceladas"
+    },
+    "profile": {
+      "subtitle": "Revise contatos, preferências de cuidado e histórico de sessões.",
+      "member-since": "Paciente desde {{date}}",
+      "unknown-patient": "paciente desconhecido",
+      "merged-note": "Este registro foi mesclado em {{patientId}} e fica disponível para histórico de auditoria.",
+      "not-found": "Não conseguimos carregar este paciente. Ele pode ter sido arquivado ou mesclado em outro registro.",
+      "actions": {
+        "call": "Ligar",
+        "edit": "Editar paciente",
+        "open-sessions": "Abrir página de sessões",
+        "whatsapp": "WhatsApp",
+        "email": "Email"
+      },
+      "edit": {
+        "title": "Editar dados do paciente",
+        "description": "Atualize contatos, preferências de atendimento, fuso horário e endereço.",
+        "save": "Salvar alterações"
+      },
+      "session-drawer": {
+        "title": "Detalhes da sessão",
+        "open-label": "Abrir detalhes da sessão de {{date}}",
+        "status": "Status",
+        "delivery": "Formato da sessão",
+        "cancelled-at": "Cancelado em",
+        "cancellation-reason": "Motivo do cancelamento",
+        "cancelled-by": "Cancelado por",
+        "cancelled-by-patient": "Paciente",
+        "cancelled-by-therapist": "Terapeuta",
+        "cancelled-by-unknown": "Não informado",
+        "notification": "Notificação",
+        "notification-sent": "Notificação enviada",
+        "notification-not-sent": "Notificação não enviada",
+        "cancel-confirm": "Confirmar cancelamento",
+        "cancel-custom-reason": "Descreva o motivo",
+        "cancel-error": "Não foi possível cancelar esta sessão. Tente novamente.",
+        "cancel-reason-prompt": "Por que você está cancelando esta sessão?",
+        "cancel-session": "Cancelar sessão",
+        "cancel-success": "Sessão cancelada com sucesso.",
+        "cancelled-title": "Sessão cancelada",
+        "completed-title": "Sessão concluída",
+        "notify": "Notificar paciente",
+        "notify-error": "Não foi possível enviar a notificação. Tente novamente.",
+        "notify-sending": "A enviar notificação…",
+        "notify-success": "Paciente notificado com sucesso.",
+        "read-only": "Sessões canceladas estão disponíveis apenas para consulta.",
+        "reschedule": "Reagendar",
+        "reschedule-confirm": "Confirmar remarcação",
+        "reschedule-error": "Não foi possível reagendar este agendamento. Tente novamente.",
+        "reschedule-no-slots": "Não há horários disponíveis para remarcar. Tente ajustar os seus horários de trabalho.",
+        "reschedule-prompt": "Selecione um novo horário para esta consulta.",
+        "reschedule-success": "Agendamento reagendado com sucesso.",
+        "role": "Sessão do paciente",
+        "upcoming-title": "Sessão agendada",
+        "update-error": "Não foi possível atualizar esta sessão. Tente novamente.",
+        "update-no-change": "Nenhuma alteração foi feita — o horário da sessão é o mesmo.",
+        "update-success": "Sessão atualizada com sucesso."
+      },
+      "status": {
+        "active": "Ativo",
+        "archived": "Arquivado",
+        "merged": "Mesclado"
+      },
+      "stats": {
+        "total": "Total de sessões",
+        "upcoming": "Próximas",
+        "completed": "Concluídas",
+        "cancelled": "Canceladas"
+      },
+      "notifications": {
+        "label": "Notificações",
+        "reminders-off": "Lembretes desativados"
+      },
+      "sections": {
+        "billing": "Cobrança",
+        "details": "Dados do paciente",
+        "timeline": "Linha do tempo"
+      },
+      "billing": {
+        "model": "Modelo de cobrança",
+        "category": "Categoria de cobrança",
+        "amount": "Preço",
+        "currency": "Moeda",
+        "models": {
+          "per-session": "Pago por sessão",
+          "monthly": "Pago mensalmente"
+        },
+        "categories": {
+          "standard": "Padrão",
+          "social": "Atendimento social",
+          "pro-bono": "Pro bono"
+        },
+        "category-descriptions": {
+          "standard": "Atendimento pago normalmente, pela tarifa acordada.",
+          "social": "Atendimento com valor reduzido ou apoio social, acompanhado separadamente.",
+          "pro_bono": "Atendimento gratuito, sem expectativa de pagamento."
+        }
+      },
+      "share": {
+        "title": "Sua página de sessões",
+        "text": "Use este link para ver e gerir as suas sessões agendadas.",
+        "link-label": "Link público de sessões"
+      },
+      "preferred-contact": {
+        "phone": "Telefone",
+        "whatsapp": "WhatsApp",
+        "google-meet": "Google Meet",
+        "zoom": "Zoom",
+        "not-set": "Não definido"
+      },
+      "next-session": "Próxima sessão",
+      "last-session": "Última sessão concluída",
+      "no-upcoming-session": "Nenhuma próxima sessão agendada",
+      "no-completed-session": "Nenhuma sessão concluída ainda",
+      "no-sessions": "Nenhuma sessão foi agendada para este paciente ainda.",
+      "delivery": {
+        "online": "Online",
+        "in-person": "Presencial",
+        "not-set": "Formato não definido"
+      },
+      "sessions": {
+        "upcoming": "Próxima",
+        "completed": "Concluída",
+        "cancelled": "Cancelada"
+      }
+    }
+  },
+  "auth": {
+    "error": {
+      "login-failed": "Email ou senha inválidos. Por favor, verifique suas credenciais e tente novamente.",
+      "registration-failed": "Não foi possível completar o cadastro. Por favor, verifique suas informações e tente novamente.",
+      "password-reset-request": "Se este email estiver cadastrado, você receberá instruções para redefinir sua senha.",
+      "password-reset-failed": "Não foi possível redefinir a senha. O link pode ter expirado. Por favor, solicite um novo.",
+      "session-expired": "Sua sessão expirou. Por favor, faça login novamente.",
+      "rate-limited": "Muitas tentativas. Por favor, aguarde um momento antes de tentar novamente.",
+      "generic": "Algo deu errado. Por favor, tente novamente mais tarde."
+    },
+    "success": {
+      "password-reset-request": "Se este email estiver cadastrado, você receberá instruções para redefinir sua senha em breve.",
+      "password-reset": "Sua senha foi alterada com sucesso. Você já pode fazer login.",
+      "logout": "Você saiu com sucesso."
+    },
+    "continue-google": "Continuar com Google",
+    "continue-email": "Continue com seu e-mail"
+  },
+  "globals": {
+    "email": "Email",
+    "name": "Nome",
+    "password": "Senha",
+    "phone": "Telefone",
+    "whatsapp": "Whatsapp",
+    "address": "Endereço",
+    "patients": "Pacientes",
+    "patient": "Paciente",
+    "registered-patients": "Pacientes registrados",
+    "patients-manager": "Genrecie seus pacientes",
+    "billing-manager": "Gerencie seus pagamentos",
+    "subscription-manager": "Gerencie sua assinatura",
+    "appointments": "Atendimentos",
+    "appointments-manager": "Gerencie seus atendimentos",
+    "change-language": "Mude o idioma",
+    "help": "Centro de suporte",
+    "logout": "Sair",
+    "plan": "Plano",
+    "cancel": "Cancelar",
+    "delete": "Excluir",
+    "edit": "Alterar",
+    "date-time-format": "{{format}}",
+    "time-remaining": {
+      "days": "Em {{count}} dia(s)",
+      "hours": "Em {{count}} horas(s)",
+      "minutes": "Em {{count}} minuto(s)",
+      "less-than-a-minute": "Sessão {{status}}"
+    },
+    "in-progress": "Em andamento",
+    "paused": "Pausada",
+    "proceed": "Continuar",
+    "resume": "Retomar",
+    "reason": "Motivo",
+    "global-reason": "Motivo geral",
+    "custom-reason": "Descreva o motivo",
+    "select": "Selecione",
+    "unselect": "Desmarcar",
+    "error": {
+      "already-subscribed": "Você já está na nossa lista de espera",
+      "internal-server-error": "Algo aconteceu errado, tente novamente mais tarde",
+      "invalid-user": "Email ou senha invalidos"
+    },
+    "success": {
+      "subscribed": "Você foi inscrito com sucesso. Por favor verifique o seu -mail!"
+    },
+    "date": "Data",
+    "time": "Hora",
+    "at": "às",
+    "date-time": "Data e Hora: ",
+    "therapist": "Terapeuta",
+    "appointment-status": {
+      "booked": "Confirmado",
+      "available": "Disponível",
+      "onhold": "Em espera",
+      "blocked": "Bloqueado",
+      "cancelled": "Cancelado"
+    },
+    "contacts": "Contatos",
+    "starts": "Começa às",
+    "ends": "Termina às",
+    "time-range": {
+      "time-from-to": "das {{start}} às {{end}}",
+      "time-range-date": "{{date}} das {{start}} às {{end}}",
+      "your-time": "Seu horário local",
+      "patient-time": "Horário do paciente",
+      "therapist-time": "Horário do terapeuta"
+    },
+    "notification": {
+      "email": "Enviar e-mail",
+      "phone": "Ligar",
+      "whatsapp": "Enviar WhatsApp"
+    },
+    "cancellation-title": "Por favor nos informe o motivo do cancelamento da sua consulta",
+    "cancellation-reason": {
+      "1": "Emergência (Questão Pessoal/Saúde)",
+      "2": "Conflito de Agenda",
+      "3": "Problemas Financeiros",
+      "4": "Questões de Saúde Mental",
+      "5": "Não Comparecimento",
+      "6": "Consulta Encerrada",
+      "7": "Outro"
+    },
+    "cancellation-other-title": "Por favor especifique o motivo",
+    "status": "Disponibilidade",
+    "close": "Fechar",
+    "read-only": "Apenas leitura",
+    "auth-method": "Método de autenticação",
+    "privacy-policy": "Política de Privacidade",
+    "terms-of-service": "Termos de Uso",
+    "privacy": "Privacidade",
+    "previous": "Anterior",
+    "next": "Próximo"
+  },
+  "components": {
+    "form": {
+      "confirm-password": "Confirmar senha",
+      "keep-loggedin": "Mantenha-me online",
+      "not-valid": "Alguns campos estão faltando",
+      "signup": {
+        "sign-up": "Cadastra-se",
+        "title-email": "Crie sua conta ",
+        "title": "Crie a sua conta Psycron",
+        "first-name": "Nome",
+        "firstName": "Nome",
+        "last-name": "Sobrenome",
+        "lastName": "Sobrenome",
+        "already-have-acc": "Você já tem uma conta?",
+        "signin-here-link": "Clique aqui para entrar"
+      },
+      "signin": {
+        "sign-in": "Entrar",
+        "title": "Olá de volta!",
+        "dont-have-acc": "Você ainda não tem uma conta?",
+        "signup-here-link": "Cadastre-se aqui",
+        "forgot-password": "Esqueceu a sua senha?"
+      },
+      "validation": {
+        "required": "{{name}} é um campo obrigatório",
+        "invalid": "{{name}} não é válido",
+        "characters": "Senha deve conter no mínimo {{numChar}} caracteres",
+        "pass-rules": "Sua senha deve conter ao menos uma letra maiúscula, uma letra minúscula, um número e um caractere especial (@€#$+...) ",
+        "at-least-one-contact": "Informe um email ou número de telefone",
+        "match": "{{name}} precisa coincidir"
+      },
+      "address-form": {
+        "search": "Procure o endereço aqui",
+        "search-note": "Você pode começar pesquisando o indereço aqui, ou então preencher os campos abaixo",
+        "street": "Rua",
+        "number": "Nº",
+        "hood": "Localidade / bairro",
+        "more-info": "Complemento",
+        "city": "Cidade",
+        "state": "Estado",
+        "zip": "Cep",
+        "country": "País",
+        "more-info-bttn": "Adicione um complemento"
+      },
+      "add-patient": {
+        "name": "Adicionar paciente"
+      },
+      "contacts-form": {
+        "contact-via": "Entrar em contato via {{method}}?",
+        "contact-via-same": "O número é o mesmo para o Whatsapp?"
+      },
+      "preferred-contact": {
+        "coming-soon": "Integração em breve — cole o link da sessão por enquanto",
+        "label": "Plataforma preferida para sessão",
+        "value-phone": "Número de telefone",
+        "value-url": "Link da reunião (URL)",
+        "type": {
+          "google_meet": "Google Meet",
+          "phone": "Ligação",
+          "whatsapp": "WhatsApp",
+          "zoom": "Zoom"
+        }
+      },
+      "consent": {
+        "terms": "Eu concordo com a <privacyLink>Política de Privacidade</privacyLink> e os <termsLink>Termos de Uso</termsLink>",
+        "marketing": "Eu concordo em receber <marketingLink>comunicações de marketing.</marketingLink>",
+        "info": "Ao continuar, você automaticamente aceita as <privacyLink>Política de Privacidade</privacyLink> e os <termsLink>Termos de Uso</termsLink> da Psycron."
+      }
+    },
+    "input": {
+      "phone-input": {
+        "select-label": "País",
+        "phone-num-label": "Número de {{registerName}}",
+        "phone-number-guide": "Por favor, forneça seu número de telefone com o código da cidade",
+        "invalid": "Número de telefone inválido",
+        "valid": "Número de telefone válido"
+      },
+      "text": {
+        "first-name": "Seu primeiro nome",
+        "last-name": "Seu último sobrenome",
+        "email": "Seu e-mail"
+      }
+    },
+    "navbar": {
+      "action-center": "Central de ações",
+      "dashboard": "Painel",
+      "conflicts": "Conflitos",
+      "notifications": "Notificações",
+      "user-settings": "Configurações",
+      "test": "Testes"
+    },
+    "user-details": {
+      "edit": "Editar detalhes",
+      "edit-contacts": "Editar contatos",
+      "edit-success": "Dados atualizados",
+      "add-contacts": "Adicione seu {{contactValue}}",
+      "change": "Alterar {{name}}",
+      "save": "Salvar",
+      "address-not-found": "Nenhum endereço cadastrado. Adicione suas informações.",
+      "detail-not-found": "{{detail}} não cadastrado ainda",
+      "no-changes": "Selecione uma secção para editar antes de guardar.",
+      "delete": {
+        "title": "Excluir conta",
+        "description": "Sua conta será desativada e seus dados ficarão anônimos dentro de 30 dias. Você pode entrar em contato com nosso suporte técnico para mais detalhes.",
+        "confirmation": "Excluir"
+      },
+      "section": {
+        "title": {
+          "account": "Conta",
+          "clinic": "Endereço do Consultório",
+          "contact": "Contatos",
+          "patients": "Pacientes",
+          "security": "Segurança & Privacidade",
+          "subscription": "Assinatura"
+        },
+        "local": "Email e Senha",
+        "security": {
+          "google-mgmt": "Gerenciada por Google - A sua senha é seguramente guardada através do sistema de autênticação da Google e nós não tem acesso.",
+          "accepted": "Ao criar sua conta na Psycron, você concordou com nossos <privacyLink>Política de Privacidade</privacyLink> e <termsLink>Termos de Uso</termsLink>.",
+          "accepted-info": "Você pode revisar esses documentos a qualquer momento.",
+          "marketing": "Receber comunicações de marketing e news"
+        },
+        "clinic": {
+          "add-address": "Adicionar endereço do consultório",
+          "address-label": "Endereço",
+          "edit-address": "Editar endereço",
+          "title-empty": "Adicione o endereço do seu consultório para que os pacientes o recebam na confirmação de consulta."
+        },
+        "contact": {
+          "title-empty": "Adicione seu número para receber notificações em SMS ou WhatsApp."
+        }
+      }
+    },
+    "dashboard": {
+      "card": {
+        "delay-notification": "Pausar o cronômetro vai atrasar todos os seus compromissos de hoje pelo tempo da pausa.",
+        "delay-confirmation": "Você tem certeza que quer pausar o cronômetro?",
+        "pause": "Pausar cronômetro",
+        "session-progress": "Progresso da sessão:"
+      },
+      "availability-card": {
+        "first-availability": "Crie sua disponibilidade de agenda aqui"
+      }
+    },
+    "appointments": {
+      "card-title": "Consultas do dia",
+      "manager": "Gerenciador de consultas"
+    },
+    "patients-table": {
+      "name": "Nome do paciente",
+      "next-session": "Próxima sessão",
+      "payment-status": "Status de pagamento",
+      "sessions-month": "Sessões por mês",
+      "value": "Valor por sessão",
+      "discount": "Desconto?",
+      "discount-val": "Valor do desconto",
+      "amount": "Valor total",
+      "currency": "Moeda",
+      "latest-payment": "Último pagamento",
+      "manage": "Veja paciente"
+    },
+    "progress": {
+      "received": "Você já recebeu {{progress}}% dos seus pagamentos 🥳",
+      "missing": "Faltam {{progress}}% dos seus pagamentos",
+      "not-received": "Você não recebeu nenhum pagamento ainda",
+      "received-all": "Você recebeu 100% dos seus pagamentos para este período 🥳 😎"
+    },
+    "c2-action": {
+      "join-waitlist": "Junte-se à nossa <strong>lista de espera</strong> para simplificar sua prática de terapia e focar mais em seus pacientes.",
+      "email": "Seu email",
+      "join-now": "Inscreva-se"
+    },
+    "hero": {
+      "heading": "Transforme sua prática de terapia com essa solução completa",
+      "helper": "Gerencie facilmente seus agendamentos, pagamentos, prontuários, faturamento e muito mais."
+    },
+    "header": {
+      "join": "Inscreva-se",
+      "benefits": "Utilidades",
+      "contact": "Contato",
+      "language": "Idioma"
+    },
+    "link": {
+      "navigate": {
+        "back": "Voltar",
+        "next": "Prosseguir",
+        "finish": "Finalizar",
+        "confirm": "Confirmar",
+        "cancel": "Cancelar"
+      }
+    },
+    "footer": {
+      "contact": "Quer entrar em contato? <a>Você pode nos encontrar aqui</a>",
+      "find-me": "Você pode nos encontrar aqui",
+      "credit": {
+        "illustration": "Ilustrações por <owner>Icons 8</owner> de <page>Ouch!</page>"
+      }
+    },
+    "share-button": {
+      "alert": {
+        "success": "Compartilhado com sucesso!",
+        "success-copy": "Link copiado com sucesso!",
+        "error": "Erro ao compartilhar, tente novamente mais tarde.",
+        "error-copy": "Erro ao copiar o link, tente novamente mais tarde."
+      },
+      "tooltip-tile": "Compartilhar com {{with}}",
+      "share-with-name": "com {{name}}",
+      "share-with-patients": "com seus pacientes",
+      "share-infos": {
+        "availability": {
+          "title": "{{therapistName}} compartilhou com você a disponibilidade",
+          "text": "Entre aqui para agendar o seu horário"
+        }
+      }
+    },
+    "agenda": {
+      "modal": "Você está marcando a sua consulta para {{appointment}}",
+      "your-details": "Seus detalhes",
+      "next-week": "Próxima semana",
+      "previous-week": "Semana anterior",
+      "today": "Hoje",
+      "Month": "Mês",
+      "appointment-details": {
+        "title": "Detalhes da sessão",
+        "mailto-subject": "🔔 Sobre sua consulta com {{therapistName}} 🔔",
+        "whatsapp-subject": "Olá, tudo bem? Estou enviando essa mensagem sobre sua consulta comigo, {{therapisName}}",
+        "next-sessions": "Outras sessões",
+        "edit-patient-details": "Alterar detalhes do paciente",
+        "edit-patient-appointment": "Alterar sessão",
+        "edit-availability": "Alterar disponibilidade",
+        "text-status": "Esse horário está {{status}}"
+      },
+      "edit-appointment": {
+        "title": "Editar consulta",
+        "confirmation": "Tem certeza de que quer reagendar esta consulta?"
+      },
+      "cancel-appointment": {
+        "title": "Cancelar consulta(s)",
+        "select-all": "{{select}} Todas",
+        "global-reason": "Por favor, selecione um motivo geral:",
+        "confirmation": "Você tem certeza que deseja cancelar todas as consultas?",
+        "review": "Revise as datas que você selecionou"
+      },
+      "book-appointment": {
+        "title": "Agendando sua consulta"
+      }
+    }
+  },
+  "page": {
+    "landing": {
+      "seo": {
+        "title": "Psycron - Aplicativo Inovador de Gestão para Terapeutas",
+        "description": "Transforme sua prática de terapia com essa solução completa. Com esse app você pode gerenciar facilmente seus agendamentos, pagamentos, prontuários, faturamento e muito mais.",
+        "ogTitle": "Psycron - Aplicativo Inovador de Gestão para Terapeutas",
+        "ogDescription": "Transforme sua prática de terapia com essa solução completa. Com esse app você pode gerenciar facilmente seus agendamentos, pagamentos, prontuários, faturamento e muito mais."
+      },
+      "values": {
+        "all-in-one": "Solução completa",
+        "text": "Do agendamento de consultas ao processamento de pagamentos, manutenção de prontuários e faturamento, ajudamos você nas tarefas diárias para que tenha muito mais tempo para cuidar dos seus pacientes. Nossa solução pode transformar a gestão da sua prática, integrando tudo em uma única plataforma intuitiva.",
+        "text-focus": "Agora você pode focar no que realmente importa e deixar o resto com a gente."
+      },
+      "benefits": {
+        "increased-efficiency": {
+          "name": "Mais eficiência",
+          "description": "Perca menos tempo em tarefas administrativas. Automatize lembretes, agendamento de consultas e gerencie seus prontuários de forma integrada. Foque mais nos seus pacientes, não nos processos"
+        },
+        "better-patient-management": {
+          "name": "Maior gestão de pacientes",
+          "description": "Acompanhe facilmente o histórico e as consultas dos pacientes. Auxilie seu atendimento com registros organizados e atualizados."
+        },
+        "reduced-administrative-burden": {
+          "name": "Elimine a carga administrativa",
+          "description": "Simplificamos o fluxo do trabalho para você"
+        },
+        "enhanced-financial-control": {
+          "name": "Maior controle financeiro",
+          "description": "Assuma o controle das suas finanças com faturamento seguro e eficiente"
+        }
+      },
+      "ct-action": {
+        "heading": "Você quer revolucionar a sua prática de trabalho?",
+        "join-waitlist": "<strong>Junte-se à nossa lista de espera</strong> hoje e <strong>e se antecipe</strong> para <strong>experimentar</strong> uma gestão de prática terapêutica <strong>inovadora</strong>. <strong>Desbloqueie</strong> <strong>novos níveis</strong> de <strong>eficiência</strong> e <strong>cuidado ao paciente</strong> com <strong>um produto feito para você</strong>."
+      }
+    },
+    "not-found": {
+      "title": "Oops, algo deu errado!",
+      "sub-title": "Mas relaxa que já estamos correndo atrás disso!",
+      "note": "Pois é... prometo que estamos :)"
+    },
+    "unsubscribe": {
+      "title": "Até logo, {{email}}!",
+      "body-text": "Agradecemos por fazer parte da nossa jornada. Embora a gente fique triste em ver você partir, entendemos completamente sua decisão. Continuaremos trabalhando duro para oferecer o melhor que podemos e, lembre-se, estaremos sempre com as portas abertas para você, sempre que quiser voltar.",
+      "see-you": "Esperamos você de volta logo logo! ❤️",
+      "confirm": "Clique aqui para completar"
+    },
+    "reset-password": {
+      "reset": "Resetar senha",
+      "change-password": "Alterar senha",
+      "password-rule": "A sua senha deve conter no mínimo:",
+      "password-example": "Exemplo:",
+      "item-letter": "Uma letra {{rule}}",
+      "item-number": "Um número {{rule}}",
+      "item-special": "Um caractere especial {{rule}}",
+      "item-minimum": "9 dígitos",
+      "current-password": "Senha atual"
+    },
+    "availability": {
+      "wizard": {
+        "wizard-items": {
+          "intro": {
+            "label": "Introdução",
+            "title": "Vamos configurar sua disponibilidade. Podemos começar?",
+            "alert": "Você vai precisar finalizar a sua configuração de disponibilidade depois"
+          },
+          "weekdays": {
+            "label": "Escolha os dias da semana",
+            "title": "Por favor nos informe os dias no qual você costuma atender os seus pacientes."
+          },
+          "duration": {
+            "label": "Duração da consulta",
+            "title": "Por favor nos informe quanto tempo dura a sua consulta."
+          },
+          "week-slots": {
+            "label": "Horários em uma semana"
+          }
+        },
+        "intro": {
+          "options": {
+            "proceed": "Sim!",
+            "finish-later": "Deixar para depois"
+          }
+        },
+        "availability-days": {
+          "days": {
+            "mon": "Segunda",
+            "tue": "Terça",
+            "wed": "Quarta",
+            "thu": "Quinta",
+            "fri": "Sexta"
+          },
+          "options": {
+            "all": "Incluir todos os dias",
+            "weekends": "Excluir fins de semana",
+            "specific": "Selecionar dias específicos"
+          }
+        },
+        "duration": {
+          "label": "Duração da consulta",
+          "note": "Caso você tenha mais de um tipo de consulta, nos informe a duração que você mais utiliza. Você poderá alterar isso no futuro, sem maiores problemas!"
+        },
+        "hours": {
+          "no-session": "Nenhuma sessão disponível"
+        },
+        "modal-title": "Repita sua disponibilidade semanal",
+        "modal-info": "Por favor, escolha uma das opções abaixo. Se você selecionar 'semanal,' sua disponibilidade será repetida até o final do mês. Se escolher 'mensal,' ela será repetida até o final do ano.",
+        "complete": "Sessão de disponibilidade concluída!"
+      },
+      "agenda": {
+        "status": {
+          "available": "Disponível",
+          "unavailable": "Indisponível",
+          "booked": "Reservado",
+          "empty": "Vazio",
+          "blocked": "Bloqueado",
+          "cancelled": "Cancelado",
+          "onhold": "Em espera"
+        },
+        "therapist-edit-modal": {
+          "title": "Altere sua disponibilidade"
+        }
+      }
+    },
+    "book-appointment": {
+      "title": "Horários Disponíveis de {{therapisName}}",
+      "description": "Agende facilmente sua consulta. Veja os horários disponíveis e escolha o melhor momento para marcar sua sessão de forma rápida e prática.",
+      "confirmation-should-replicate": "Deseja usar esse dia como sua escolha padrão para futuras consultas?",
+      "recurrence-pattern": {
+        "month": "Toda semana até o fim do mês",
+        "year": "Toda semana até o fim do ano",
+        "single": "Apenas esta consulta",
+        "all-future": "Todas as próximas consultas"
+      },
+      "confirm-edit": "Por favor, confirme que deseja alterar sua consulta de {{previousDate}} para:",
+      "edit-recurrence-title": "Você deseja alterar apenas esta consulta ou todas as próximas?",
+      "edit-appointment-title": "Você está alterando a sua consulta do dia {{formattedDate}} às {{startTime}}."
+    },
+    "booking-confirmation": {
+      "title": "Sua consulta com <strong>{{therapistName}}</strong> está confirmada 🎉",
+      "title-plain": "Sua consulta com {{therapistName}} está confirmada 🎉",
+      "subtitle": "Estamos ansiosos para te ver em breve!",
+      "whats-next": "<strong>{{therapistName}}</strong> entrará em contato com mais detalhes quando estiver perto da consulta",
+      "advise": "Pedimos para que você esteja disponível alguns minutos antes da consula começar",
+      "reschedule": "Você pode remarcar a sua consulta até 1 dia de antecedência.",
+      "cancel": "Para remarcar ou cancelar, por favor <strong>clique aqui</strong>",
+      "help": "Caso tenha alguma dúvida ou precise de ajuda, entre em contato conosco via ",
+      "thanks": "Estamos aqui para te apoiar. Aguardamos sua consulta!",
+      "cancel-or-edit": {
+        "title": "Deseja fazer alguma mudança?",
+        "sub": "Você pode reagendar ou cancelar esta sessão agora.",
+        "appointment-info": "Sua consulta no dia {{date}} às {{startTime}}",
+        "donwload-ics": "Adicione ao seu calendário 📅"
+      },
+      "no-appointments-title": "Você ainda não tem nenhuma consulta marcada",
+      "no-appointments-link": "Clique aqui para agendar suas consultas"
+    },
+    "appointment-list": {
+      "date": "Data",
+      "starts": "Começa",
+      "ends": "Termina",
+      "modal": {
+        "title": "Tem certeza que você deseja {{action}} esta sessão?"
+      },
+      "description": "Aqui você poderá configurar seus horários para consultas e compartilhá-los com seus pacientes. Vamos guiar você por um processo simples para definir seus horários de atendimento, de maneira que eles sejam replicados ao longo das semanas ou até o final do ano. O processo é flexível e você poderá ajustar as informações a qualquer momento no futuro.",
+      "guide": {
+        "step1": {
+          "title": "Decida se quer começar agora ou depois",
+          "description": "Se preferir, você pode voltar a esta etapa mais tarde. Sabemos que nem sempre é possível configurar tudo de imediato, então você terá a opção de retomar o processo no momento que for mais conveniente."
+        },
+        "step2": {
+          "title": "Defina seus dias de folga",
+          "description": "Nos informe quais dias da semana você não estará disponível para consultas. Esses dias ficarão bloqueados, mas poderão ser alterados no futuro, se necessário."
+        },
+        "step3": {
+          "title": "Duração da sessão",
+          "description": "Informe a duração média das suas consultas. Caso ofereça mais de um tipo de sessão, vamos definir um padrão agora e você poderá ajustar os tempos conforme o paciente e o tipo de terapia."
+        },
+        "step4": {
+          "title": "Escolha seus horários",
+          "description": "De maneira visual e interativa, você poderá selecionar os horários em que estará disponível para consultas ao longo da semana. É um processo flexível: se suas preferências mudarem, você pode ajustar seus horários a qualquer momento."
+        }
+      },
+      "session-past": "Consulta passada"
+    },
+    "cancel-appointment": {
+      "title": "Cancelamento de Consulta(s)",
+      "sub-title": "Por favor selecione a(s) consulta(s) que você quer cancelar"
+    },
+    "edit-appointment": {
+      "title": "Altere a Consulta",
+      "sub-title": "Por favor selecione a data que deseja alterar"
+    },
+    "add-patient": {
+      "title": "Adicione um Novo Paciente",
+      "sub-title": "Preencha o formulário abaixo com os detalhes da pessoa"
+    },
+    "dashboard": {
+      "title": "Dashboard",
+      "greeting": {
+        "headline": "Olá, {{name}}!",
+        "band": {
+          "morning": "Bom dia",
+          "afternoon": "Boa tarde",
+          "evening": "Boa noite"
+        }
+      },
+      "tiles": {
+        "action-center": "Central de ações",
+        "schedule": "Agenda de hoje",
+        "greeting": "Saudação",
+        "jupiter-insights": "Insights da Júpiter",
+        "notifications": "Notificações",
+        "quick-actions": "Ações rápidas",
+        "active-patients": "Pacientes ativos",
+        "billing-readiness": "Cobrança configurada",
+        "revenue": "Receita estimada",
+        "session-analytics": "Análise de sessões",
+        "pending-tasks": "Tarefas pendentes",
+        "recent-patients": "Pacientes recentes"
+      },
+      "tile": {
+        "close": "Fechar",
+        "hide": "Ocultar bloco",
+        "layout-column": "Usar layout em coluna",
+        "layout-column-aria": "Alternar bloco para layout em coluna",
+        "layout-row": "Usar layout em linha",
+        "layout-row-aria": "Alternar bloco para layout em linha",
+        "read-more": "Ler mais",
+        "resize-down": "Reduzir altura",
+        "resize-narrow": "Estreitar",
+        "resize-narrow-aria": "Tornar o bloco mais estreito",
+        "resize-down-aria": "Reduzir altura do bloco",
+        "resize-up": "Aumentar altura",
+        "resize-wide": "Alargar",
+        "resize-wide-aria": "Tornar o bloco mais largo",
+        "resize-up-aria": "Aumentar altura do bloco",
+        "show": "Mostrar bloco",
+        "drag": "Arrastar para reordenar",
+        "drag-aria": "Arrastar tile para reordenar"
+      },
+      "customize": {
+        "open": "Personalizar",
+        "done": "Concluído",
+        "hint": "Arraste os blocos para reordenar · clique no ícone de olho para ocultar",
+        "organize": "Organizar",
+        "reset": "Redefinir layout"
+      },
+      "widgets": {
+        "schedule": {
+          "title": "Hoje",
+          "title-week": "Semana",
+          "title-label": "Agenda de hoje",
+          "title-week-label": "Agenda desta semana",
+          "range-aria-label": "Escolher período da agenda",
+          "count": "{{count}} sessões",
+          "empty": "Nenhuma sessão agendada para hoje",
+          "unknown-patient": "Paciente desconhecido",
+          "sessions-today": "sessões hoje",
+          "sessions-week": "sessões esta semana",
+          "view-week": "Ver semana",
+          "online": "Online",
+          "in-person": "Presencial",
+          "min": "min",
+          "status": {
+            "live": "AO VIVO",
+            "done": "Concluído",
+            "confirmed": "Confirmado",
+            "pending": "Pendente"
+          },
+          "info": {
+            "title": "Agenda de hoje",
+            "description": "Mostra suas sessões agendadas para hoje e esta semana, com rastreamento de status em tempo real.",
+            "future": "Notas de preparação por paciente, alertas de conflito inteligentes e sugestões de reagendamento em um toque."
+          }
+        },
+        "jupiter-insights": {
+          "aria-label": "Carrossel de insights da Júpiter",
+          "dismiss": "Dispensar insight",
+          "empty": "Nenhum insight disponível no momento",
+          "action-availability": "Ver disponibilidade",
+          "title-schedule": "Sessões de hoje",
+          "text-schedule": "Você tem {{count}} sessão(ões) agendada(s) hoje. Continue assim!",
+          "title-patients": "Pacientes ativos",
+          "text-patients": "Você tem atualmente {{count}} paciente(s) ativo(s) na sua lista.",
+          "subtitle": "Co-piloto de IA · aprendendo seus padrões",
+          "default-category": "Cuidado ao Paciente",
+          "category-daily-briefing": "Resumo do dia",
+          "category-operations": "Operações",
+          "category-patient-care": "Cuidado ao Paciente",
+          "category-insights": "Insights",
+          "action-send-message": "Enviar mensagem",
+          "action-view-profile": "Ver perfil",
+          "mic": "Entrada de voz",
+          "text-setup-availability": "Configure sua agenda com a Júpiter para começar a receber agendamentos.",
+          "action-setup-availability": "Configurar agora",
+          "text-no-patients-yet": "Tudo pronto — compartilhe seu link de agendamento com seus primeiros pacientes.",
+          "category-setup": "Configuração",
+          "category-growth": "Crescimento",
+          "category-schedule": "Agenda",
+          "text-session-none-today": "Nenhuma sessão hoje — um bom momento para revisar suas anotações.",
+          "text-session-count-today": "Você tem {{count}} sessão(ões) hoje. Continue assim!",
+          "text-whatsapp-reminders": "Ative os lembretes por WhatsApp para reduzir faltas em poucos toques.",
+          "action-set-up-reminders": "Configurar lembretes",
+          "text-busy-day": "{{day}} parece ser seu dia mais movimentado desta semana. Mantenha o ritmo!",
+          "action-view-schedule": "Ver agenda",
+          "text-week-cancellations": "{{count}} sessão(ões) cancelada(s) esta semana. Considere entrar em contato para reagendar.",
+          "text-patient-milestone": "Você chegou a {{count}} pacientes ativos. Grande conquista!",
+          "text-low-week-volume": "Você tem {{count}} sessão(ões) esta semana. Abrir mais horários pode ajudar seu crescimento.",
+          "text-billing-readiness-incomplete": "{{missing}} paciente(s) ainda precisam do valor das sessões para que futuros pagamentos se encaixem no seu fluxo.",
+          "text-billing-readiness-ready": "Os dados de cobrança dos pacientes estão prontos para futuros fluxos de pagamento e cobrança.",
+          "action-review-patients": "Revisar pacientes",
+          "action-view-patients": "Ver pacientes",
+          "text-session-none-today-week": "Nenhuma sessão hoje — você tem {{count}} sessão(ões) esta semana. Veja sua agenda.",
+          "text-missed-rebooking": "{{name}} faltou à última sessão e não reagendou. Um contato pode ajudar.",
+          "text-dashboard-summary-fallback": "A Júpiter está lendo seu painel. Você tem {{count}} sessão(ões) agendada(s) esta semana.",
+          "info": {
+            "title": "Insights da Júpiter",
+            "description": "Observações geradas por IA sobre sua prática com base em agenda, pacientes e cobrança — personalizadas a cada sessão.",
+            "future": "Recomendações preditivas de agenda, alertas de risco por paciente e orientação clínica proativa adaptada à sua especialidade."
+          }
+        },
+        "quick-actions": {
+          "title": "Ações Rápidas",
+          "descriptions": {
+            "add-patient": "Criar perfil de paciente",
+            "availability-settings": "Horários, fuso horário",
+            "fix-reminders-count": "{{count}} com falha ou em fila",
+            "fix-reminders-setup": "Configurações de lembrete",
+            "follow-up-cancellations": "{{count}} item(ns) de recuperação",
+            "patients": "{{count}} ativos",
+            "setup-availability": "Criar horários de atendimento",
+            "view-week": "{{count}} sessões"
+          },
+          "actions": {
+            "new-session": "Nova sessão",
+            "new-session-aria": "Abrir disponibilidade para nova sessão",
+            "patients": "Meus pacientes",
+            "patients-aria": "Ir para lista de pacientes",
+            "add-patient": "Adicionar paciente",
+            "add-patient-aria": "Adicionar novo paciente",
+            "fix-reminders": "Ajustar lembretes",
+            "follow-up-cancellations": "Acompanhar cancelamentos",
+            "notifications": "Notificações",
+            "notifications-aria": "Ver notificações",
+            "setup-availability": "Configurar agenda",
+            "view-week": "Ver semana",
+            "availability-settings": "Configurações de agenda"
+          },
+          "info": {
+            "title": "Ações rápidas",
+            "description": "Atalhos para as ações mais relevantes com base no estado atual da sua prática. O Psycron escolhe o que importa mais agora.",
+            "future": "Sugestões de ações totalmente contextuais com a Júpiter que se adaptam à sua semana, seus pacientes e seus hábitos."
+          }
+        },
+        "active-patients": {
+          "label": "Pacientes ativos",
+          "title": "Últimos pacientes",
+          "empty": "Nenhum paciente adicionado ainda"
+        },
+        "billing-readiness": {
+          "label": "Cobrança configurada",
+          "status": {
+            "empty": "Prepare as futuras ferramentas de pagamento adicionando pacientes primeiro.",
+            "partial": "{{configured}} de {{total}} pacientes prontos para pagamentos futuros · {{missing}} pendentes",
+            "ready": "Configuração pronta para pagamentos futuros"
+          },
+          "details": "Adicione o valor das sessões agora para que a Psycron crie fluxos de pagamento e cobrança alinhados à forma como sua prática já funciona.",
+          "donut-meta": "{{configured}}/{{total}} prontos",
+          "status-chip": {
+            "empty": "Ação necessária",
+            "partial": "Em progresso",
+            "ready": "Pronto"
+          },
+          "teaser": {
+            "title": "Prepare pagamentos futuros",
+            "subtitle": "Registre os valores das sessões agora para que as futuras ferramentas de pagamento se encaixem no seu fluxo desde o primeiro dia.",
+            "coming-soon": "Cobrança e pagamentos virão depois; por enquanto, isso só mantém os dados de cobrança dos pacientes prontos."
+          },
+          "info": {
+            "title": "Prontidão de cobrança",
+            "description": "Adicione o valor de cada sessão do paciente agora para que a Psycron possa criar fluxos de pagamento e faturamento alinhados à forma como sua prática já funciona.",
+            "future": "Em seguida, a Psycron avançará para pagamentos criando um sistema automatizado adaptado à forma como você cobra cada paciente."
+          }
+        },
+        "revenue": {
+          "title": "Receita",
+          "title-with-month": "Receita · {{month}}",
+          "estimate-chip": "Est.",
+          "completed": "Concluídas",
+          "configured": "Cobrança",
+          "sessions": "{{count}} sessão(ões)",
+          "patients-ready": "{{configured}} prontos · {{missing}} pendentes",
+          "info": {
+            "title": "Estimativa de receita",
+            "description": "Estima seus ganhos mensais com base nas configurações de cobrança definidas para pacientes ativos. Atualizado em tempo real.",
+            "future": "A Psycron usará esses padrões de receita para criar um sistema automatizado de pagamentos adaptado à sua prática, com faturas, cobrança e acompanhamento de pagamentos integrados ao seu fluxo."
+          }
+        },
+        "notifications": {
+          "title": "Notificações · 24h",
+          "window": "Últimas 24h",
+          "sent": "Enviadas",
+          "failed": "Falharam",
+          "queued": "Em fila",
+          "view-feed": "Ver feed",
+          "info": {
+            "title": "Notificações",
+            "description": "Mostra quantos lembretes e confirmações de consultas foram entregues aos seus pacientes nas últimas 24 horas.",
+            "future": "Desempenho de canal ao longo do tempo, lógica de reenvio inteligente e alertas de falha antes que os pacientes percam sessões."
+          }
+        },
+        "action-center": {
+          "title": "Central de ações",
+          "count-chip": "{{count}} precisa de você",
+          "count-chip_other": "{{count}} precisam de você",
+          "empty": "Nenhum alerta operacional agora.",
+          "item-count": "{{count}} item(ns)",
+          "summary-title": "{{count}} item precisa de atenção",
+          "summary-title_other": "{{count}} itens precisam de atenção",
+          "summary-body": "Um resumo discreto do trabalho operacional em aberto. As ações ficam no espaço dedicado.",
+          "breakdown-label": "Resumo da central de ações",
+          "view-all": "Abrir central de ações",
+          "view-all-meta": "Conflitos e fila de recuperação",
+          "items": {
+            "notification-failed": "Notificação falhou",
+            "patient-duplicate": "Paciente duplicado",
+            "recovery-needed": "Recuperação necessária",
+            "schedule-conflict": "Conflito na agenda"
+          },
+          "info": {
+            "title": "Central de ações",
+            "description": "Sinaliza problemas que precisam de resolução — conflitos de agenda, falhas de entrega de notificações e cancelamentos aguardando acompanhamento.",
+            "future": "Propostas automáticas de resolução de conflitos, fluxos de recuperação com um clique e filas de problemas ordenadas por prioridade."
+          }
+        },
+        "session-analytics": {
+          "title": "Análise de sessões",
+          "range-aria-label": "Escolher período da análise",
+          "completion-rate": "Taxa de conclusão",
+          "blocked": "Bloqueios admin",
+          "blocked-hours": "{{hours}}h bloqueadas",
+          "cancelled": "Canceladas",
+          "chart-aria-label": "Gráfico de barras empilhadas com sessões por dia",
+          "completed": "Concluídas",
+          "insight-down": "Taxa de conclusão caiu {{delta}}% vs {{period}} anterior — vale acompanhar os cancelamentos.",
+          "insight-empty": "Ainda não há sessões encerradas — a comparação começa quando houver dados.",
+          "insight-flat": "Taxa de conclusão estável vs {{period}} anterior — mantenha o ritmo dos lembretes.",
+          "insight-source": "Júpiter",
+          "insight-summary": "{{completed}} de {{concluded}} sessões encerradas foram concluídas.",
+          "insight-up": "Taxa de conclusão subiu {{delta}}% vs {{period}} anterior — os lembretes estão funcionando.",
+          "legend": {
+            "blocked": "Bloqueios admin",
+            "cancelled": "Canceladas",
+            "completed": "Concluídas",
+            "upcoming": "Próximas"
+          },
+          "period": {
+            "month": "mês",
+            "week": "semana"
+          },
+          "sessions": "sessões",
+          "upcoming": "Próximas",
+          "view-month": "Mês",
+          "view-week": "Semana",
+          "info": {
+            "title": "Análise de sessões",
+            "description": "Acompanha sua taxa de conclusão de sessões, cancelamentos e volume ao longo do tempo — a saúde da sua prática em tempo real.",
+            "future": "Análise de tendências, previsão de faltas e benchmarks de ritmo comparados a práticas semelhantes."
+          }
+        },
+        "pending-tasks": {
+          "title": "Tarefas Pendentes",
+          "cancellation-followups": "Acompanhar cancelamentos",
+          "descriptions": {
+            "cancellation-followups": "{{count}} precisam de recuperação",
+            "missing-billing": "{{count}} paciente(s) para configurar",
+            "missing-contact": "{{count}} paciente(s) para atualizar",
+            "reminder-delivery": "{{count}} exigem revisão",
+            "setup-availability": "Obrigatório antes das reservas"
+          },
+          "empty": "Nenhuma tarefa pendente no momento.",
+          "missing-billing": "Pacientes sem cobrança",
+          "missing-contact": "Pacientes sem contato",
+          "reminder-delivery": "Problemas nos lembretes",
+          "setup-availability": "Concluir agenda",
+          "empty-heading": "Tudo certo",
+          "info": {
+            "title": "Tarefas pendentes",
+            "description": "Exibe itens administrativos que precisam de atenção para manter sua prática funcionando — desde cobrança faltante até cancelamentos não resolvidos.",
+            "future": "Pontuação de prioridade, delegação de tarefas para práticas em grupo e sequências de conclusão para manter o ritmo."
+          }
+        },
+        "recent-patients": {
+          "title": "Pacientes Recentes",
+          "activity": {
+            "cancelled": "Sessão cancelada",
+            "created": "Adicionado",
+            "session": "Atividade de sessão",
+            "updated": "Atualizado"
+          },
+          "empty": "Atividades recentes dos pacientes aparecerão aqui.",
+          "view-all": "Todos",
+          "last-note": "última nota",
+          "message-aria": "Enviar mensagem para {{name}}",
+          "info": {
+            "title": "Pacientes recentes",
+            "description": "Destaca os pacientes com atividade mais recente na sua lista, para que você possa retomar rapidamente de onde parou.",
+            "future": "Pontuações de engajamento, mapas de frequência de sessões e alertas proativos quando um paciente some."
+          }
+        },
+        "latest-patients": {
+          "info": {
+            "title": "Últimos pacientes",
+            "description": "Mostra os pacientes adicionados mais recentemente para você nunca perder o controle de novos ingressos e iniciar o onboarding imediatamente.",
+            "future": "Checklists de onboarding automatizados, integração com formulários de admissão e modelos de mensagem de boas-vindas personalizados."
+          }
+        },
+        "info-modal": {
+          "feedback-error": "Não foi possível salvar este feedback. Tente novamente.",
+          "feedback-placeholder": "Compartilhe sua opinião sobre este widget...",
+          "feedback-submit": "Enviar feedback",
+          "feedback-thanks": "Obrigado! Sua opinião ajuda a moldar o Psycron.",
+          "future-heading": "O que vem por aí",
+          "tooltip": "Sobre este widget"
+        }
+      }
+    },
+    "unsubscribe-preferences": {
+      "title": "Gerencie suas preferências de email",
+      "description": "Insira seu endereço de email abaixo para cancelar o recebimento de comunicações de marketing e lista de espera do Psycron.",
+      "disclaimer": "Atenção: emails transacionais — como confirmações de consultas, notificações da conta e alertas de segurança — são obrigatórios e não podem ser cancelados.",
+      "email-label": "Seu endereço de email",
+      "email-placeholder": "voce@exemplo.com",
+      "submit": "Cancelar inscrição",
+      "success-title": "Você foi removido da lista",
+      "success-description": "Se este email estava na nossa lista, ele foi removido. Você não receberá mais emails de marketing do Psycron.",
+      "back-home": "Voltar ao início"
+    }
+  },
+  "chat": {
+    "greeting": "Olá! Eu sou a Júpiter, sua assistente para configurar sua agenda de atendimentos. Vamos construir isso juntos, passo a passo 🧘‍♀️! Vamos?",
+    "let-start": "Quais tipos de terapia você oferece?",
+    "system-instruction": "Você é uma assistente gentil que ajuda terapeutas a montar sua agenda passo a passo. Sempre responda com a próxima pergunta e os dados extraídos até o momento. Por exemplo, se a pergunta for sobre reccurencePattern, você deve explicar que weekly significa até o fim do mês e monthly até o fim do ano",
+    "error": "Oops! Não foi possível continuar a conversa. Tente novamente."
+  },
+  "jupiter": {
+    "welcome": {
+      "title-line1": "Eu sou a Júpiter,",
+      "title-line2": "sua Assistente Inteligente",
+      "subtitle": "Vou te ajudar a configurar sua disponibilidade em poucos momentos. Vamos tornar o agendamento simples e rápido.",
+      "cta": "Configurar minha agenda"
+    },
+    "specialty": {
+      "response": "Qual é a sua área de atuação? Use o nome profissional do que você pratica.",
+      "chip-occupational-therapist": "Terapeuta Ocupacional",
+      "chip-nutritionist": "Nutricionista",
+      "chip-other": "Outro",
+      "chip-physiotherapist": "Fisioterapeuta",
+      "chip-psychiatrist": "Psiquiatra",
+      "chip-psychologist": "Psicólogo(a)",
+      "chip-speech-therapist": "Fonoaudiólogo(a)",
+      "continue": "Continuar",
+      "other-placeholder": "Sua especialidade ou título profissional",
+      "acknowledged": "Entendido! Vou configurar tudo levando isso em conta.",
+      "error-rephrase": "Não consegui identificar bem — tente usar o nome profissional do que você pratica.",
+      "error-rejected": "Não consigo configurar agendamentos para isso. Se você tem outra especialidade, adoraria te ajudar a começar."
+    },
+    "calendar-choice": {
+      "msg1": "Olá! Eu sou a Júpiter, sua assistente de agendamento via IA. Estou aqui para te ajudar a configurar sua disponibilidade de forma simples e natural.",
+      "msg2": "Vamos começar configurando sua agenda. Como você prefere?",
+      "chip-google": "Conectar Google Agenda",
+      "chip-manual": "Criar manualmente",
+      "google-already-connected": "Sua Google Agenda já está conectada! Você gostaria de importar sua agenda dela?"
+    },
+    "working-days": {
+      "response": "Ótimo! Em quais dias você costuma atender seus clientes?",
+      "chip-mon": "Seg",
+      "chip-tue": "Ter",
+      "chip-wed": "Qua",
+      "chip-thu": "Qui",
+      "chip-fri": "Sex",
+      "chip-sat": "Sáb",
+      "chip-sun": "Dom",
+      "back": "← Voltar",
+      "continue": "Continuar",
+      "other-placeholder": "Ou digite sua rotina..."
+    },
+    "time-range": {
+      "response": "Perfeito! Qual faixa de horário funciona melhor para você nesses dias?",
+      "chip-1": "09:00 – 17:00",
+      "chip-2": "10:00 – 18:00",
+      "chip-3": "12:00 – 20:00",
+      "chip-custom": "Personalizado",
+      "other-placeholder": "ex: 08:30 – 16:00"
+    },
+    "session-duration": {
+      "response": "Qual a duração de uma sessão? Você pode alterar isso depois.",
+      "chip-45": "45 min",
+      "chip-60": "60 min",
+      "chip-custom": "Personalizado",
+      "other-placeholder": "ex: 90 minutos"
+    },
+    "session-type": {
+      "response": "Como você costuma realizar suas sessões?",
+      "response-with-suggestion": "Como você costuma realizar suas sessões? Tenho uma sugestão com base na sua especialidade — escolha o que funciona melhor para você.",
+      "chip-online": "Apenas online",
+      "chip-in-person": "Apenas presencial",
+      "chip-both": "Online e presencial"
+    },
+    "timezone": {
+      "response": "Quase lá! Vou usar o fuso horário do seu dispositivo para agendar consultas com precisão. Assim, seus clientes sempre vão agendar no horário certo. Tudo bem?",
+      "chip-yes": "Sim",
+      "chip-no": "Não",
+      "follow-up": "Sem problema! Selecione seu fuso horário:",
+      "search-placeholder": "Buscar fuso horário..."
+    },
+    "recurrence-pattern": {
+      "response": "Última pergunta — com qual frequência você quer que sua disponibilidade se repita?",
+      "chip-weekly": "Semanal (até o fim do mês)",
+      "chip-monthly": "Mensal (até o fim do ano)",
+      "summary-weekly": "Entendido! Seus horários vão se repetir toda semana até o fim deste mês. Você pode estender a qualquer momento pelo painel.",
+      "summary-monthly": "Perfeito! Sua disponibilidade vai se repetir mensalmente até o fim do ano — cobrindo todo o seu calendário anual.",
+      "value-weekly": "Semanal (até o fim do mês)",
+      "value-monthly": "Mensal (até o fim do ano)"
+    },
+    "preview": {
+      "title": "Resumo da sua Disponibilidade",
+      "label-days": "Dias de atendimento:",
+      "label-hours": "Horário:",
+      "label-duration": "Duração:",
+      "label-recurrence": "Repetição:",
+      "label-session-type": "Tipo de sessão:",
+      "label-timezone": "Fuso horário:",
+      "footer": "Você pode editar sua disponibilidade a qualquer momento no painel.",
+      "cta": "Publicar Disponibilidade",
+      "loading": "Publicando...",
+      "reset": "Recomeçar"
+    },
+    "post-publish": {
+      "page-title": "Disponibilidade",
+      "page-subtitle": "Gerencie sua disponibilidade e preferências de agendamento",
+      "success-toast": "Sua disponibilidade está ativa. Seus clientes já podem agendar sessões com você.",
+      "welcome-toast": "Bem-vindo ao Psycron!",
+      "tip-title": "Dica da Júpiter",
+      "tip-text": "Sua disponibilidade está ótima. Adicionar uma política de cancelamento ajuda a reduzir faltas e define expectativas claras com seus clientes.",
+      "tip-cta": "Configurar política de cancelamento",
+      "status-active-hours": "Horas ativas",
+      "status-bookings": "Agendamentos futuros",
+      "status-this-week": "Esta semana",
+      "status-booked-label": "{{percent}}% Agendado",
+      "checklist-title": "Complete sua disponibilidade",
+      "checklist-subtitle": "Melhore sua configuração de agendamento para uma experiência melhor",
+      "checklist-session-types": "Definir tipos de sessão",
+      "checklist-session-types-desc": "Crie diferentes tipos e durações de consultas",
+      "checklist-price": "Adicionar preço da sessão",
+      "checklist-price-desc": "Defina seus valores e condições de pagamento",
+      "checklist-price-badge": "Recomendado",
+      "checklist-buffer": "Adicionar intervalo entre sessões",
+      "checklist-buffer-desc": "Defina um tempo entre consultas para preparação",
+      "checklist-cancel-policy": "Configurar política de cancelamento",
+      "checklist-cancel-desc": "Defina como clientes podem cancelar ou remarcar",
+      "checklist-calendar-sync": "Sincronizar com sua agenda existente",
+      "checklist-calendar-desc": "Conecte sua agenda para evitar conflitos",
+      "checklist-recurrence": "Definir estilo de recorrência",
+      "checklist-recurrence-desc": "Escolha como sua agenda é gerada e gerenciada",
+      "checklist-specialty": "Adicionar sua especialidade",
+      "checklist-specialty-desc": "Informe os pacientes sobre sua área de atuação",
+      "help-title": "Precisa de ajuda?",
+      "help-text": "A Júpiter pode te ajudar a completar sua configuração",
+      "help-cta": "Falar com a Júpiter",
+      "banner-dismiss": "Fechar",
+      "buffer-drawer-desc": "O tempo de intervalo adiciona uma pausa entre as sessões para que possa se preparar, fazer anotações ou simplesmente respirar entre os atendimentos.",
+      "buffer-drawer-title": "Tempo de intervalo",
+      "buffer-custom-input-helper": "Escolha o intervalo que fizer mais sentido entre as sessões.",
+      "buffer-impact-day": "Adiciona cerca de {{value}} na sua agenda diária.",
+      "buffer-impact-empty": "Vamos estimar o impacto assim que existirem sessões futuras disponíveis.",
+      "buffer-impact-hours-value": "{{hours}}h",
+      "buffer-impact-hours-minutes-value": "{{hours}}h {{minutes}} min",
+      "buffer-impact-minutes-value": "{{minutes}} min",
+      "buffer-impact-title": "Pré-visualização do impacto",
+      "buffer-impact-week": "Adiciona cerca de {{value}} ao longo das suas horas semanais de trabalho.",
+      "buffer-input-label": "Minutos entre sessões",
+      "buffer-jupiter-title": "Recomendação da Júpiter",
+      "buffer-range-helper": "Escolha um intervalo entre 5 e 20 minutos. A Júpiter vai adaptar uma sugestão com base na sua agenda futura.",
+      "buffer-jupiter-empty": "Vamos personalizar isto assim que existirem sessões futuras.",
+      "buffer-jupiter-thinking": "A Júpiter está a analisar a sua agenda futura",
+      "buffer-jupiter-unavailable": "A Júpiter não conseguiu personalizar isto agora. Ainda pode escolher o intervalo manualmente.",
+      "buffer-save": "Salvar",
+      "buffer-save-fail": "Não foi possível salvar o tempo de intervalo. Tente novamente.",
+      "buffer-save-success": "Tempo de intervalo salvo com sucesso.",
+      "buffer-warning-overflow": "{{day}} pode ultrapassar o seu horário de término configurado com este intervalo.",
+      "buffer-warning-soft-weekly": "Isto adiciona um tempo de recuperação perceptível ao longo da semana, o que pode reduzir o stress, mas alongar a sua agenda.",
+      "buffer-warning-strong-weekly": "Isto adiciona um grande volume de tempo de recuperação ao longo da semana e pode aumentar visivelmente a sua carga horária.",
+      "buffer-warning-title": "Aviso de agenda",
+      "checklist-action-configure": "Configurar",
+      "checklist-action-edit": "Editar",
+      "checklist-action-soon": "Em breve",
+      "checklist-action-view": "Ver",
+      "checklist-badge-recommended": "Recomendado",
+      "checklist-duration": "Duração da sessão",
+      "checklist-duration-desc": "Defina a duração de cada consulta",
+      "checklist-progress-label": "{{count}} de {{total}} concluídos",
+      "checklist-session-type": "Tipo de sessão",
+      "checklist-session-type-desc": "Como você conduz suas sessões",
+      "checklist-timezone": "Fuso horário",
+      "checklist-timezone-desc": "Garanta que todas as reservas usem o fuso horário correto",
+      "checklist-working-hours": "Horário de trabalho",
+      "checklist-working-hours-desc": "Seus dias e horários disponíveis para atendimentos",
+      "tip-buffer-time": "Adicionar um intervalo entre sessões ajuda você a se preparar, fazer anotações e evitar atrasos. Apenas 5 minutos já fazem diferença.",
+      "tip-session-address": "Deixe seus pacientes saberem onde encontrá-lo. Adicione o endereço da sua clínica ou consultório para que as sessões presenciais sejam fáceis de localizar."
+    },
+    "google-calendar": {
+      "permissions-intro": "Vamos conectar sua Google Agenda com segurança para:",
+      "permission-1": "Ler seus horários ocupados",
+      "permission-2": "Evitar agendamentos duplicados",
+      "permission-3": "Manter tudo sincronizado",
+      "privacy-note": "Nós nunca editamos ou excluímos eventos sem sua permissão.",
+      "back": "← Voltar",
+      "continue": "Continuar",
+      "success-line1": "Perfeito! 🎉",
+      "success-line2": "Sua Google Agenda está conectada.",
+      "success-line3": "Vou bloquear automaticamente os horários em que você já estiver ocupado.",
+      "next-choice": "Você gostaria de:",
+      "chip-use-existing": "Usar minha agenda atual como disponibilidade",
+      "chip-define-hours": "Definir horários de trabalho específicos",
+      "define-hours-fallback": "Entendido! A importação do Google Agenda estará disponível em breve. Por enquanto, vamos definir seus horários manualmente.",
+      "importing": "Um momento — estou importando sua agenda do Google Agenda...",
+      "imported": "Pronto! Encontrei seus dias e horários de trabalho. Só mais algumas configurações.",
+      "import-failed": "Não consegui ler sua agenda. Vamos definir seus horários de trabalho manualmente."
+    },
+    "errors": {
+      "network": "Algo deu errado. Vamos tentar de novo.",
+      "retry": "Tentar novamente",
+      "google-oauth-fail": "Não consegui conectar à Google Agenda. Tente novamente ou configure manualmente.",
+      "google-oauth-cancel": "Sem problema! Você pode conectar sua agenda depois. Vamos configurar manualmente.",
+      "save-fail": "Não consegui salvar sua disponibilidade. Tente novamente.",
+      "session-timeout": "Parece que você se ausentou. Seu progresso foi salvo — continue de onde parou.",
+      "empty-days": "Selecione pelo menos um dia de atendimento para continuar.",
+      "invalid-time-range": "O horário final deve ser depois do horário inicial.",
+      "invalid-input": "Não entendi bem. Pode tentar de novo?",
+      "ai-fallback": "Obrigado! Deixa eu processar isso para você.",
+      "ai-thinking": "Pensando...",
+      "no-timezone": "Não consegui detectar seu fuso horário automaticamente. Por favor, selecione abaixo.",
+      "publish-success": "Tudo certo! Sua disponibilidade está no ar.",
+      "publish-redirect": "Redirecionando para seu painel..."
+    },
+    "subtitle": "Seu assistente de agendamento",
+    "days": {
+      "MONDAY": "Segunda-feira",
+      "TUESDAY": "Terça-feira",
+      "WEDNESDAY": "Quarta-feira",
+      "THURSDAY": "Quinta-feira",
+      "FRIDAY": "Sexta-feira",
+      "SATURDAY": "Sábado",
+      "SUNDAY": "Domingo"
+    }
+  },
+  "availability": {
+    "calendar": {
+      "legend-available": "Disponível",
+      "legend-busy": "Ocupado",
+      "legend-empty": "Indisponível",
+      "legend-full": "Completo",
+      "legend-partial": "Parcial",
+      "legend-today": "Hoje",
+      "page-title": "Disponibilidade",
+      "source-google": "Google",
+      "source-jupiter": "Júpiter",
+      "subtitle": "Seu calendário de disponibilidade",
+      "settings": "Definições de disponibilidade"
+    },
+    "cancellation-recovery": {
+      "title": "Recuperação de cancelamentos",
+      "subtitle": "Revise consultas canceladas, reabra horários e avance no acompanhamento do paciente sem poluir o calendário ao vivo.",
+      "accessibility": {
+        "detail": "Detalhe de recuperação",
+        "queue": "Fila de recuperação"
+      },
+      "empty": "Nenhuma consulta cancelada corresponde aos filtros atuais.",
+      "empty-selection": "Escolha uma consulta cancelada para revisar os detalhes de recuperação e as próximas ações.",
+      "unknown-patient": "Paciente desconhecido",
+      "queue": {
+        "title": "Fila de recuperação",
+        "subtitle": "Acompanhe cancelamentos que ainda precisam de atenção do terapeuta."
+      },
+      "stats": {
+        "total": "Total",
+        "pending-follow-up": "Pendentes",
+        "reopened": "Reabertos"
+      },
+      "filters": {
+        "title": "Filtros",
+        "summary-default": "Expanda para refinar a fila de recuperação.",
+        "summary-active": "{{count}} filtros ativos",
+        "patient": "Paciente",
+        "patient-placeholder": "Busque pelo nome do paciente",
+        "period": "Período",
+        "status": "Estado",
+        "cancelled-by": "Cancelado por",
+        "reason": "Motivo",
+        "reason-all": "Todos os motivos",
+        "delivery": "Modalidade",
+        "period-options": {
+          "all": "Todos",
+          "past": "Passado",
+          "upcoming": "Futuros"
+        },
+        "status-options": {
+          "all": "Todos",
+          "needs-action": "Precisa de ação",
+          "resolved": "Resolvidos"
+        },
+        "cancelled-by-options": {
+          "all": "Todos",
+          "patient": "Paciente",
+          "therapist": "Terapeuta",
+          "unknown": "Desconhecido"
+        },
+        "delivery-options": {
+          "all": "Todas",
+          "in-person": "Presencial",
+          "online": "Online",
+          "unknown": "Desconhecida"
+        }
+      },
+      "state": {
+        "archived": "Arquivado",
+        "followed-up": "Acompanhado",
+        "overdue": "Atrasado",
+        "pending-follow-up": "Aguardando acompanhamento",
+        "rebooked": "Reagendado",
+        "reopened": "Reaberto"
+      },
+      "cancelled-by": {
+        "patient": "Cancelado pelo paciente",
+        "therapist": "Cancelado pelo terapeuta",
+        "unknown": "Cancelado por origem desconhecida"
+      },
+      "delivery": {
+        "in-person": "Presencial",
+        "online": "Online",
+        "unknown": "Não informado"
+      },
+      "detail": {
+        "eyebrow": "Detalhe da recuperação",
+        "cancelled-at": "Cancelado em",
+        "cancelled-by": "Cancelado por",
+        "reason": "Motivo",
+        "delivery": "Modalidade",
+        "followed-up-at": "Acompanhado em",
+        "patient": "Paciente",
+        "rebooked-appointment": "Agendamento remarcado",
+        "recovery-state": "Estado da recuperação",
+        "not-provided": "Não informado"
+      },
+      "actions": {
+        "rebook": "Reagendar este paciente",
+        "archive": "Marcar como resolvido",
+        "archive-all": "Marcar todos como resolvidos ({{count}})",
+        "more": "Mais ações",
+        "open-patient": "Abrir perfil do paciente",
+        "reopen": "Tornar horário disponível novamente",
+        "archive-success": "Recuperação fechada sem nova ação.",
+        "archive-error": "Não foi possível fechar este item de recuperação. Tente novamente.",
+        "archive-all-success": "{{count}} itens de recuperação marcados como resolvidos.",
+        "archive-all-error": "Não foi possível resolver todos os itens de recuperação. Tente novamente.",
+        "reopen-success": "Horário reaberto com sucesso.",
+        "reopen-error": "Não foi possível reabrir o horário. Tente novamente."
+      }
+    },
+    "week": {
+      "drawer": {
+        "address-override": "Local da sessão",
+        "address-override-question": "Usar um local diferente para esta sessão?",
+        "address-reset": "Repor padrão",
+        "address-save": "Guardar local",
+        "address-save-error": "Falha ao guardar o local da sessão. Tente novamente.",
+        "address-saved": "Local da sessão guardado.",
+        "block-confirm": "Confirmar bloqueio",
+        "block-confirm-body": "Este horário não estará mais disponível para agendamentos de pacientes.",
+        "block-error": "Falha ao bloquear o horário. Tente novamente.",
+        "block-reason-label": "Motivo do bloqueio",
+        "block-reason-placeholder": "Opcional: Adicione um motivo para o bloqueio",
+        "block-slot": "Bloquear horário",
+        "block-success": "Horário bloqueado com sucesso.",
+        "break-edit": "Editar pausa",
+        "break-edit-body": "Esta pausa é controlada pela sua definição global de buffer. Atualize os minutos abaixo para alterar os próximos blocos de pausa.",
+        "break-edit-save": "Guardar pausa",
+        "break-note": "Bloqueado automaticamente para descanso entre sessões.",
+        "break-note-label": "Como funciona",
+        "break-remove": "Remover",
+        "break-subtitle": "Pausa agendada",
+        "break-title": "Tempo de pausa",
+        "blocked-at": "Bloqueado em {{date}}",
+        "blocked-subtitle": "Pacientes não podem agendar este horário",
+        "blocked-title": "Horário bloqueado",
+        "cancelled-at": "Cancelado em {{date}}",
+        "cancelled-reason-label": "Motivo do cancelamento",
+        "cancelled-by-patient": "Esta consulta foi cancelada pelo paciente",
+        "cancelled-by-therapist": "Esta consulta foi cancelada pelo terapeuta",
+        "cancelled-subtitle": "Esta consulta foi cancelada",
+        "cancelled-title": "Consulta cancelada",
+        "booking-link-copy-aria": "Copiar link de agendamento para a área de transferência",
+        "booking-link-hint": "Partilhe este link para abrir a página pública de agendamento com este horário pré-selecionado enquanto ele ainda estiver disponível.",
+        "booking-link-label": "Link de agendamento",
+        "booking-share-text": "Abra este link para agendar a sessão selecionada.",
+        "booking-share-title": "Agendar esta sessão em {{date}} às {{time}}",
+        "book-slot": "Agendar este horário",
+        "cancel": "Cancelar",
+        "cancel-appointment": "Cancelar consulta",
+        "cancel-back": "Voltar",
+        "cancel-choice-sub": "Cancelar esta consulta permanentemente",
+        "cancel-confirm": "Confirmar cancelamento",
+        "cancel-custom-reason-label": "Detalhes adicionais (opcional)",
+        "cancel-error": "Falha ao cancelar a consulta. Tente novamente.",
+        "cancel-reason-label": "Motivo do cancelamento",
+        "cancel-success": "Consulta cancelada com sucesso.",
+        "confirm-booking": "Confirmar",
+        "confirmed": "Confirmado",
+        "date": "Data",
+        "edit": "Editar",
+        "edit-end-time": "Horário de término",
+        "booking-error": "Falha ao agendar a consulta. Tente novamente.",
+        "booking-success": "Consulta agendada com sucesso.",
+        "conflict-change-details": "Alterar dados de contacto",
+        "conflict-confirm": "Agendar para {{name}}",
+        "conflict-multiple-body": "O telefone e o email correspondem a pacientes diferentes. Atualize os dados de contacto para continuar.",
+        "conflict-single-body": "Já existe um paciente registado com este contacto:",
+        "conflict-title": "Paciente já registado",
+        "existing-booking-body": "{{name}} já tem uma sessão agendada em {{date}} às {{time}}. Deseja adicionar outra sessão para este paciente?",
+        "existing-booking-cancel": "Escolher outro paciente",
+        "existing-booking-confirm": "Adicionar outra sessão",
+        "existing-booking-title": "Paciente já tem sessão agendada",
+        "edit-error": "Falha ao salvar as alterações. Tente novamente.",
+        "edit-note": "Notas",
+        "edit-save": "Salvar alterações",
+        "edit-start-time": "Horário de início",
+        "edit-success": "Horário atualizado com sucesso.",
+        "edit-success-booked": "Horário atualizado. Atenção: esta sessão tinha uma reserva ativa.",
+        "let-patient-choose-address": "Deixar o paciente escolher o local?",
+        "location-choice-clinic": "Consultório",
+        "location-choice-custom": "Personalizado",
+        "location-choice-label": "Local da sessão",
+        "session-delivery-in-person": "Presencial",
+        "session-delivery-in-person-subtitle": "No seu consultório ou endereço do paciente",
+        "session-delivery-label": "Como será realizada esta sessão?",
+        "session-delivery-online": "Online",
+        "recurrence-all": "Todos os agendamentos futuros",
+        "recurrence-end-month": "Até o fim do mês",
+        "recurrence-end-year": "Até o fim do ano",
+        "recurrence-label": "Repetir agendamento",
+        "recurrence-single": "Apenas este agendamento",
+        "session-delivery-online-subtitle": "Videochamada, telefone ou mensagens",
+        "location-choice-patient": "Paciente",
+        "location-subtitle-clinic": "Vamos partilhar o endereço do consultório na localização da consulta",
+        "location-subtitle-custom": "Vamos partilhar o endereço personalizado na localização da consulta",
+        "location-subtitle-patient": "Vai permitir que o seu paciente escolha o endereço na localização da consulta",
+        "minutes": "minutos",
+        "notes": "Notas",
+        "patient-email": "Email do paciente",
+        "patient-timezone": "Fuso horário do paciente",
+        "patient-timezone-placeholder": "Pesquise por cidade, ex: Sao Paulo",
+        "patient-first-name": "Nome do paciente",
+        "patient-last-name": "Sobrenome do paciente",
+        "patient-search": {
+          "no-results": "Nenhum paciente encontrado",
+          "placeholder": "Pesquise ou digite um novo nome",
+          "type-to-search": "Digite pelo menos 2 caracteres para pesquisar"
+        },
+        "patient-time": "Horário local do paciente",
+        "reschedule": "Remarcar",
+        "reschedule-choice-sub": "Mover para outro horário disponível",
+        "reschedule-confirm": "Confirmar remarcação",
+        "reschedule-error": "Falha ao remarcar a consulta. Tente novamente.",
+        "reschedule-no-slots": "Não há horários disponíveis para remarcar. Tente ajustar os seus horários de trabalho.",
+        "reschedule-select-prompt": "Selecione um novo horário para esta consulta.",
+        "reschedule-success": "Consulta remarcada com sucesso.",
+        "reopen-slot": "Tornar disponível novamente",
+        "reopened-note-fallback-name": "este paciente",
+        "reopened-note-label": "Cancelamento anterior",
+        "reopened-note-text": "Anteriormente cancelada para {{name}} em {{date}}.",
+        "session-duration": "Duração: ",
+        "session-type": "Tipo de sessão",
+        "share-address": "Partilhar endereço do consultório com o paciente",
+        "status-cancelled": "Cancelado",
+        "status-confirmed": "Confirmado",
+        "available-status-open": "Aberto para agendamento",
+        "your-time": "Seu horário local",
+        "appointment-address": "Endereço da consulta",
+        "patient-phone": "Telefone do paciente",
+        "patient-provides-address": "O paciente irá fornecer o endereço",
+        "call-whatsapp": "Ligar pelo WhatsApp",
+        "call-phone": "Ligar para o paciente",
+        "join-meet": "Entrar no Google Meet",
+        "join-zoom": "Entrar no Zoom",
+        "booked-section-session": "Sessão",
+        "booked-section-patient": "Paciente",
+        "booked-section-location": "Localização",
+        "booked-section-notes": "Notas",
+        "booked-date": "Data",
+        "booked-time": "Hora",
+        "booked-duration": "Duração",
+        "booked-session-count": "Sessão {{count}} com {{name}}",
+        "booked-session-first": "Primeira sessão com {{name}}",
+        "booked-email": "Email",
+        "booked-phone": "Telefone",
+        "booked-online-session": "Sessão online",
+        "booked-hybrid": "Online / Presencial",
+        "booked-in-person": "Presencial",
+        "booked-google-sync": "Sincronizado do Google Agenda",
+        "booked-profile-link": "Perfil",
+        "booked-profile-coming-soon": "Perfil do paciente — em breve",
+        "booked-no-email": "Nenhum email fornecido",
+        "booked-no-phone": "Nenhum telefone fornecido",
+        "booked-awaiting-address": "Aguardando endereço do paciente",
+        "booked-request-address": "Solicitar endereço",
+        "booked-view-notifications": "Ver notificações",
+        "booked-past-disabled": "Consulta passada — ações desativadas",
+        "booked-copied": "Copiado",
+        "booked-copy-aria": "Copiar {{field}} para a área de transferência",
+        "booked-call-aria": "Ligar para {{name}}",
+        "booked-whatsapp-aria": "Enviar mensagem para {{name}} no WhatsApp",
+        "booked-email-aria": "Enviar email para {{name}}",
+        "source-manual": "Agendado",
+        "unblock-confirm": "Confirmar desbloqueio",
+        "unblock-confirm-body": "Este horário ficará disponível para agendamentos novamente.",
+        "unblock-error": "Falha ao desbloquear o horário. Tente novamente.",
+        "unblock-slot": "Desbloquear horário",
+        "unblock-success": "Horário desbloqueado com sucesso."
+      },
+      "buffer-label": "Buffer",
+      "legend-available": "Disponível",
+      "legend-blocked": "Bloqueado",
+      "legend-booked-google": "Google",
+      "legend-booked-jupiter": "Agendado",
+      "legend-buffer": "Buffer",
+      "legend-cancelled": "Cancelado",
+      "next-week": "Próxima semana",
+      "no-appointments": "Sem agendamentos",
+      "page-title": "Disponibilidade",
+      "prev-week": "Semana anterior",
+      "collapse-day": "Ver menos",
+      "expand-day": "+{{count}} mais",
+      "show-available-slots": "Ver horários disponíveis ({{count}})",
+      "slot": "horário",
+      "slots": "horários",
+      "filter-clear": "Limpar filtros",
+      "filter-delivery-in-person": "Presencial",
+      "filter-delivery-online": "Online",
+      "filter-hide-free": "Ocultar horários livres",
+      "filter-label-cancelled": "Horários cancelados",
+      "filter-label-free": "Horários livres",
+      "filter-section-delivery": "Modalidade",
+      "filter-section-session-type": "Tipo de sessão",
+      "filter-section-source": "Origem",
+      "filter-section-status": "Status do horário",
+      "filter-section-time": "Período do dia",
+      "filter-show-free": "Mostrar horários livres",
+      "filter-source-google": "Google",
+      "filter-source-jupiter": "Júpiter",
+      "filter-time-afternoon": "Tarde",
+      "filter-time-evening": "Noite",
+      "filter-time-morning": "Manhã",
+      "filters": "Filtros",
+      "blocked-hover-label": "Horário bloqueado",
+      "title": "Agenda da Semana",
+      "settings": "Definições",
+      "default-blocked-day": {
+        "body": "{{day}} está fechado pelas suas definições padrão de disponibilidade. Abra apenas esta data como dia completo, parte do dia ou horários específicos.",
+        "confirm": "Abrir este dia",
+        "end-time": "Hora de fim",
+        "error": "Não foi possível abrir este dia. Tente novamente.",
+        "open-full-day": "Abrir dia completo",
+        "open-full-day-desc": "Crie todos os horários disponíveis para esta data usando o seu horário habitual.",
+        "open-part-day": "Abrir parte do dia",
+        "open-part-day-desc": "Escolha um intervalo de horas personalizado apenas para esta data.",
+        "open-specific-slots": "Abrir horários específicos",
+        "open-specific-slots-desc": "Selecione apenas os horários exatos que quer disponibilizar.",
+        "start-time": "Hora de início",
+        "success": "Este dia agora está disponível.",
+        "title": "Abrir este dia fechado?"
+      },
+      "day-header": {
+        "actions": "Ações do dia",
+        "block-all": "Bloquear todos os horários disponíveis",
+        "block-all-confirm": "Bloquear todos os {{count}} horários disponíveis em {{day}}? Os pacientes não poderão agendar nesses horários.",
+        "booked-warning": "Este dia tem {{count}} agendamento(s). O bloqueio do dia afetará apenas os horários ainda disponíveis.",
+        "block-all-error": "Falha ao bloquear os horários. Tente novamente.",
+        "block-all-success": "Todos os horários disponíveis foram bloqueados.",
+        "summary": "{{total}} no total · {{available}} disponíveis · {{booked}} agendados · {{blocked}} bloqueados · {{cancelled}} cancelados",
+        "unblock-all": "Desbloquear todos os horários bloqueados",
+        "unblock-all-confirm": "Desbloquear todos os {{count}} horários bloqueados em {{day}}? Esses horários ficarão disponíveis para agendamento.",
+        "unblock-all-error": "Falha ao desbloquear os horários. Tente novamente.",
+        "unblock-all-success": "Todos os horários bloqueados foram desbloqueados."
+      }
+    },
+    "gate": {
+      "deleted-notice": "Você não tem mais disponibilidade configurada. Fale com a Júpiter para criar uma nova."
+    },
+    "settings": {
+      "google-calendar-connect-btn": "Conectar Google Agenda",
+      "google-calendar-connect-error": "Não foi possível iniciar a conexão com o Google Agenda. Tente novamente.",
+      "first-publish-alert": "A sua disponibilidade está ativa! Complete o checklist abaixo para otimizar a sua configuração.",
+      "google-calendar-connected": "Seu Google Agenda está conectado.",
+      "google-calendar-desc": "Sincronize seu Google Agenda para importar sua agenda existente, bloquear horários ocupados automaticamente e manter suas sessões no Psycron sincronizadas.",
+      "google-calendar-drawer-title": "Google Agenda",
+      "live-alert": "Sua disponibilidade está ativa. Seus clientes já podem agendar sessões com você.",
+      "page-title": "Configurações de Disponibilidade",
+      "save-error": "Não foi possível salvar. Tente novamente.",
+      "save-success": "Configurações salvas com sucesso.",
+      "session-duration-desc": "Defina a duração padrão de cada atendimento.",
+      "session-duration-drawer-title": "Duração da sessão",
+      "session-type-both": "Ambos",
+      "session-type-desc": "Escolha como você conduz suas sessões.",
+      "session-type-drawer-title": "Tipo de sessão",
+      "session-type-in-person": "Presencial",
+      "session-type-online": "Online",
+      "session-address-desc": "Insira o endereço da sua clínica ou consultório para que os pacientes possam encontrá-lo.",
+      "session-type-address-hint": "Atendimentos presenciais exigem um endereço de clínica. Você será solicitado a adicioná-lo após salvar.",
+      "session-address-drawer-title": "Endereço do atendimento",
+      "session-address-title": "Endereço da clínica",
+      "specialty-drawer-title": "Sua especialidade",
+      "specialty-desc": "Escolha a área de atuação principal. Você pode detalhar sua abordagem específica abaixo.",
+      "specialty-psychology": "Psicologia",
+      "specialty-psychiatry": "Psiquiatria",
+      "specialty-physiotherapy": "Fisioterapia",
+      "specialty-nutrition": "Nutrição",
+      "specialty-coaching": "Coaching",
+      "specialty-occupational-therapy": "Terapia ocupacional",
+      "specialty-speech-therapy": "Fonoaudiologia",
+      "specialty-social-work": "Serviço social",
+      "specialty-other": "Outro",
+      "specialty-detail-label": "Abordagem ou método específico (opcional)",
+      "specialty-detail-helper": "ex: Terapia Cognitivo-Comportamental, EMDR — usado para melhorar seu perfil",
+      "feature-disabled-tooltip": "Esta funcionalidade está a chegar em breve",
+      "jupiter-cta-disabled-tooltip": "A Júpiter ainda não está disponível — estamos a lançar gradualmente",
+      "jupiter-help-action": "Falar com a Júpiter",
+      "jupiter-help-description": "A Júpiter pode guiá-lo a completar as suas configurações",
+      "jupiter-help-title": "Precisa de ajuda?",
+      "talk-to-jupiter": "Editar com a Júpiter",
+      "timezone-desc": "Todos os agendamentos serão exibidos e criados neste fuso horário.",
+      "timezone-drawer-title": "Fuso horário",
+      "timezone-input-label": "Fuso horário",
+      "timezone-warning-body": "Seus agendamentos existentes não serão movidos — continuarão no mesmo horário UTC, mas exibidos no novo fuso horário.",
+      "timezone-warning-confirm": "Alterar fuso horário",
+      "timezone-warning-title": "Alterar fuso horário?",
+      "working-hours-days-label": "Dias de trabalho",
+      "working-hours-desc": "Defina seus dias disponíveis e o horário para atendimentos.",
+      "working-hours-drawer-title": "Horário de trabalho",
+      "working-hours-end-label": "Fim",
+      "recurrence-consistent": "Consistente",
+      "recurrence-consistent-desc": "Sua agenda repete os mesmos dias e horários toda semana, gerada mês a mês. Ideal para uma rotina previsível e consistente.",
+      "recurrence-flexible": "Flexível",
+      "recurrence-flexible-desc": "Os slots são gerados para o mês inteiro de uma vez. Ideal se sua disponibilidade varia — você pode editar slots individuais sem reconstruir toda a agenda.",
+      "recurrence-pattern-desc": "Alterar isso vai regenerar seus slots de disponibilidade abertos com o novo padrão. Todos os agendamentos já confirmados permanecem exatamente como estão.",
+      "recurrence-pattern-drawer-title": "Padrão de recorrência",
+      "working-hours-start-label": "Início",
+      "working-hours-time-label": "Intervalo de horário"
+    }
+  },
+  "conflicts": {
+    "title": "Painel de conflitos",
+    "subtitle": "Revise e resolva conflitos de agenda e de pacientes.",
+    "empty": "Nenhum conflito corresponde aos filtros atuais.",
+    "filters": {
+      "title": "Filtros",
+      "summary-default": "Refine a fila por status ou tipo de conflito.",
+      "summary-active": "{{count}} filtro ativo",
+      "summary-active_other": "{{count}} filtros ativos",
+      "status": "Status",
+      "type": "Tipo",
+      "open": "Em aberto",
+      "all-statuses": "Todos os status",
+      "all-types": "Todos os tipos"
+    },
+    "queue": {
+      "eyebrow": "Operação",
+      "title": "Fila de conflitos",
+      "subtitle": "Revise os itens que ainda precisam da sua decisão."
+    },
+    "layout": {
+      "expand-queue": "Expandir fila",
+      "collapse-queue": "Recolher fila"
+    },
+    "accessibility": {
+      "queue": "Fila de conflitos",
+      "detail": "Detalhe do conflito"
+    },
+    "status": {
+      "open": "Em aberto",
+      "resolved": "Resolvido",
+      "dismissed": "Dispensado"
+    },
+    "types": {
+      "patient-duplicate": "Paciente duplicado",
+      "slot-replication": "Replicação de horário"
+    },
+    "patient-duplicate": {
+      "title": "Possível paciente duplicado",
+      "and": "e",
+      "summary": {
+        "phone-and-email": "Corresponde a registros existentes pelo telefone {{phone}} e pelo email {{email}}. Revisar: {{candidates}}.",
+        "phone-only": "Corresponde a registros existentes pelo telefone {{phone}}. Revisar: {{candidates}}.",
+        "email-only": "Corresponde a registros existentes pelo email {{email}}. Revisar: {{candidates}}.",
+        "generic": "Corresponde a um registro de paciente existente. Revisar: {{candidates}}."
+      },
+      "match": {
+        "phone-and-email": "Telefone {{phone}} e email {{email}}",
+        "phone-only": "Telefone {{phone}}",
+        "email-only": "Email {{email}}",
+        "generic": "Dados de paciente existentes"
+      }
+    },
+    "detail": {
+      "incoming-patient": "Paciente recebido",
+      "existing-patient": "Paciente existente",
+      "matched-by": "Detectado por",
+      "candidate-records": "Registros candidatos",
+      "conflicting-details": "Detalhes em conflito",
+      "conflicting-date": "Data em conflito",
+      "conflicting-time": "Hora em conflito",
+      "recurrence-pattern": "Padrão de recorrência",
+      "preferred-contact": "Contato preferido",
+      "additional-candidates": "{{count}} outro possível registro ainda está na fila para revisão.",
+      "additional-candidates_other": "{{count}} outros possíveis registros ainda estão na fila para revisão.",
+      "not-provided": "Não informado"
+    },
+    "merge-review": {
+      "title": "Escolha o que manter",
+      "description": "Agendamentos, cancelamentos e notificações serão combinados automaticamente. Escolha os dados de perfil que devem permanecer no paciente principal.",
+      "primary": "Manter de {{name}}",
+      "secondary": "Usar de {{name}}",
+      "confirm": "Confirmar união",
+      "fields": {
+        "firstName": "Nome",
+        "lastName": "Sobrenome",
+        "contacts": {
+          "email": "Email",
+          "phone": "Telefone",
+          "whatsapp": "WhatsApp"
+        },
+        "billing": "Cobrança",
+        "preferredContact": "Contato preferido",
+        "timeZone": "Fuso horário",
+        "address": "Endereço"
+      }
+    },
+    "resolution": {
+      "title": "Histórico da resolução",
+      "completed-at": "Concluído em {{date}}.",
+      "actions": {
+        "auto-dismissed-stale": "O Psycron fechou este conflito porque os registros duplicados não estão mais ativos.",
+        "dismissed": "O terapeuta dispensou este conflito sem alterar os registros de pacientes.",
+        "keep-existing": "O terapeuta manteve o paciente existente e não uniu os registros.",
+        "keep-new": "O terapeuta manteve o novo paciente e não uniu os registros.",
+        "marked-resolved": "O terapeuta marcou este conflito como resolvido.",
+        "merged": "O terapeuta uniu os registros de pacientes duplicados.",
+        "merge-reconciled": "O Psycron fechou este conflito porque outra união já tratou o paciente duplicado.",
+        "unknown": "Este conflito foi fechado."
+      },
+      "sources": {
+        "primary": "Mantido de {{name}}",
+        "secondary": "Alterado para {{name}}"
+      }
+    },
+    "actions": {
+      "recommended-title": "Resolução recomendada",
+      "recommended-hint": "Una ambos os registros e mantenha um único paciente como fonte principal.",
+      "alternatives-title": "Outras opções",
+      "alternatives-hint": "Use apenas um registro se não quiser unir os dois agora.",
+      "merge": "Unir pacientes",
+      "keep-existing": "Manter paciente existente",
+      "keep-new": "Manter novo paciente",
+      "dismiss": "Dispensar",
+      "mark-resolved": "Marcar como resolvido",
+      "error": "Não foi possível atualizar este conflito. Tente novamente."
+    }
+  },
+  "action-center": {
+    "title": "Central de ações",
+    "subtitle": "Resolva os itens operacionais que precisam da sua atenção hoje.",
+    "tabs": {
+      "aria-label": "Seções da central de ações",
+      "conflicts": "Conflitos",
+      "recovery": "Recuperação"
+    }
+  },
+  "notifications": {
+    "title": "Notificações",
+    "subtitle": "Acompanhe comunicações enviadas aos pacientes por WhatsApp, email e SMS.",
+    "empty": "Nenhuma notificação corresponde aos filtros atuais.",
+    "load-more": "Carregar mais",
+    "queue": {
+      "title": "Feed de notificações",
+      "subtitle": "Uma linha do tempo de entrega para a comunicação com pacientes."
+    },
+    "layout": {
+      "expand-feed": "Expandir feed",
+      "collapse-feed": "Recolher feed"
+    },
+    "accessibility": {
+      "page": "Área de notificações",
+      "queue": "Feed de notificações",
+      "detail": "Detalhe da notificação"
+    },
+    "stats": {
+      "total": "Total",
+      "failed": "Falhas",
+      "delivered": "Entregues",
+      "sent": "Enviados"
+    },
+    "search": {
+      "placeholder": "Buscar paciente ou mensagem"
+    },
+    "sort": {
+      "label": "Ordenar",
+      "options": {
+        "newest": "Mais recentes primeiro",
+        "oldest": "Mais antigas primeiro",
+        "status": "Status"
+      }
+    },
+    "filters": {
+      "title": "Filtros",
+      "summary-default": "Refine o feed por canal, status, tipo ou data.",
+      "summary-active": "{{count}} filtro ativo",
+      "summary-active_other": "{{count}} filtros ativos",
+      "channel": "Canal",
+      "status": "Status",
+      "message-type": "Tipo de mensagem",
+      "date-range": "Período",
+      "from": "De",
+      "to": "Até",
+      "all-channels": "Todos os canais",
+      "all-statuses": "Todos os status",
+      "all-types": "Todos os tipos",
+      "active": "Ativo",
+      "archived": "Arquivado"
+    },
+    "channels": {
+      "whatsapp": "WhatsApp",
+      "email": "Email",
+      "sms": "SMS",
+      "icalendar": "Convite de calendário"
+    },
+    "statuses": {
+      "pending": "Pendente",
+      "sent": "Enviada",
+      "delivered": "Entregue",
+      "failed": "Falhou"
+    },
+    "message-types": {
+      "appointment_confirmation": "Confirmação de consulta",
+      "appointment_updated": "Consulta atualizada",
+      "reminder": "Lembrete",
+      "conflict": "Conflito",
+      "account_setup": "Configuração da conta",
+      "daily_schedule_summary": "Resumo diário da agenda",
+      "unknown": "Notificação"
+    },
+    "bulk": {
+      "resend-eligible": "Renotificar elegíveis",
+      "action": "Notificar novamente"
+    },
+    "card": {
+      "appointment": "Consulta: {{value}}",
+      "delivered-at": "Enviada em {{value}}",
+      "failed": "Falha na entrega"
+    },
+    "patient-settings": {
+      "action": "Preferências de notificação do paciente",
+      "title": "Preferências de Notificação do Paciente",
+      "subtitle": "Configure quais canais este paciente recebe notificações.",
+      "subtitle-named": "Configure quais canais {{name}} recebe notificações.",
+      "save-success": "Preferências de notificação do paciente salvas.",
+      "save-error": "Não foi possível salvar as preferências do paciente."
+    },
+    "settings": {
+      "action": "Configurar notificações",
+      "title": "Preferências de Notificações",
+      "subtitle": "Controle quais canais são usados para cada tipo de comunicação com o paciente.",
+      "save-success": "Preferências de notificação salvas.",
+      "save-error": "Não foi possível salvar as preferências. Tente novamente.",
+      "appointment-confirmation": {
+        "title": "Confirmação de Consulta",
+        "description": "Enviada ao paciente quando uma nova consulta é agendada."
+      },
+      "reminder": {
+        "title": "Lembretes de Consulta",
+        "description": "Enviado ao paciente antes da consulta.",
+        "toggle": "Ativar lembretes",
+        "lead-time": {
+          "label": "Enviar lembrete",
+          "30m": "30 min antes",
+          "1h": "1 hora antes",
+          "2h": "2 horas antes",
+          "24h": "24 horas antes",
+          "48h": "48 horas antes"
+        }
+      },
+      "appointment-updated": {
+        "title": "Consulta Atualizada",
+        "description": "Enviada ao paciente quando uma consulta é remarcada ou alterada."
+      },
+      "calendar-invite": {
+        "title": "Convite de Calendário",
+        "description": "Anexa um arquivo .ics às confirmações e lembretes por e-mail.",
+        "toggle": "Incluir anexo de calendário"
+      }
+    },
+    "context": {
+      "channel-status": "Notificação por {{channel}} está {{status}}.",
+      "sent-at": "Enviada em {{value}}.",
+      "delivered-at": "Entregue em {{value}}.",
+      "appointment": "Consulta: {{value}}.",
+      "session": "Sessão: {{value}}.",
+      "calendar-invite-attached": "Convite de calendário anexado.",
+      "error": "Erro de entrega: {{value}}"
+    },
+    "detail": {
+      "title": "Detalhes da comunicação",
+      "patient": "Paciente",
+      "unknown-patient": "Paciente desconhecido",
+      "message-type": "Tipo de mensagem",
+      "channel": "Canal",
+      "status": "Status",
+      "sent-at": "Enviada em",
+      "delivered-at": "Entregue em",
+      "appointment": "Consulta",
+      "ics": "Convite de calendário",
+      "ics-attached": "Anexado",
+      "ics-empty": "Não anexado",
+      "message": "Mensagem",
+      "context": "Contexto",
+      "error": "Erro de entrega",
+      "payload": "Payload"
+    },
+    "retry": {
+      "action": "Tentar novamente",
+      "action-short": "Tentar",
+      "success": "Notificação enviada novamente.",
+      "error": "Não foi possível enviar esta notificação novamente. Tente novamente."
+    },
+    "resend": {
+      "action": "Notificar novamente",
+      "action-short": "Notificar novamente"
+    },
+    "archive": {
+      "action": "Arquivar",
+      "success": "Notificação arquivada.",
+      "error": "Não foi possível arquivar esta notificação."
+    }
+  }
 }

--- a/src/components/dashboard/widgets/notifications-widget/NotificationsWidget.tsx
+++ b/src/components/dashboard/widgets/notifications-widget/NotificationsWidget.tsx
@@ -4,7 +4,6 @@ import {
 	Calendar,
 	ChevronRight,
 	Mail,
-	Phone,
 	WhatsApp,
 } from '@psycron/components/icons';
 
@@ -96,10 +95,6 @@ export const NotificationsWidget = ({
 					<ChannelCounter>
 						<Mail />
 						{summary.channels.EMAIL}
-					</ChannelCounter>
-					<ChannelCounter>
-						<Phone />
-						{summary.channels.SMS}
 					</ChannelCounter>
 					<ChannelCounter>
 						<Calendar />

--- a/src/components/form/SignIn/SignIn.types.ts
+++ b/src/components/form/SignIn/SignIn.types.ts
@@ -10,14 +10,22 @@ export type SignInFormTypes = {
 	onSubmit: SubmitHandler<ISignInForm>;
 };
 
-export interface ISignInResponse {
-	refreshToken: string;
-	token: string;
-	user: {
-		email: string;
-		id: string;
-	};
-}
+export type ISignInResponse =
+	| {
+			mode?: never;
+			refreshToken: string;
+			status: 'success';
+			token: string;
+			user: { email: string; id: string };
+	  }
+	| {
+			mode: 'whatsapp_challenge';
+			refreshToken?: never;
+			status: 'success';
+			therapistId: string;
+			token?: never;
+			user?: never;
+	  };
 
 export interface IRefreshToken {
 	accessToken: string;

--- a/src/context/user/auth/UserAuthenticationContext.tsx
+++ b/src/context/user/auth/UserAuthenticationContext.tsx
@@ -21,12 +21,13 @@ import {
 	signInFc,
 	signUpFc,
 	verifyEmail,
+	verifyWhatsAppOtpFc,
 } from '@psycron/api/auth';
 import type { CustomError } from '@psycron/api/error';
 import type { ISignInForm } from '@psycron/components/form/SignIn/SignIn.types';
 import type { ISignUpForm } from '@psycron/components/form/SignUp/SignUpEmail.types';
 import { useAlert } from '@psycron/context/alert/AlertContext';
-import { DASHBOARD, HOMEPAGE } from '@psycron/pages/urls';
+import { DASHBOARD, HOMEPAGE, WHATSAPP_OTP_CHALLENGE } from '@psycron/pages/urls';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
@@ -68,9 +69,11 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 	const queryClient = useQueryClient();
 	const { showAlert } = useAlert();
 
-	const [redirectAfterAuth, setRedirectAfterAuth] = useState<string | null>(
-		null
-	);
+	const [redirectAfterAuth, setRedirectAfterAuth] = useState<string | null>(null);
+	const [pendingChallenge, setPendingChallenge] = useState<{
+		persist: boolean;
+		therapistId: string;
+	} | null>(null);
 
 	const accessToken = getAccessToken();
 	const hasAccessToken = Boolean(accessToken);
@@ -145,6 +148,15 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 	const signInMutation = useMutation({
 		mutationFn: signInFc,
 		onSuccess: async (res, variables: ISignInForm) => {
+			if (res.mode === 'whatsapp_challenge') {
+				setPendingChallenge({
+					therapistId: res.therapistId,
+					persist: Boolean(variables.stayConnected),
+				});
+				navigate(WHATSAPP_OTP_CHALLENGE, { replace: true });
+				return;
+			}
+
 			const persist = Boolean(variables.stayConnected);
 
 			await handleAuthSuccess({
@@ -168,6 +180,31 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 				audience: 'therapist',
 				error_code: toAuthErrorCode(error),
 			});
+			showAlert({ severity: 'error', message: t(error.message) });
+		},
+	});
+
+	const verifyWhatsAppOtpMutation = useMutation({
+		mutationFn: verifyWhatsAppOtpFc,
+		onSuccess: async (res) => {
+			const persist = pendingChallenge?.persist ?? false;
+			setPendingChallenge(null);
+
+			await handleAuthSuccess({
+				accessToken: res.token,
+				refreshToken: res.refreshToken,
+				persist,
+				redirectTo: redirectAfterAuth ?? DASHBOARD,
+			});
+
+			capture(PostHogEvent.AuthSignInSucceeded, {
+				method: '2fa_whatsapp',
+				audience: 'therapist',
+			});
+
+			setRedirectAfterAuth(null);
+		},
+		onError: (error: CustomError) => {
 			showAlert({ severity: 'error', message: t(error.message) });
 		},
 	});
@@ -263,6 +300,17 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 		logoutMutation.mutate();
 	}, [logoutMutation]);
 
+	const verifyWhatsAppOtp = useCallback(
+		(otp: string) => {
+			if (!pendingChallenge) return;
+			verifyWhatsAppOtpMutation.mutate({
+				therapistId: pendingChallenge.therapistId,
+				otp,
+			});
+		},
+		[pendingChallenge, verifyWhatsAppOtpMutation]
+	);
+
 	const value = useMemo<AuthContextType>(
 		() => ({
 			signIn,
@@ -276,6 +324,9 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 			isSignUpMutationLoading: signUpMutation.isPending,
 			verifyEmailToken,
 			isVerifyEmailLoading: verifyEmailMutation.isPending,
+			verifyWhatsAppOtp,
+			isVerifyWhatsAppOtpLoading: verifyWhatsAppOtpMutation.isPending,
+			hasPendingWhatsAppChallenge: Boolean(pendingChallenge),
 		}),
 		[
 			signIn,
@@ -289,6 +340,9 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 			signUpMutation.isPending,
 			verifyEmailToken,
 			verifyEmailMutation.isPending,
+			verifyWhatsAppOtp,
+			verifyWhatsAppOtpMutation.isPending,
+			pendingChallenge,
 		]
 	);
 

--- a/src/context/user/auth/UserAuthenticationContext.types.ts
+++ b/src/context/user/auth/UserAuthenticationContext.types.ts
@@ -12,17 +12,20 @@ export type TherapistRole = 'THERAPIST' | 'ADMIN';
 export type AuthProvider = 'local' | 'google';
 
 export interface AuthContextType {
+	hasPendingWhatsAppChallenge: boolean;
 	isAuthenticated: boolean;
 	isSessionLoading: boolean;
 	isSessionSuccess: boolean;
 	isSignInMutationLoading: boolean;
 	isSignUpMutationLoading: boolean;
 	isVerifyEmailLoading: boolean;
+	isVerifyWhatsAppOtpLoading: boolean;
 	logout: () => void;
 	signIn: (data: ISignInForm) => void;
 	signUp: (data: ISignUpForm) => void;
 	user?: ITherapist;
 	verifyEmailToken: (token: string) => Promise<IVerifyEmailResponse>;
+	verifyWhatsAppOtp: (otp: string) => void;
 }
 
 export interface AuthProviderProps {

--- a/src/pages/auth/whatsapp-otp/WhatsAppOtpChallenge.styles.tsx
+++ b/src/pages/auth/whatsapp-otp/WhatsAppOtpChallenge.styles.tsx
@@ -1,4 +1,5 @@
-import { Box, styled } from '@mui/material';
+import styled from '@emotion/styled';
+import { Box } from '@mui/material';
 import { spacing } from '@psycron/theme/spacing/spacing.theme';
 
 export const OtpWrapper = styled(Box)`
@@ -9,11 +10,4 @@ export const OtpWrapper = styled(Box)`
 	max-width: 400px;
 	width: 100%;
 	padding: ${spacing[6]};
-`;
-
-export const OtpInputRow = styled(Box)`
-	display: flex;
-	gap: ${spacing[2]};
-	justify-content: center;
-	width: 100%;
 `;

--- a/src/pages/auth/whatsapp-otp/WhatsAppOtpChallenge.styles.tsx
+++ b/src/pages/auth/whatsapp-otp/WhatsAppOtpChallenge.styles.tsx
@@ -1,0 +1,19 @@
+import { Box, styled } from '@mui/material';
+import { spacing } from '@psycron/theme/spacing/spacing.theme';
+
+export const OtpWrapper = styled(Box)`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: ${spacing[4]};
+	max-width: 400px;
+	width: 100%;
+	padding: ${spacing[6]};
+`;
+
+export const OtpInputRow = styled(Box)`
+	display: flex;
+	gap: ${spacing[2]};
+	justify-content: center;
+	width: 100%;
+`;

--- a/src/pages/auth/whatsapp-otp/WhatsAppOtpChallenge.tsx
+++ b/src/pages/auth/whatsapp-otp/WhatsAppOtpChallenge.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { TextField } from '@mui/material';
+import { Button } from '@psycron/components/button/Button';
+import { Text } from '@psycron/components/text/Text';
+import { useAuth } from '@psycron/context/user/auth/UserAuthenticationContext';
+import i18n from '@psycron/i18n';
+import { SIGNIN } from '@psycron/pages/urls';
+
+import { OtpWrapper } from './WhatsAppOtpChallenge.styles';
+
+export const WhatsAppOtpChallenge = () => {
+	const { t } = useTranslation();
+	const navigate = useNavigate();
+	const { verifyWhatsAppOtp, isVerifyWhatsAppOtpLoading, hasPendingWhatsAppChallenge } =
+		useAuth();
+
+	const [otp, setOtp] = useState('');
+
+	if (!hasPendingWhatsAppChallenge) {
+		navigate(`/${i18n.resolvedLanguage}/${SIGNIN}`, { replace: true });
+		return null;
+	}
+
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		if (otp.length === 6) verifyWhatsAppOtp(otp);
+	};
+
+	return (
+		<OtpWrapper component='form' onSubmit={handleSubmit}>
+			<Text variant='h5'>{t('page.auth.whatsapp-otp.title')}</Text>
+			<Text variant='body2'>{t('page.auth.whatsapp-otp.description')}</Text>
+			<TextField
+				autoFocus
+				disabled={isVerifyWhatsAppOtpLoading}
+				fullWidth
+				inputProps={{ inputMode: 'numeric', maxLength: 6, pattern: '[0-9]*' }}
+				label={t('page.auth.whatsapp-otp.label')}
+				onChange={(e) => setOtp(e.target.value.replace(/\D/g, '').slice(0, 6))}
+				value={otp}
+			/>
+			<Button
+				disabled={otp.length !== 6 || isVerifyWhatsAppOtpLoading}
+				fullWidth
+				loading={isVerifyWhatsAppOtpLoading}
+				type='submit'
+				variant='contained'
+			>
+				{t('page.auth.whatsapp-otp.submit')}
+			</Button>
+		</OtpWrapper>
+	);
+};

--- a/src/pages/auth/whatsapp-otp/WhatsAppOtpChallenge.types.ts
+++ b/src/pages/auth/whatsapp-otp/WhatsAppOtpChallenge.types.ts
@@ -1,0 +1,1 @@
+export type WhatsAppOtpChallengeProps = Record<string, never>;

--- a/src/pages/notifications/NotificationsPage.styles.tsx
+++ b/src/pages/notifications/NotificationsPage.styles.tsx
@@ -138,3 +138,34 @@ export const FiltersContent = styled(Box)`
 	flex-direction: column;
 	gap: ${spacing.small};
 `;
+
+export const WhatsAppActionBanner = styled(Box)`
+	align-items: flex-start;
+	background: ${hexToRgba(palette.warning.main, 0.08)};
+	border: 1px solid ${hexToRgba(palette.warning.main, 0.25)};
+	border-radius: ${spacing.xs};
+	color: ${palette.warning.dark};
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.xs};
+	padding: ${spacing.small};
+
+	svg {
+		flex-shrink: 0;
+		height: 18px;
+		width: 18px;
+	}
+`;
+
+export const WhatsAppActionBannerRow = styled(Box)`
+	align-items: center;
+	display: flex;
+	gap: ${spacing.xs};
+	font-size: 0.88rem;
+	font-weight: 700;
+`;
+
+export const WhatsAppActionBannerBody = styled(Box)`
+	font-size: 0.84rem;
+	line-height: 1.55;
+`;

--- a/src/pages/notifications/NotificationsPage.utils.ts
+++ b/src/pages/notifications/NotificationsPage.utils.ts
@@ -37,6 +37,7 @@ export const NOTIFICATION_MESSAGE_TYPES = [
 	'CONFLICT',
 	'ACCOUNT_SETUP',
 	'DAILY_SCHEDULE_SUMMARY',
+	'WHATSAPP_ACTION_REQUIRED',
 ] satisfies NotificationMessageType[];
 
 export const DEFAULT_NOTIFICATION_LIMIT = 20;
@@ -155,27 +156,16 @@ export const formatNotificationDeliveryDate = (
 	);
 };
 
-const APPOINTMENT_MESSAGE_TYPES: NotificationMessageType[] = [
-	'APPOINTMENT_CONFIRMATION',
-	'APPOINTMENT_UPDATED',
-	'REMINDER',
-];
-
 export const isNotificationResendable = (
 	notification: INotificationRecord
 ): boolean => {
-	if (notification.status === 'FAILED') return true;
+	if (notification.messageType === 'WHATSAPP_ACTION_REQUIRED') return false;
 
-	// Appointment hydrated — trust its isUpcoming flag
-	if (notification.appointment) {
-		return Boolean(notification.appointment.isUpcoming);
-	}
-
-	// Appointment not hydrated — optimistically allow resend for appointment-related types;
-	// the backend validates the actual slot date on retry
-	return APPOINTMENT_MESSAGE_TYPES.includes(
-		notification.messageType as NotificationMessageType
-	);
+	// Appointment must be hydrated and upcoming. If the slot can't be found by the
+	// backend (deleted, old record without slotId) appointment is null — in that
+	// case we conservatively hide the button; resending a past or unknown slot is
+	// always wrong and the backend guards against it anyway.
+	return Boolean(notification.appointment?.isUpcoming);
 };
 
 export const getPatientProfilePath = (

--- a/src/pages/notifications/NotificationsPage.utils.ts
+++ b/src/pages/notifications/NotificationsPage.utils.ts
@@ -20,7 +20,6 @@ import type { TFunction } from 'i18next';
 export const NOTIFICATION_CHANNELS: NotificationChannel[] = [
 	'WHATSAPP',
 	'EMAIL',
-	'SMS',
 	'ICALENDAR',
 ];
 

--- a/src/pages/notifications/components/NotificationDetailPanel.tsx
+++ b/src/pages/notifications/components/NotificationDetailPanel.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Button } from '@psycron/components/button/Button';
-import { Archive } from '@psycron/components/icons';
+import { Alert, Archive } from '@psycron/components/icons';
 import { Link } from '@psycron/components/link/Link';
 import {
 	QueueActionsRow,
@@ -22,6 +22,9 @@ import {
 	ContextList,
 	NotificationStatusPill,
 	NotificationUtilityRow,
+	WhatsAppActionBanner,
+	WhatsAppActionBannerBody,
+	WhatsAppActionBannerRow,
 } from '../NotificationsPage.styles';
 import {
 	formatNotificationAppointment,
@@ -153,6 +156,18 @@ export const NotificationDetailPanel = ({
 				<QueueDetailLabel>{t('notifications.detail.message')}</QueueDetailLabel>
 				<QueueDetailMessage>{notification.content}</QueueDetailMessage>
 			</QueueDetailCard>
+
+			{notification.messageType === 'WHATSAPP_ACTION_REQUIRED' ? (
+				<WhatsAppActionBanner>
+					<WhatsAppActionBannerRow>
+						<Alert aria-hidden='true' />
+						{t('notifications.whatsapp-action-required.title')}
+					</WhatsAppActionBannerRow>
+					<WhatsAppActionBannerBody>
+						{t('notifications.whatsapp-action-required.body')}
+					</WhatsAppActionBannerBody>
+				</WhatsAppActionBanner>
+			) : null}
 
 			<QueueActionsRow>
 				{canResend ? (

--- a/src/pages/unsubscribe-preferences/UnsubscribePreferences.styles.tsx
+++ b/src/pages/unsubscribe-preferences/UnsubscribePreferences.styles.tsx
@@ -1,0 +1,72 @@
+import styled from '@emotion/styled';
+import { Box } from '@mui/material';
+import { Text } from '@psycron/components/text/Text';
+import {
+	isBiggerThanTabletMedia,
+} from '@psycron/theme/media-queries/mediaQueries';
+import { palette } from '@psycron/theme/palette/palette.theme';
+import { spacing } from '@psycron/theme/spacing/spacing.theme';
+
+export const PageWrapper = styled(Box)`
+	min-height: calc(100vh - var(--total-component-height, 0px));
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: ${spacing.large};
+	background: ${palette.background.default};
+`;
+
+export const Card = styled(Box)`
+	width: 100%;
+	max-width: 480px;
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.medium};
+`;
+
+export const Heading = styled(Text)`
+	font-weight: 700;
+	font-size: 1.5rem;
+	color: ${palette.text.primary};
+
+	${isBiggerThanTabletMedia} {
+		font-size: 2rem;
+	}
+`;
+
+export const Description = styled(Text)`
+	font-size: 0.95rem;
+	color: ${palette.text.secondary};
+	line-height: 1.6;
+`;
+
+export const Disclaimer = styled(Text)`
+	font-size: 0.8rem;
+	color: ${palette.text.disabled};
+	line-height: 1.5;
+	padding: ${spacing.small};
+	border-left: 3px solid ${palette.gray['02']};
+	padding-left: ${spacing.small};
+`;
+
+export const SuccessWrapper = styled(Box)`
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.small};
+	padding: ${spacing.medium};
+	border-radius: 12px;
+	background: ${palette.success.light ?? '#e8f5e9'};
+`;
+
+export const BackLink = styled('a')`
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: ${palette.secondary.main};
+	cursor: pointer;
+	text-decoration: none;
+	align-self: flex-start;
+
+	&:hover {
+		text-decoration: underline;
+	}
+`;

--- a/src/pages/unsubscribe-preferences/UnsubscribePreferences.tsx
+++ b/src/pages/unsubscribe-preferences/UnsubscribePreferences.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { unsubscribeByEmail } from '@psycron/api/subs';
+import { Button } from '@psycron/components/button/Button';
+import { InputFields } from '@psycron/components/form/components/shared/SignLayout.styles';
+import { useMutation } from '@tanstack/react-query';
+
+import {
+	BackLink,
+	Card,
+	Description,
+	Disclaimer,
+	Heading,
+	PageWrapper,
+	SuccessWrapper,
+} from './UnsubscribePreferences.styles';
+
+type FormValues = { email: string };
+
+export const UnsubscribePreferences = () => {
+	const { t, i18n } = useTranslation();
+	const [succeeded, setSucceeded] = useState(false);
+
+	const { register, handleSubmit, formState: { errors } } = useForm<FormValues>();
+
+	const mutation = useMutation({
+		mutationFn: ({ email }: FormValues) => unsubscribeByEmail(email),
+		onSuccess: () => setSucceeded(true),
+	});
+
+	const onSubmit = (data: FormValues) => mutation.mutate(data);
+
+	const locale = i18n.language?.startsWith('pt') ? 'pt' : 'en';
+
+	return (
+		<PageWrapper>
+			<Card>
+				{succeeded ? (
+					<SuccessWrapper>
+						<Heading variant='h1'>
+							{t('page.unsubscribe-preferences.success-title')}
+						</Heading>
+						<Description>
+							{t('page.unsubscribe-preferences.success-description')}
+						</Description>
+						<BackLink href={`/${locale}`}>
+							{t('page.unsubscribe-preferences.back-home')}
+						</BackLink>
+					</SuccessWrapper>
+				) : (
+					<>
+						<Heading variant='h1'>
+							{t('page.unsubscribe-preferences.title')}
+						</Heading>
+						<Description>
+							{t('page.unsubscribe-preferences.description')}
+						</Description>
+
+						<form onSubmit={handleSubmit(onSubmit)} noValidate>
+							<InputFields
+								label={t('page.unsubscribe-preferences.email-label')}
+								placeholder={t('page.unsubscribe-preferences.email-placeholder')}
+								type='email'
+								fullWidth
+								{...register('email', { required: true })}
+								error={!!errors.email || !!mutation.error}
+								sx={{ mb: 2 }}
+							/>
+							<Button
+								type='submit'
+								fullWidth
+								isLoading={mutation.isPending}
+							>
+								{t('page.unsubscribe-preferences.submit')}
+							</Button>
+						</form>
+
+						<Disclaimer>
+							{t('page.unsubscribe-preferences.disclaimer')}
+						</Disclaimer>
+					</>
+				)}
+			</Card>
+		</PageWrapper>
+	);
+};

--- a/src/pages/urls.tsx
+++ b/src/pages/urls.tsx
@@ -22,6 +22,7 @@ export const AUTHCALLBACK = 'auth/callback';
 
 // UNSUBSCRIBE
 export const UNSUBSCRIBE = ':token/unsubscribe';
+export const UNSUBSCRIBE_PREFERENCES = 'unsubscribe';
 
 // PRIVATE
 export const DASHBOARD = 'dashboard';

--- a/src/pages/urls.tsx
+++ b/src/pages/urls.tsx
@@ -19,6 +19,7 @@ export const REQPASSRESET = 'reset-password';
 export const PASSRESET = 'password-reset/:token';
 export const VERIFYEMAIL = 'auth/verify-email';
 export const AUTHCALLBACK = 'auth/callback';
+export const WHATSAPP_OTP_CHALLENGE = 'auth/whatsapp-otp';
 
 // UNSUBSCRIBE
 export const UNSUBSCRIBE = ':token/unsubscribe';

--- a/src/routes/PublicRoutes.tsx
+++ b/src/routes/PublicRoutes.tsx
@@ -5,6 +5,7 @@ import { ResetPassword } from '@psycron/pages/auth/password/ResetPassword';
 import { VerifyEmail } from '@psycron/pages/auth/verification/email/VerifyEmail';
 import { TestHomePage } from '@psycron/pages/back-office/home/TestHomePage';
 import { Unsubscribe } from '@psycron/pages/unsubscribe/Unsubscribe';
+import { UnsubscribePreferences } from '@psycron/pages/unsubscribe-preferences/UnsubscribePreferences';
 import {
 	APPOINTMENTCONFIRMATIONPATH,
 	AUTHCALLBACK,
@@ -16,6 +17,7 @@ import {
 	SIGNIN,
 	SIGNUP,
 	UNSUBSCRIBE,
+	UNSUBSCRIBE_PREFERENCES,
 	VERIFYEMAIL,
 } from '@psycron/pages/urls';
 import { BookAppointment } from '@psycron/pages/user/appointment/booking/BookAppointment';
@@ -25,6 +27,7 @@ import { AppointmentsList } from '@psycron/pages/user/appointment/list/patient/A
 const publicRoutes = [
 	{ path: HOMEPAGE, element: <TestHomePage /> },
 	{ path: UNSUBSCRIBE, element: <Unsubscribe /> },
+	{ path: UNSUBSCRIBE_PREFERENCES, element: <UnsubscribePreferences /> },
 	{ path: SIGNIN, element: <AuthPage /> },
 	{ path: SIGNUP, element: <AuthPage /> },
 	{ path: AUTHCALLBACK, element: <AuthCallback /> },

--- a/src/routes/PublicRoutes.tsx
+++ b/src/routes/PublicRoutes.tsx
@@ -3,6 +3,7 @@ import { AuthCallback } from '@psycron/pages/auth/callback/AuthCallback';
 import { ChangePassword } from '@psycron/pages/auth/password/ChangePassword';
 import { ResetPassword } from '@psycron/pages/auth/password/ResetPassword';
 import { VerifyEmail } from '@psycron/pages/auth/verification/email/VerifyEmail';
+import { WhatsAppOtpChallenge } from '@psycron/pages/auth/whatsapp-otp/WhatsAppOtpChallenge';
 import { TestHomePage } from '@psycron/pages/back-office/home/TestHomePage';
 import { Unsubscribe } from '@psycron/pages/unsubscribe/Unsubscribe';
 import { UnsubscribePreferences } from '@psycron/pages/unsubscribe-preferences/UnsubscribePreferences';
@@ -19,6 +20,7 @@ import {
 	UNSUBSCRIBE,
 	UNSUBSCRIBE_PREFERENCES,
 	VERIFYEMAIL,
+	WHATSAPP_OTP_CHALLENGE,
 } from '@psycron/pages/urls';
 import { BookAppointment } from '@psycron/pages/user/appointment/booking/BookAppointment';
 import { AppointmentConfirmation } from '@psycron/pages/user/appointment/confirmation/AppointmentConfirmation';
@@ -32,6 +34,7 @@ const publicRoutes = [
 	{ path: SIGNUP, element: <AuthPage /> },
 	{ path: AUTHCALLBACK, element: <AuthCallback /> },
 	{ path: VERIFYEMAIL, element: <VerifyEmail /> },
+	{ path: WHATSAPP_OTP_CHALLENGE, element: <WhatsAppOtpChallenge /> },
 	{ path: REQPASSRESET, element: <ResetPassword /> },
 	{ path: PASSRESET, element: <ChangePassword /> },
 	{ path: BOOKAPPOINTMENT, element: <BookAppointment /> },


### PR DESCRIPTION
## Summary

PR-335 notifications refactor — frontend side. Implements WhatsApp 2FA challenge flow, SMS removal, and notification page data correctness fixes.

- **WhatsApp OTP challenge**: new `WhatsAppOtpChallenge` page + route; `UserAuthenticationContext` detects `whatsapp_challenge` response and redirects; `verifyWhatsAppOtp` action issues JWT on success; fixed `@emotion/styled` import crash in `.styles.tsx`
- **SMS toggled off**: removed SMS from `NotificationChannel` type, channel filters, dashboard widget counters — Twilio kept in package for future SMS re-enablement
- **Notification resend gate**: `isNotificationResendable` now requires `appointment.isUpcoming === true` (hydrated slot, future date); removed FAILED bypass and type-based fallback that showed "Notify again" on past-appointment notifications
- **WHATSAPP_ACTION_REQUIRED**: added to message type filter; warning banner in `NotificationDetailPanel` prompts therapist to follow up manually (EN + PT i18n)
- **Dashboard SMS cleanup**: removed SMS from `DashboardNotificationChannel` type — aligned with BE

## Test plan

- [ ] Log in as therapist with WhatsApp 2FA enabled → OTP challenge screen appears, correct OTP issues JWT
- [ ] Open a past-appointment notification → "Notify again" button is hidden
- [ ] Open a future-appointment notification → "Notify again" button is visible
- [ ] Open a `WHATSAPP_ACTION_REQUIRED` notification → orange warning banner renders, no resend button
- [ ] Notifications filter by message type includes "WhatsApp follow-up required" entry
- [ ] Dashboard notifications widget shows EMAIL / ICALENDAR / WHATSAPP counters (no SMS column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)