### PR TITLE
PR-333: LGPD/GDPR patient consent UI

### DIFF
--- a/src/analytics/posthog/types.ts
+++ b/src/analytics/posthog/types.ts
@@ -33,6 +33,8 @@ export const enum PostHogEvent {
 	AvailabilitySlotBlocked = 'availability slot blocked',
 	AvailabilitySlotUnblocked = 'availability slot unblocked',
 	BackofficeWorkerSessionFailed = 'backoffice worker session failed',
+	ConsentGranted = 'consent granted',
+	ConsentRevoked = 'consent revoked',
 
 	DashboardActionCenterItemClicked = 'dashboard action center item clicked',
 	DashboardBillingReadinessClicked = 'dashboard billing readiness clicked',
@@ -52,6 +54,7 @@ export const enum PostHogEvent {
 	DashboardTileRestored = 'dashboard tile restored',
 	DashboardWidgetFeedbackSubmitted = 'dashboard widget feedback submitted',
 	DashboardWidgetInfoOpened = 'dashboard widget info opened',
+	DeletionRequested = 'deletion requested',
 	EditUserSubmitted = 'edit user submitted',
 
 	FeaturePageQueueExpansionChanged = 'feature page queue expansion changed',
@@ -232,6 +235,21 @@ export type PostHogEventProps = {
 	[PostHogEvent.BackofficeWorkerSessionFailed]: {
 		reason: 'not_authenticated' | 'missing_worker';
 	};
+
+	[PostHogEvent.ConsentGranted]: {
+		channel: 'self_management' | 'therapist_booked' | 'web_booking';
+		purpose:
+			| 'data_processing'
+			| 'marketing_communications'
+			| 'third_party_sharing';
+	};
+	[PostHogEvent.ConsentRevoked]: {
+		purpose:
+			| 'data_processing'
+			| 'marketing_communications'
+			| 'third_party_sharing';
+	};
+	[PostHogEvent.DeletionRequested]: never;
 
 	[PostHogEvent.AuthSignInStarted]: {
 		audience: 'therapist' | 'worker';

--- a/src/api/patient/consent.ts
+++ b/src/api/patient/consent.ts
@@ -1,0 +1,52 @@
+import apiClient from '../axios-instance';
+
+import type {
+	ConsentPurpose,
+	ConsentRecordsResponse,
+	DataDeletionResponse,
+	RecordConsentPayload,
+} from './consent.types';
+
+export const recordConsent = async (
+	patientId: string,
+	payload: RecordConsentPayload
+): Promise<ConsentRecordsResponse> => {
+	const response = await apiClient.post<ConsentRecordsResponse>(
+		`/patient/${patientId}/consent`,
+		payload
+	);
+
+	return response.data;
+};
+
+export const revokeConsent = async (
+	patientId: string,
+	purpose: ConsentPurpose
+): Promise<ConsentRecordsResponse> => {
+	const response = await apiClient.delete<ConsentRecordsResponse>(
+		`/patient/${patientId}/consent/${purpose}`
+	);
+
+	return response.data;
+};
+
+export const getConsentRecords = async (
+	patientId: string
+): Promise<ConsentRecordsResponse> => {
+	const response = await apiClient.get<ConsentRecordsResponse>(
+		`/patient/${patientId}/consent`
+	);
+
+	return response.data;
+};
+
+export const requestDataDeletion = async (
+	patientId: string
+): Promise<DataDeletionResponse> => {
+	const response = await apiClient.post<DataDeletionResponse>(
+		'/patient/me/deletion-request',
+		{ patientId }
+	);
+
+	return response.data;
+};

--- a/src/api/patient/consent.types.ts
+++ b/src/api/patient/consent.types.ts
@@ -1,0 +1,39 @@
+export type ConsentPurpose =
+	| 'data_processing'
+	| 'marketing_communications'
+	| 'third_party_sharing';
+
+export type ConsentChannel =
+	| 'web_booking'
+	| 'therapist_booked'
+	| 'self_management';
+
+export interface ConsentRecord {
+	channel: ConsentChannel;
+	grantedAt: string;
+	ipAddress: string;
+	purpose: ConsentPurpose;
+	revokedAt: string | null;
+	version: string;
+}
+
+export interface RecordConsentPayload {
+	channel: ConsentChannel;
+	purpose: ConsentPurpose;
+	version: string;
+}
+
+export interface ConsentRecordsResponse {
+	consent: ConsentRecord[];
+}
+
+export interface DataDeletionResponse {
+	deletionRequest: {
+		_id: string;
+		patientId: string;
+		requestedAt: string;
+		status: 'pending' | 'acknowledged' | 'completed';
+		therapistId: string;
+	};
+	retentionNotice: string;
+}

--- a/src/api/patient/index.types.ts
+++ b/src/api/patient/index.types.ts
@@ -75,6 +75,7 @@ export interface ICreatePatientResponse {
 export type SessionDelivery = 'in_person' | 'online';
 
 export interface ICreatePatientForm {
+	consentAccepted?: boolean;
 	countryCode: string;
 	email?: string;
 	firstName: string;

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -2198,5 +2198,30 @@
       "success": "Notification archived.",
       "error": "Could not archive this notification."
     }
+  },
+  "consent": {
+    "title": "Consent",
+    "dataProcessing": "I consent to my personal information being stored and processed by {{therapistName}} through Psycron for appointment management purposes. I have read the <privacyLink>Privacy Policy</privacyLink>.",
+    "privacyPolicyLink": "Privacy Policy",
+    "required": "Consent is required to proceed",
+    "yourPrivacy": "Your data & privacy",
+    "activeConsents": "Active consents",
+    "revokeConsent": "Revoke",
+    "requestDeletion": "Request deletion of my data",
+    "deletionRequested": "Your deletion request was sent.",
+    "noActiveConsents": "No active consents.",
+    "notGranted": "Not granted",
+    "yourTherapist": "your therapist",
+    "deletionModal": {
+      "title": "Data deletion request",
+      "body": "Your request will be sent to your therapist. Health appointment records are retained for a minimum of 5 years under Brazilian CFP resolution 001/2009. Your data will be anonymised, not immediately deleted.",
+      "confirm": "Submit request"
+    },
+    "noConsentWarning": "No explicit consent on record for this patient",
+    "purposes": {
+      "data_processing": "Data processing",
+      "marketing_communications": "Marketing communications",
+      "third_party_sharing": "Third-party sharing"
+    }
   }
 }

--- a/src/assets/locales/pt/translation.json
+++ b/src/assets/locales/pt/translation.json
@@ -2198,5 +2198,30 @@
       "success": "Notificação arquivada.",
       "error": "Não foi possível arquivar esta notificação."
     }
+  },
+  "consent": {
+    "title": "Consentimento",
+    "dataProcessing": "Eu consinto que minhas informações pessoais sejam armazenadas e processadas por {{therapistName}} por meio da Psycron para fins de gestão de consultas. Li a <privacyLink>Política de Privacidade</privacyLink>.",
+    "privacyPolicyLink": "Política de Privacidade",
+    "required": "O consentimento é obrigatório para continuar",
+    "yourPrivacy": "Seus dados e privacidade",
+    "activeConsents": "Consentimentos ativos",
+    "revokeConsent": "Revogar",
+    "requestDeletion": "Solicitar exclusão dos meus dados",
+    "deletionRequested": "Sua solicitação de exclusão foi enviada.",
+    "noActiveConsents": "Nenhum consentimento ativo.",
+    "notGranted": "Não concedido",
+    "yourTherapist": "seu terapeuta",
+    "deletionModal": {
+      "title": "Solicitação de exclusão de dados",
+      "body": "Sua solicitação será enviada ao seu terapeuta. Registros de consultas de saúde são mantidos por no mínimo 5 anos conforme a resolução CFP 001/2009. Seus dados serão anonimizados, não excluídos imediatamente.",
+      "confirm": "Enviar solicitação"
+    },
+    "noConsentWarning": "Nenhum consentimento explícito registrado para este paciente",
+    "purposes": {
+      "data_processing": "Processamento de dados",
+      "marketing_communications": "Comunicações de marketing",
+      "third_party_sharing": "Compartilhamento com terceiros"
+    }
   }
 }

--- a/src/pages/availability/week/drawer/hooks/useBookingForm.ts
+++ b/src/pages/availability/week/drawer/hooks/useBookingForm.ts
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { capture } from '@psycron/analytics/posthog/events';
+import { PostHogEvent } from '@psycron/analytics/posthog/types';
+import { recordConsent } from '@psycron/api/patient/consent';
 import {
 	type ICreatePatientForm,
 	RecurrencePattern,
@@ -94,7 +97,7 @@ export const useBookingForm = (
 	const executeBooking = async (payload: IPendingBooking) => {
 		const deliveryMode = sessionType === 'ONLINE' ? 'online' : 'in-person';
 
-		await bookSlotByTherapist({
+		const response = await bookSlotByTherapist({
 			therapistId: therapistId ?? '',
 			availabilityDayId: slot.availabilityDayId ?? '',
 			slotId: slot._id ?? slot.id,
@@ -122,6 +125,18 @@ export const useBookingForm = (
 				? { existingPatientId: payload.existingPatientId }
 				: {}),
 		});
+
+		if (!payload.existingPatientId && response.patient._id) {
+			await recordConsent(response.patient._id, {
+				channel: 'therapist_booked',
+				purpose: 'data_processing',
+				version: '1.0',
+			});
+			capture(PostHogEvent.ConsentGranted, {
+				channel: 'therapist_booked',
+				purpose: 'data_processing',
+			});
+		}
 
 		await queryClient.invalidateQueries({
 			queryKey: ['therapistAvailability'],

--- a/src/pages/availability/week/drawer/views/slot-available-body/SlotAvailableBody.styles.tsx
+++ b/src/pages/availability/week/drawer/views/slot-available-body/SlotAvailableBody.styles.tsx
@@ -49,6 +49,25 @@ export const BookingLinkHint = styled(Text)`
 	line-height: 1.5;
 `;
 
+export const ConsentBox = styled(Box)`
+	background: ${palette.background.paper};
+	border: 1px solid ${palette.gray['02']};
+	border-radius: ${spacing.small};
+	padding: ${spacing.small};
+`;
+
+export const ConsentLabel = styled('span')`
+	color: ${palette.text.primary};
+	font-size: 0.875rem;
+	line-height: 1.5;
+
+	a {
+		color: ${palette.brand.purple};
+		font-weight: 600;
+		text-decoration: underline;
+	}
+`;
+
 export const ReopenedNote = styled(Box)`
 	display: flex;
 	flex-direction: column;

--- a/src/pages/availability/week/drawer/views/slot-available-body/SlotAvailableBody.tsx
+++ b/src/pages/availability/week/drawer/views/slot-available-body/SlotAvailableBody.tsx
@@ -1,13 +1,21 @@
 import { useMemo } from 'react';
-import { FormProvider, useWatch } from 'react-hook-form';
-import { useTranslation } from 'react-i18next';
-import { Box, TextField } from '@mui/material';
+import { Controller, FormProvider, useWatch } from 'react-hook-form';
+import { Trans, useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import {
+	Box,
+	Checkbox,
+	FormControlLabel,
+	FormHelperText,
+	TextField,
+} from '@mui/material';
 import type { ICreatePatientForm } from '@psycron/api/patient/index.types';
 import { ShareButton } from '@psycron/components/button/share/ShareButton';
 import { Divider } from '@psycron/components/divider/Divider';
 import { ContactsForm } from '@psycron/components/form/components/contacts/ContactsForm';
 import { PreferredContactForm } from '@psycron/components/form/components/preferred-contact/PreferredContactForm';
 import { TimezoneSelect } from '@psycron/components/form/components/timezone/TimezoneSelect';
+import { externalUrls } from '@psycron/pages/urls';
 
 import { FormWrapper } from '../../AvailabilityWeekDrawer.styles';
 import { PatientNameAutocomplete } from '../patient-name-autocomplete/PatientNameAutocomplete';
@@ -23,6 +31,8 @@ import {
 	BookingLinkSection,
 	BookingLinkValue,
 	BookingLinkValueRow,
+	ConsentBox,
+	ConsentLabel,
 	ReopenedNote,
 	ReopenedNoteLabel,
 	ReopenedNoteText,
@@ -46,7 +56,7 @@ export const SlotAvailableBody = ({
 	shareTitle,
 	...locationProps
 }: ISlotAvailableBodyProps) => {
-	const { t } = useTranslation();
+	const { i18n, t } = useTranslation();
 	const {
 		control,
 		register,
@@ -166,6 +176,47 @@ export const SlotAvailableBody = ({
 					{isInPerson && <SlotLocationSection {...locationProps} />}
 					<SlotRecurrenceSection />
 					<TimezoneSelect />
+					{!selectedPatient ? (
+						<ConsentBox>
+							<Controller
+								control={control}
+								name='consentAccepted'
+								rules={{ validate: (value) => value || t('consent.required') }}
+								render={({ field }) => (
+									<FormControlLabel
+										control={
+											<Checkbox
+												checked={Boolean(field.value)}
+												onChange={(e) => field.onChange(e.target.checked)}
+											/>
+										}
+										label={
+											<ConsentLabel>
+												<Trans
+													i18nKey='consent.dataProcessing'
+													values={{
+														therapistName: t('consent.yourTherapist'),
+													}}
+													components={{
+														privacyLink: (
+															<Link
+																to={externalUrls(i18n.language).PRIVACY}
+															/>
+														),
+													}}
+												/>
+											</ConsentLabel>
+										}
+									/>
+								)}
+							/>
+							{errors.consentAccepted?.message ? (
+								<FormHelperText error>
+									{String(errors.consentAccepted.message)}
+								</FormHelperText>
+							) : null}
+						</ConsentBox>
+					) : null}
 				</FormWrapper>
 			</Box>
 		</FormProvider>

--- a/src/pages/patients/patient-details/PatientProfilePage.tsx
+++ b/src/pages/patients/patient-details/PatientProfilePage.tsx
@@ -44,6 +44,7 @@ import {
 	getSessionsAscending,
 } from '../PatientsPage.utils';
 
+import { ConsentSection } from './components/consent/ConsentSection';
 import { PatientEditForm } from './edit-patient-form/PatientEditForm';
 import { SessionDrawer } from './session-drawer/SessionDrawer';
 import {
@@ -518,6 +519,11 @@ export const PatientProfilePage = () => {
 									})}
 								</MutedValue>
 							) : null}
+						</SectionCard>
+
+						<SectionCard>
+							<SectionTitle>{t('consent.title')}</SectionTitle>
+							<ConsentSection patientId={patientDetails._id} />
 						</SectionCard>
 
 						<SectionCard>

--- a/src/pages/patients/patient-details/components/consent/ConsentSection.styles.tsx
+++ b/src/pages/patients/patient-details/components/consent/ConsentSection.styles.tsx
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+import { Box } from '@mui/material';
+import { hexToRgba, palette } from '@psycron/theme/palette/palette.theme';
+import { spacing } from '@psycron/theme/spacing/spacing.theme';
+
+export const ConsentSectionRoot = styled(Box)`
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.small};
+`;
+
+export const ConsentWarning = styled(Box)`
+	background: ${hexToRgba(palette.warning.main, 0.1)};
+	border: 1px solid ${hexToRgba(palette.warning.main, 0.3)};
+	border-radius: ${spacing.small};
+	color: ${palette.warning.dark};
+	padding: ${spacing.small};
+`;
+
+export const ConsentRow = styled(Box)`
+	align-items: center;
+	border: 1px solid ${palette.gray['02']};
+	border-radius: ${spacing.small};
+	display: flex;
+	gap: ${spacing.small};
+	justify-content: space-between;
+	padding: ${spacing.small};
+`;
+
+export const ConsentMeta = styled(Box)`
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.space};
+`;

--- a/src/pages/patients/patient-details/components/consent/ConsentSection.tsx
+++ b/src/pages/patients/patient-details/components/consent/ConsentSection.tsx
@@ -1,0 +1,102 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { capture } from '@psycron/analytics/posthog/events';
+import { PostHogEvent } from '@psycron/analytics/posthog/types';
+import {
+	getConsentRecords,
+	revokeConsent,
+} from '@psycron/api/patient/consent';
+import type { ConsentPurpose } from '@psycron/api/patient/consent.types';
+import { Button } from '@psycron/components/button/Button';
+import { Text } from '@psycron/components/text/Text';
+import { formatLocalizedDate } from '@psycron/utils/date/date.utils';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+	ConsentMeta,
+	ConsentRow,
+	ConsentSectionRoot,
+	ConsentWarning,
+} from './ConsentSection.styles';
+
+const CONSENT_PURPOSES: ConsentPurpose[] = [
+	'data_processing',
+	'marketing_communications',
+	'third_party_sharing',
+];
+
+interface ConsentSectionProps {
+	patientId: string;
+}
+
+export const ConsentSection = ({ patientId }: ConsentSectionProps) => {
+	const { i18n, t } = useTranslation();
+	const queryClient = useQueryClient();
+	const queryKey = ['patientConsent', patientId] as const;
+
+	const { data, isLoading } = useQuery({
+		enabled: Boolean(patientId),
+		queryFn: () => getConsentRecords(patientId),
+		queryKey,
+	});
+
+	const activeByPurpose = useMemo(() => {
+		const active = new Map<ConsentPurpose, NonNullable<typeof data>['consent'][number]>();
+
+		for (const record of data?.consent ?? []) {
+			if (!record.revokedAt) active.set(record.purpose, record);
+		}
+
+		return active;
+	}, [data?.consent]);
+
+	const revokeMutation = useMutation({
+		mutationFn: (purpose: ConsentPurpose) => revokeConsent(patientId, purpose),
+		onSuccess: (_data, purpose) => {
+			capture(PostHogEvent.ConsentRevoked, { purpose });
+			void queryClient.invalidateQueries({ queryKey });
+		},
+	});
+
+	const hasActiveConsent = activeByPurpose.size > 0;
+
+	return (
+		<ConsentSectionRoot>
+			{!isLoading && !hasActiveConsent ? (
+				<ConsentWarning>
+					<Text variant='body2'>{t('consent.noConsentWarning')}</Text>
+				</ConsentWarning>
+			) : null}
+			{CONSENT_PURPOSES.map((purpose) => {
+				const active = activeByPurpose.get(purpose);
+
+				return (
+					<ConsentRow key={purpose}>
+						<ConsentMeta>
+							<Text fontWeight={600} variant='body2'>
+								{t(`consent.purposes.${purpose}`)}
+							</Text>
+							<Text color='text.secondary' variant='caption'>
+								{active
+									? formatLocalizedDate(
+											active.grantedAt,
+											t('patients.list.not-available'),
+											i18n.language
+										)
+									: t('consent.notGranted')}
+							</Text>
+						</ConsentMeta>
+						<Button
+							disabled={!active || revokeMutation.isPending}
+							onClick={() => revokeMutation.mutate(purpose)}
+							severity='error'
+							variant='outlined'
+						>
+							{t('consent.revokeConsent')}
+						</Button>
+					</ConsentRow>
+				);
+			})}
+		</ConsentSectionRoot>
+	);
+};

--- a/src/pages/user/appointment/booking/BookAppointment.tsx
+++ b/src/pages/user/appointment/booking/BookAppointment.tsx
@@ -6,6 +6,7 @@ import { Skeleton, Typography } from '@mui/material';
 import { capture } from '@psycron/analytics/posthog/events';
 import { PostHogEvent } from '@psycron/analytics/posthog/types';
 import { bookAppointmentFromLink } from '@psycron/api/patient';
+import { recordConsent } from '@psycron/api/patient/consent';
 import { getAvailabilityCalendar, getUserById } from '@psycron/api/user';
 import { Button } from '@psycron/components/button/Button';
 import { Calendar, ClockIn, Globe, MapPin } from '@psycron/components/icons';
@@ -101,6 +102,7 @@ export const BookAppointment = () => {
 	const methods = useForm<IBookingFormValues>({
 		defaultValues: {
 			countryCode: '',
+			consentAccepted: false,
 			email: '',
 			firstName: '',
 			lastName: '',
@@ -213,6 +215,20 @@ export const BookAppointment = () => {
 					therapist_id: therapistId,
 				});
 			}
+			recordConsent(res.patient._id, {
+				channel: 'web_booking',
+				purpose: 'data_processing',
+				version: '1.0',
+			})
+				.then(() => {
+					capture(PostHogEvent.ConsentGranted, {
+						channel: 'web_booking',
+						purpose: 'data_processing',
+					});
+				})
+				.catch(() => {
+					showAlert({ message: t('booking.error'), severity: 'error' });
+				});
 			navigate(`../${therapistId}/${res.patient._id}/appointment-confirmation`, {
 				replace: true,
 			});
@@ -627,6 +643,11 @@ export const BookAppointment = () => {
 						<PublicBookingForm
 							letPatientChooseAddress={selectedSlot.letPatientChooseAddress ?? false}
 							methods={methods}
+							therapistName={
+								therapist
+									? `${therapist.firstName} ${therapist.lastName}`
+									: t('globals.therapist')
+							}
 						/>
 					</PatientDrawerShell>
 				) : null}

--- a/src/pages/user/appointment/booking/BookAppointment.types.ts
+++ b/src/pages/user/appointment/booking/BookAppointment.types.ts
@@ -22,6 +22,7 @@ export interface IBookingFilters {
 
 export interface IBookingFormValues {
 	address?: ISlotAddress;
+	consentAccepted: boolean;
 	countryCode: string;
 	email: string;
 	firstName: string;

--- a/src/pages/user/appointment/booking/components/PublicBookingForm.styles.tsx
+++ b/src/pages/user/appointment/booking/components/PublicBookingForm.styles.tsx
@@ -61,3 +61,22 @@ export const NotifyCheckboxWrapper = styled(Box)`
 	flex-direction: column;
 	padding-left: ${spacing.small};
 `;
+
+export const ConsentBox = styled(Box)`
+	background: ${palette.background.paper};
+	border: 1px solid ${palette.gray['02']};
+	border-radius: ${spacing.small};
+	padding: ${spacing.small};
+`;
+
+export const ConsentLabel = styled('span')`
+	color: ${palette.text.primary};
+	font-size: 0.875rem;
+	line-height: 1.5;
+
+	a {
+		color: ${palette.brand.purple};
+		font-weight: 600;
+		text-decoration: underline;
+	}
+`;

--- a/src/pages/user/appointment/booking/components/PublicBookingForm.tsx
+++ b/src/pages/user/appointment/booking/components/PublicBookingForm.tsx
@@ -1,15 +1,19 @@
 import { Controller, FormProvider } from 'react-hook-form';
-import { useTranslation } from 'react-i18next';
-import { Checkbox, FormControlLabel, Radio } from '@mui/material';
+import { Trans, useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { Checkbox, FormControlLabel, FormHelperText, Radio } from '@mui/material';
 import { Divider } from '@psycron/components/divider/Divider';
 import { AddressForm } from '@psycron/components/form/components/address/AddressForm';
 import { ContactsForm } from '@psycron/components/form/components/contacts/ContactsForm';
 import { NameForm } from '@psycron/components/form/components/name/NameForm';
 import { Text } from '@psycron/components/text/Text';
+import { externalUrls } from '@psycron/pages/urls';
 
 import type { IBookingFormValues } from '../BookAppointment.types';
 
 import {
+	ConsentBox,
+	ConsentLabel,
 	FormSection,
 	NotifyBox,
 	NotifyCheckboxWrapper,
@@ -29,9 +33,14 @@ const RECURRENCE_OPTIONS = [
 export const PublicBookingForm = ({
 	letPatientChooseAddress,
 	methods,
+	therapistName,
 }: IPublicBookingFormProps) => {
-	const { t } = useTranslation();
-	const { control, watch } = methods;
+	const { i18n, t } = useTranslation();
+	const {
+		control,
+		formState: { errors },
+		watch,
+	} = methods;
 	const recurrence = watch('recurrencePattern');
 
 	return (
@@ -146,6 +155,42 @@ export const PublicBookingForm = ({
 						{t('booking.notifications.fallback-note')}
 					</Text>
 				</NotifyBox>
+
+				<ConsentBox>
+					<Controller
+						control={control}
+						name='consentAccepted'
+						rules={{ validate: (value) => value || t('consent.required') }}
+						render={({ field }) => (
+							<FormControlLabel
+								control={
+									<Checkbox
+										checked={Boolean(field.value)}
+										onChange={(e) => field.onChange(e.target.checked)}
+									/>
+								}
+								label={
+									<ConsentLabel>
+										<Trans
+											i18nKey='consent.dataProcessing'
+											values={{ therapistName }}
+											components={{
+												privacyLink: (
+													<Link to={externalUrls(i18n.language).PRIVACY} />
+												),
+											}}
+										/>
+									</ConsentLabel>
+								}
+							/>
+						)}
+					/>
+					{errors.consentAccepted?.message ? (
+						<FormHelperText error>
+							{String(errors.consentAccepted.message)}
+						</FormHelperText>
+					) : null}
+				</ConsentBox>
 			</FormSection>
 		</FormProvider>
 	);

--- a/src/pages/user/appointment/booking/components/PublicBookingForm.types.ts
+++ b/src/pages/user/appointment/booking/components/PublicBookingForm.types.ts
@@ -5,4 +5,5 @@ import type { IBookingFormValues } from '../BookAppointment.types';
 export interface IPublicBookingFormProps {
 	letPatientChooseAddress: boolean;
 	methods: UseFormReturn<IBookingFormValues>;
+	therapistName: string;
 }

--- a/src/pages/user/appointment/list/patient/AppointmentsList.tsx
+++ b/src/pages/user/appointment/list/patient/AppointmentsList.tsx
@@ -47,6 +47,7 @@ import { PatientDrawerShell } from '../../shared/PatientDrawerShell';
 import { PublicSchedulingCalendar } from '../../shared/PublicSchedulingCalendar';
 import type { PublicSchedulingViewMode } from '../../shared/PublicSchedulingCalendar.types';
 
+import { PatientPrivacySection } from './components/privacy/PatientPrivacySection';
 import {
 	ActionsRow,
 	CancelReasonGrid,
@@ -622,6 +623,8 @@ export const AppointmentsList = () => {
 					viewMode={calendarViewMode}
 					weekLabel={t('booking.calendar.view-week')}
 				/>
+
+				{patientId ? <PatientPrivacySection patientId={patientId} /> : null}
 
 				{selectedAppointment ? (
 					<PatientDrawerShell

--- a/src/pages/user/appointment/list/patient/components/privacy/PatientPrivacySection.styles.tsx
+++ b/src/pages/user/appointment/list/patient/components/privacy/PatientPrivacySection.styles.tsx
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+import { Box } from '@mui/material';
+import { hexToRgba, palette } from '@psycron/theme/palette/palette.theme';
+import { shadowSmall } from '@psycron/theme/shadow/shadow.theme';
+import { spacing } from '@psycron/theme/spacing/spacing.theme';
+
+export const PrivacySectionRoot = styled(Box)`
+	background: ${palette.background.paper};
+	border: 1px solid ${palette.gray['02']};
+	border-radius: ${spacing.small};
+	box-shadow: ${shadowSmall};
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.small};
+	padding: ${spacing.medium};
+`;
+
+export const ConsentList = styled(Box)`
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.extraSmall};
+`;
+
+export const ConsentRow = styled(Box)`
+	align-items: center;
+	background: ${hexToRgba(palette.brand.purple, 0.05)};
+	border: 1px solid ${hexToRgba(palette.brand.purple, 0.14)};
+	border-radius: ${spacing.small};
+	display: flex;
+	gap: ${spacing.small};
+	justify-content: space-between;
+	padding: ${spacing.small};
+`;
+
+export const ConsentText = styled(Box)`
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.space};
+`;
+
+export const DeletionActions = styled(Box)`
+	display: flex;
+	gap: ${spacing.small};
+	justify-content: flex-end;
+`;

--- a/src/pages/user/appointment/list/patient/components/privacy/PatientPrivacySection.tsx
+++ b/src/pages/user/appointment/list/patient/components/privacy/PatientPrivacySection.tsx
@@ -1,0 +1,130 @@
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { capture } from '@psycron/analytics/posthog/events';
+import { PostHogEvent } from '@psycron/analytics/posthog/types';
+import {
+	getConsentRecords,
+	requestDataDeletion,
+	revokeConsent,
+} from '@psycron/api/patient/consent';
+import type { ConsentPurpose } from '@psycron/api/patient/consent.types';
+import { Button } from '@psycron/components/button/Button';
+import { Modal } from '@psycron/components/modal/Modal';
+import { Text } from '@psycron/components/text/Text';
+import { useAlert } from '@psycron/context/alert/AlertContext';
+import { formatLocalizedDate } from '@psycron/utils/date/date.utils';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+	ConsentList,
+	ConsentRow,
+	ConsentText,
+	DeletionActions,
+	PrivacySectionRoot,
+} from './PatientPrivacySection.styles';
+
+interface PatientPrivacySectionProps {
+	patientId: string;
+}
+
+export const PatientPrivacySection = ({
+	patientId,
+}: PatientPrivacySectionProps) => {
+	const { i18n, t } = useTranslation();
+	const { showAlert } = useAlert();
+	const queryClient = useQueryClient();
+	const [deletionModalOpen, setDeletionModalOpen] = useState(false);
+
+	const queryKey = ['patientConsent', patientId] as const;
+	const { data } = useQuery({
+		enabled: Boolean(patientId),
+		queryFn: () => getConsentRecords(patientId),
+		queryKey,
+	});
+
+	const activeConsents = useMemo(
+		() => (data?.consent ?? []).filter((record) => !record.revokedAt),
+		[data?.consent]
+	);
+
+	const revokeMutation = useMutation({
+		mutationFn: (purpose: ConsentPurpose) => revokeConsent(patientId, purpose),
+		onSuccess: (_data, purpose) => {
+			capture(PostHogEvent.ConsentRevoked, { purpose });
+			void queryClient.invalidateQueries({ queryKey });
+		},
+	});
+
+	const deletionMutation = useMutation({
+		mutationFn: () => requestDataDeletion(patientId),
+		onSuccess: () => {
+			capture(PostHogEvent.DeletionRequested);
+			setDeletionModalOpen(false);
+			showAlert({
+				message: t('consent.deletionRequested'),
+				severity: 'success',
+			});
+		},
+	});
+
+	return (
+		<PrivacySectionRoot>
+			<Text variant='h6'>{t('consent.yourPrivacy')}</Text>
+			<Text color='text.secondary' variant='body2'>
+				{t('consent.activeConsents')}
+			</Text>
+			<ConsentList>
+				{activeConsents.length ? (
+					activeConsents.map((record) => (
+						<ConsentRow key={`${record.purpose}-${record.grantedAt}`}>
+							<ConsentText>
+								<Text fontWeight={600} variant='body2'>
+									{t(`consent.purposes.${record.purpose}`)}
+								</Text>
+								<Text color='text.secondary' variant='caption'>
+									{formatLocalizedDate(
+										record.grantedAt,
+										t('patients.list.not-available'),
+										i18n.language
+									)}
+								</Text>
+							</ConsentText>
+							<Button
+								disabled={revokeMutation.isPending}
+								onClick={() => revokeMutation.mutate(record.purpose)}
+								severity='error'
+								variant='outlined'
+							>
+								{t('consent.revokeConsent')}
+							</Button>
+						</ConsentRow>
+					))
+				) : (
+					<Text color='text.secondary' variant='body2'>
+						{t('consent.noActiveConsents')}
+					</Text>
+				)}
+			</ConsentList>
+			<DeletionActions>
+				<Button onClick={() => setDeletionModalOpen(true)} severity='error'>
+					{t('consent.requestDeletion')}
+				</Button>
+			</DeletionActions>
+			<Modal
+				cardActionsProps={{
+					actionName: t('consent.deletionModal.confirm'),
+					disabled: deletionMutation.isPending,
+					hasSecondAction: true,
+					onClick: () => deletionMutation.mutate(),
+					secondAction: () => setDeletionModalOpen(false),
+					secondActionName: t('common.cancel'),
+				}}
+				onClose={() => setDeletionModalOpen(false)}
+				openModal={deletionModalOpen}
+				title={t('consent.deletionModal.title')}
+			>
+				<Text variant='body2'>{t('consent.deletionModal.body')}</Text>
+			</Modal>
+		</PrivacySectionRoot>
+	);
+};


### PR DESCRIPTION
## Summary
- Add frontend consent API/types and PostHog event typings with no PHI payloads.
- Add explicit data-processing consent checkbox to public booking and therapist-side booking.
- Add patient self-management privacy controls and therapist-facing consent status section.
- Add EN/PT consent translations.

## Tracking
- Jira: https://psycron.atlassian.net/browse/PR-333
- Version Tracking: https://psycron.atlassian.net/wiki/spaces/Product/pages/132120577/Version+Tracking+Release+History
- Backend pair: https://github.com/psycron-app/psycron-be/pull/87

## Validation
- npm run lint
- npm run build

Note: local Node is 20.11.1 and Vite warns that 20.19+ is preferred, but the build completed successfully.