### PR TITLE
fix(availability): PR-289 fix Google Calendar OAuth consent flow

### DIFF
--- a/src/pages/availability/jupiter-conversation/useJupiterFlow.ts
+++ b/src/pages/availability/jupiter-conversation/useJupiterFlow.ts
@@ -529,22 +529,30 @@ export const useJupiterFlow = ({
 				setIsImporting(true);
 				addBotMessage(t('jupiter.google-calendar.importing'));
 
-				const schedule = await importGoogleCalendarSchedule();
+				try {
+					const schedule = await importGoogleCalendarSchedule();
 
-				setIsImporting(false);
+					setIsImporting(false);
 
-				if (schedule && schedule.workingDays.length > 0) {
-					const timeRange = `${schedule.startTime} - ${schedule.endTime}`;
-					setAnswers((prev) => ({
-						...prev,
-						workingDays: schedule.workingDays,
-						timeRange,
-					}));
-					setTimeout(() => {
-						addBotMessage(t('jupiter.google-calendar.imported'), false);
-						setStep('session-duration');
-					}, 300);
-				} else {
+					if (schedule && schedule.workingDays.length > 0) {
+						const timeRange = `${schedule.startTime} - ${schedule.endTime}`;
+						setAnswers((prev) => ({
+							...prev,
+							workingDays: schedule.workingDays,
+							timeRange,
+						}));
+						setTimeout(() => {
+							addBotMessage(t('jupiter.google-calendar.imported'), false);
+							setStep('session-duration');
+						}, 300);
+					} else {
+						setTimeout(() => {
+							addBotMessage(t('jupiter.google-calendar.import-failed'), false);
+							setStep('working-days');
+						}, 300);
+					}
+				} catch {
+					setIsImporting(false);
 					setTimeout(() => {
 						addBotMessage(t('jupiter.google-calendar.import-failed'), false);
 						setStep('working-days');


### PR DESCRIPTION
## Summary

- Wraps `importGoogleCalendarSchedule()` in `handleGooglePostConnect` with try/catch so API failures (400 not connected, 404 no recurring schedule, network errors) fall back gracefully to the manual working-days step instead of crashing the component
- Previously any failure from this call propagated uncaught and surfaced raw errors to users

## Test plan

- [ ] Go through Jupiter flow → choose Google Calendar → complete OAuth → choose "Use my existing schedule" → confirm working days pre-populate or gracefully fall back to manual entry
- [ ] Test failure path: remove `googleCalendar` tokens from DB, retry import → should fall back to working-days step with no crash or visible error
- [ ] Confirm lint passes: `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)