### PR TITLE
feat(conflicts,availability): day-block panel, block-day modal, slot available sectioned redesign

### DIFF
--- a/src/api/user/conflicts/index.types.ts
+++ b/src/api/user/conflicts/index.types.ts
@@ -1,4 +1,4 @@
-export type ConflictType = 'SLOT_REPLICATION' | 'PATIENT_DUPLICATE';
+export type ConflictType = 'SLOT_REPLICATION' | 'PATIENT_DUPLICATE' | 'DAY_BLOCK';
 export type ConflictStatus = 'OPEN' | 'RESOLVED' | 'DISMISSED';
 export type PatientMergeFieldSource = 'primary' | 'secondary';
 export type PatientMergeField =
@@ -53,6 +53,16 @@ export interface IPatientDuplicateConflictMetadata {
 	match: 'multiple' | 'single';
 }
 
+export interface IBookingConflictMetadata {
+	appointmentDate: string;
+	availabilityId: string;
+	dayId: string;
+	endTime: string;
+	patientId: string;
+	slotId: string;
+	startTime: string;
+}
+
 export interface IConflictResolutionDetails {
 	fieldSelections?: PatientMergeFieldSelections;
 	fieldSnapshots?: IPatientMergeFieldSnapshot[];
@@ -65,7 +75,7 @@ export interface IConflict {
 	actionTaken?: string | null;
 	createdAt: string;
 	description: string;
-	metadata: ISlotReplicationConflictMetadata | IPatientDuplicateConflictMetadata;
+	metadata: ISlotReplicationConflictMetadata | IPatientDuplicateConflictMetadata | IBookingConflictMetadata;
 	resolutionDetails?: IConflictResolutionDetails | null;
 	resolvedAt?: string | null;
 	status: ConflictStatus;

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -1784,7 +1784,13 @@
         "unblock-confirm-body": "This slot will become available for booking again.",
         "unblock-error": "Failed to unblock slot. Please try again.",
         "unblock-slot": "Unblock slot",
-        "unblock-success": "Slot unblocked successfully."
+        "unblock-success": "Slot unblocked successfully.",
+        "section": {
+          "booking-link": "Booking link",
+          "contact-delivery": "Contact & Delivery",
+          "patient": "Patient",
+          "session": "Session"
+        }
       },
       "buffer-label": "Buffer",
       "legend-available": "Available",
@@ -1850,6 +1856,14 @@
         "unblock-all-confirm": "Unblock all {{count}} blocked slots on {{day}}? These slots will become available for booking.",
         "unblock-all-error": "Failed to unblock slots. Please try again.",
         "unblock-all-success": "All blocked slots unblocked successfully."
+      },
+      "block-conflict-modal": {
+        "confirm": "Block day",
+        "next": "Review & confirm",
+        "step1-hint": "{{count}} booked appointment(s) on {{day}} will become conflicts. You can cancel or reschedule them from the Action Center.",
+        "step1-title": "Booked appointments need attention",
+        "step2-summary": "Blocking this day will block {{available}} available slot(s) and create {{conflicts}} conflict(s) for booked appointments.",
+        "step2-title": "Confirm day block"
       }
     },
     "gate": {
@@ -1955,6 +1969,7 @@
       "dismissed": "Dismissed"
     },
     "types": {
+      "day-block": "Day block",
       "patient-duplicate": "Patient duplicate",
       "slot-replication": "Slot replication"
     },
@@ -1986,6 +2001,8 @@
       "preferred-contact": "Preferred contact",
       "additional-candidates": "{{count}} more possible match is still queued for review.",
       "additional-candidates_other": "{{count}} more possible matches are still queued for review.",
+      "appointment-date": "Appointment date",
+      "appointment-time": "Appointment time",
       "not-provided": "Not provided"
     },
     "merge-review": {
@@ -2027,16 +2044,19 @@
       }
     },
     "actions": {
-      "recommended-title": "Recommended resolution",
-      "recommended-hint": "Merge both records and keep one patient as the source of truth.",
-      "alternatives-title": "Other options",
       "alternatives-hint": "Use one record only if you do not want to merge them now.",
-      "merge": "Merge patients",
+      "alternatives-title": "Other options",
+      "cancel-appointment": "Cancel appointment",
+      "day-block-hint": "This appointment is affected by a day block. Cancel it to notify the patient and resolve the conflict.",
+      "day-block-title": "Resolve this booking conflict",
+      "dismiss": "Dismiss",
+      "error": "We couldn't update this conflict. Please try again.",
       "keep-existing": "Keep existing patient",
       "keep-new": "Keep new patient",
-      "dismiss": "Dismiss",
       "mark-resolved": "Mark resolved",
-      "error": "We couldn't update this conflict. Please try again."
+      "merge": "Merge patients",
+      "recommended-hint": "Merge both records and keep one patient as the source of truth.",
+      "recommended-title": "Recommended resolution"
     }
   },
   "action-center": {

--- a/src/assets/locales/pt/translation.json
+++ b/src/assets/locales/pt/translation.json
@@ -1784,7 +1784,13 @@
         "unblock-confirm-body": "Este horário ficará disponível para agendamentos novamente.",
         "unblock-error": "Falha ao desbloquear o horário. Tente novamente.",
         "unblock-slot": "Desbloquear horário",
-        "unblock-success": "Horário desbloqueado com sucesso."
+        "unblock-success": "Horário desbloqueado com sucesso.",
+        "section": {
+          "booking-link": "Link de agendamento",
+          "contact-delivery": "Contato e modalidade",
+          "patient": "Paciente",
+          "session": "Sessão"
+        }
       },
       "buffer-label": "Buffer",
       "legend-available": "Disponível",
@@ -1850,6 +1856,14 @@
         "unblock-all-confirm": "Desbloquear todos os {{count}} horários bloqueados em {{day}}? Esses horários ficarão disponíveis para agendamento.",
         "unblock-all-error": "Falha ao desbloquear os horários. Tente novamente.",
         "unblock-all-success": "Todos os horários bloqueados foram desbloqueados."
+      },
+      "block-conflict-modal": {
+        "confirm": "Bloquear dia",
+        "next": "Revisar e confirmar",
+        "step1-hint": "{{count}} agendamento(s) em {{day}} se tornarão conflitos. Você pode cancelá-los ou reagendá-los pela Central de Ações.",
+        "step1-title": "Agendamentos precisam de atenção",
+        "step2-summary": "Bloquear este dia irá bloquear {{available}} horário(s) disponível(is) e criar {{conflicts}} conflito(s) para agendamentos existentes.",
+        "step2-title": "Confirmar bloqueio do dia"
       }
     },
     "gate": {
@@ -1955,6 +1969,7 @@
       "dismissed": "Dispensado"
     },
     "types": {
+      "day-block": "Bloqueio de dia",
       "patient-duplicate": "Paciente duplicado",
       "slot-replication": "Replicação de horário"
     },
@@ -1986,6 +2001,8 @@
       "preferred-contact": "Contato preferido",
       "additional-candidates": "{{count}} outro possível registro ainda está na fila para revisão.",
       "additional-candidates_other": "{{count}} outros possíveis registros ainda estão na fila para revisão.",
+      "appointment-date": "Data do atendimento",
+      "appointment-time": "Horário do atendimento",
       "not-provided": "Não informado"
     },
     "merge-review": {
@@ -2027,16 +2044,19 @@
       }
     },
     "actions": {
-      "recommended-title": "Resolução recomendada",
-      "recommended-hint": "Una ambos os registros e mantenha um único paciente como fonte principal.",
-      "alternatives-title": "Outras opções",
       "alternatives-hint": "Use apenas um registro se não quiser unir os dois agora.",
-      "merge": "Unir pacientes",
+      "alternatives-title": "Outras opções",
+      "cancel-appointment": "Cancelar atendimento",
+      "day-block-hint": "Este atendimento foi afetado por um bloqueio de dia. Cancele-o para notificar o paciente e resolver o conflito.",
+      "day-block-title": "Resolver conflito de agendamento",
+      "dismiss": "Dispensar",
+      "error": "Não foi possível atualizar este conflito. Tente novamente.",
       "keep-existing": "Manter paciente existente",
       "keep-new": "Manter novo paciente",
-      "dismiss": "Dispensar",
       "mark-resolved": "Marcar como resolvido",
-      "error": "Não foi possível atualizar este conflito. Tente novamente."
+      "merge": "Unir pacientes",
+      "recommended-hint": "Una ambos os registros e mantenha um único paciente como fonte principal.",
+      "recommended-title": "Resolução recomendada"
     }
   },
   "action-center": {

--- a/src/pages/action-center/conflicts/ConflictsPage.utils.ts
+++ b/src/pages/action-center/conflicts/ConflictsPage.utils.ts
@@ -8,10 +8,11 @@ import { getPatientFullName } from '@psycron/utils/patient/patient.utils';
 export const getConflictTypeLabel = (
 	type: ConflictType,
 	t: (key: string) => string
-) =>
-	type === 'PATIENT_DUPLICATE'
-		? t('conflicts.types.patient-duplicate')
-		: t('conflicts.types.slot-replication');
+) => {
+	if (type === 'PATIENT_DUPLICATE') return t('conflicts.types.patient-duplicate');
+	if (type === 'DAY_BLOCK') return t('conflicts.types.day-block');
+	return t('conflicts.types.slot-replication');
+};
 
 export const getConflictStatusLabel = (
 	status: 'OPEN' | 'RESOLVED' | 'DISMISSED',

--- a/src/pages/action-center/conflicts/components/ConflictsFiltersDrawer.tsx
+++ b/src/pages/action-center/conflicts/components/ConflictsFiltersDrawer.tsx
@@ -76,6 +76,13 @@ export const ConflictsFiltersDrawer = ({
 					>
 						{t('conflicts.types.slot-replication')}
 					</QueueFilterChip>
+					<QueueFilterChip
+						isActive={typeFilter === 'DAY_BLOCK'}
+						onClick={() => onSetTypeFilter('DAY_BLOCK')}
+						type='button'
+					>
+						{t('conflicts.types.day-block')}
+					</QueueFilterChip>
 				</QueueFiltersRow>
 			</QueueFiltersSection>
 		</QueueFiltersDrawer>

--- a/src/pages/action-center/conflicts/components/conflict-detail/ConflictDetail.tsx
+++ b/src/pages/action-center/conflicts/components/conflict-detail/ConflictDetail.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type {
+	IBookingConflictMetadata,
 	IPatientDuplicateConflictMetadata,
 	ISlotReplicationConflictMetadata,
 } from '@psycron/api/user/conflicts/index.types';
@@ -35,6 +36,7 @@ import {
 } from './styles/ConflictDetail.styles';
 import type { ConflictDetailProps } from './types/ConflictDetail.types';
 import { ConflictResolutionSummary } from './ConflictResolutionSummary';
+import { DayBlockConflictDetail } from './DayBlockConflictDetail';
 import { PatientDuplicateConflictDetail } from './PatientDuplicateConflictDetail';
 import { PatientDuplicateMergeReview } from './PatientDuplicateMergeReview';
 import { SlotReplicationConflictDetail } from './SlotReplicationConflictDetail';
@@ -63,6 +65,11 @@ export const ConflictDetail = ({
 		conflict.type === 'SLOT_REPLICATION'
 			? (conflict.metadata as ISlotReplicationConflictMetadata)
 			: null;
+	const dayBlockMetadata =
+		conflict.type === 'DAY_BLOCK'
+			? (conflict.metadata as IBookingConflictMetadata)
+			: null;
+
 	const metadata =
 		conflict.type === 'PATIENT_DUPLICATE' && duplicateMetadata ? (
 			<PatientDuplicateConflictDetail
@@ -70,6 +77,8 @@ export const ConflictDetail = ({
 				shouldFetchCandidates={conflict.status === 'OPEN' && !isUpdating}
 				t={t}
 			/>
+		) : conflict.type === 'DAY_BLOCK' && dayBlockMetadata ? (
+			<DayBlockConflictDetail metadata={dayBlockMetadata} t={t} />
 		) : (
 			<SlotReplicationConflictDetail metadata={slotReplicationMetadata!} t={t} />
 		);
@@ -80,6 +89,48 @@ export const ConflictDetail = ({
 	const actions =
 		conflict.status !== 'OPEN' ? (
 			<ConflictResolutionSummary conflict={conflict} />
+		) : conflict.type === 'DAY_BLOCK' ? (
+			<ConflictActions>
+				<ConflictActionSection>
+					<ConflictActionHeading>
+						{t('conflicts.actions.day-block-title')}
+					</ConflictActionHeading>
+					<ConflictActionHint>
+						{t('conflicts.actions.day-block-hint')}
+					</ConflictActionHint>
+					<Button
+						fullWidth
+						severity='error'
+						variant='contained'
+						disabled={isUpdating}
+						onClick={() =>
+							onUpdateConflict({
+								actionTaken: 'CANCEL_APPOINTMENT',
+								conflictId: conflict._id,
+								status: 'RESOLVED',
+							})
+						}
+					>
+						{t('conflicts.actions.cancel-appointment')}
+					</Button>
+				</ConflictActionSection>
+				<ConflictActionFooter>
+					<Button
+						small
+						tertiary
+						disabled={isUpdating}
+						onClick={() =>
+							onUpdateConflict({
+								actionTaken: 'DISMISSED',
+								conflictId: conflict._id,
+								status: 'DISMISSED',
+							})
+						}
+					>
+						{t('conflicts.actions.dismiss')}
+					</Button>
+				</ConflictActionFooter>
+			</ConflictActions>
 		) : conflict.type === 'PATIENT_DUPLICATE' ? (
 			<ConflictActions>
 				<ConflictActionSection>

--- a/src/pages/action-center/conflicts/components/conflict-detail/DayBlockConflictDetail.tsx
+++ b/src/pages/action-center/conflicts/components/conflict-detail/DayBlockConflictDetail.tsx
@@ -1,0 +1,31 @@
+import { format } from 'date-fns';
+
+import {
+	ConflictMetaGroup,
+	ConflictMetaLabel,
+	ConflictMetaValue,
+} from './styles/ConflictDetail.styles';
+import type { DayBlockConflictDetailProps } from './types/ConflictDetail.types';
+
+export const DayBlockConflictDetail = ({
+	metadata,
+	t,
+}: DayBlockConflictDetailProps) => (
+	<>
+		<ConflictMetaGroup>
+			<ConflictMetaLabel>{t('conflicts.detail.appointment-date')}</ConflictMetaLabel>
+			<ConflictMetaValue>
+				{metadata.appointmentDate
+					? format(new Date(metadata.appointmentDate), 'PPP')
+					: t('conflicts.detail.not-provided')}
+			</ConflictMetaValue>
+		</ConflictMetaGroup>
+		<ConflictMetaGroup>
+			<ConflictMetaLabel>{t('conflicts.detail.appointment-time')}</ConflictMetaLabel>
+			<ConflictMetaValue>
+				{metadata.startTime}
+				{metadata.endTime ? ` – ${metadata.endTime}` : ''}
+			</ConflictMetaValue>
+		</ConflictMetaGroup>
+	</>
+);

--- a/src/pages/action-center/conflicts/components/conflict-detail/types/ConflictDetail.types.ts
+++ b/src/pages/action-center/conflicts/components/conflict-detail/types/ConflictDetail.types.ts
@@ -1,4 +1,5 @@
 import type {
+	IBookingConflictMetadata,
 	IConflict,
 	IPatientDuplicateConflictMetadata,
 	ISlotReplicationConflictMetadata,
@@ -35,5 +36,10 @@ export interface ConflictResolutionSummaryProps {
 
 export interface SlotReplicationConflictDetailProps {
 	metadata: ISlotReplicationConflictMetadata;
+	t: (key: string) => string;
+}
+
+export interface DayBlockConflictDetailProps {
+	metadata: IBookingConflictMetadata;
 	t: (key: string) => string;
 }

--- a/src/pages/availability/week/day-header-popover/BlockDayConflictModal.styles.tsx
+++ b/src/pages/availability/week/day-header-popover/BlockDayConflictModal.styles.tsx
@@ -1,0 +1,36 @@
+import styled from '@emotion/styled';
+import { Box } from '@mui/material';
+import { palette } from '@psycron/theme/palette/palette.theme';
+import { spacing } from '@psycron/theme/spacing/spacing.theme';
+
+export const ConflictSummaryNote = styled(Box)`
+	padding: ${spacing.small} ${spacing.medium};
+	background: ${palette.warning.light};
+	border-radius: ${spacing.xs};
+	color: ${palette.warning.dark};
+	font-size: 0.875rem;
+	margin-bottom: ${spacing.small};
+`;
+
+export const BookedSlotList = styled(Box)`
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.xs};
+	margin-top: ${spacing.small};
+`;
+
+export const BookedSlotItem = styled(Box)`
+	display: flex;
+	align-items: center;
+	gap: ${spacing.small};
+	padding: ${spacing.xs} ${spacing.small};
+	border: 1px solid ${palette.gray['02']};
+	border-radius: ${spacing.xs};
+	font-size: 0.875rem;
+`;
+
+export const BookedSlotTime = styled('span')`
+	font-weight: 600;
+	color: ${palette.brand.purple};
+	min-width: 60px;
+`;

--- a/src/pages/availability/week/day-header-popover/BlockDayConflictModal.tsx
+++ b/src/pages/availability/week/day-header-popover/BlockDayConflictModal.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Modal } from '@psycron/components/modal/Modal';
+
+import type { IWeekSlot } from '../AvailabilityWeekPage.types';
+
+import {
+	BookedSlotItem,
+	BookedSlotList,
+	BookedSlotTime,
+	ConflictSummaryNote,
+} from './BlockDayConflictModal.styles';
+
+interface BlockDayConflictModalProps {
+	availableCount: number;
+	bookedSlots: IWeekSlot[];
+	dayLabel: string;
+	isLoading: boolean;
+	onClose: () => void;
+	onConfirm: () => void;
+	open: boolean;
+}
+
+export const BlockDayConflictModal = ({
+	availableCount,
+	bookedSlots,
+	dayLabel,
+	isLoading,
+	onClose,
+	onConfirm,
+	open,
+}: BlockDayConflictModalProps) => {
+	const { t } = useTranslation();
+	const [step, setStep] = useState<1 | 2>(1);
+
+	const handleClose = () => {
+		setStep(1);
+		onClose();
+	};
+
+	const handleConfirm = () => {
+		if (step === 1) {
+			setStep(2);
+			return;
+		}
+		onConfirm();
+	};
+
+	const title = step === 1
+		? t('availability.week.block-conflict-modal.step1-title')
+		: t('availability.week.block-conflict-modal.step2-title');
+
+	const actionLabel = step === 1
+		? t('availability.week.block-conflict-modal.next')
+		: t('availability.week.block-conflict-modal.confirm');
+
+	return (
+		<Modal
+			openModal={open}
+			title={title}
+			onClose={handleClose}
+			cardActionsProps={{
+				actionName: actionLabel,
+				hasSecondAction: true,
+				loading: isLoading,
+				onClick: handleConfirm,
+				secondAction: handleClose,
+				secondActionName: t('availability.week.drawer.cancel-back'),
+			}}
+		>
+			{step === 1 ? (
+				<>
+					<ConflictSummaryNote>
+						{t('availability.week.block-conflict-modal.step1-hint', {
+							count: bookedSlots.length,
+							day: dayLabel,
+						})}
+					</ConflictSummaryNote>
+					<BookedSlotList>
+						{bookedSlots.map((slot) => (
+							<BookedSlotItem key={slot.id}>
+								<BookedSlotTime>{slot.startTime}</BookedSlotTime>
+								{slot.patientName ?? t('conflicts.detail.not-provided')}
+							</BookedSlotItem>
+						))}
+					</BookedSlotList>
+				</>
+			) : (
+				<ConflictSummaryNote>
+					{t('availability.week.block-conflict-modal.step2-summary', {
+						available: availableCount,
+						conflicts: bookedSlots.length,
+					})}
+				</ConflictSummaryNote>
+			)}
+		</Modal>
+	);
+};

--- a/src/pages/availability/week/day-header-popover/DayHeaderPopover.tsx
+++ b/src/pages/availability/week/day-header-popover/DayHeaderPopover.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@psycron/components/button/Button';
 import { Modal } from '@psycron/components/modal/Modal';
 
+import { BlockDayConflictModal } from './BlockDayConflictModal';
 import {
 	BookedWarning,
 	PopoverActions,
@@ -29,8 +30,9 @@ export const DayHeaderPopover = ({
 	const [confirmAction, setConfirmAction] = useState<
 		'block-all' | 'unblock-all' | null
 	>(null);
+	const [isConflictModalOpen, setIsConflictModalOpen] = useState(false);
 
-		const summary: IDaySummary = useMemo(() => {
+	const summary: IDaySummary = useMemo(() => {
 			let available = 0;
 			let blocked = 0;
 			let booked = 0;
@@ -56,8 +58,25 @@ export const DayHeaderPopover = ({
 		setConfirmAction(null);
 	};
 
+	const bookedSlots = useMemo(
+		() => slots.filter((s) => s.status === 'booked-jupiter' || s.status === 'booked-google'),
+		[slots]
+	);
+
 	return (
 		<>
+			<BlockDayConflictModal
+				availableCount={summary.available}
+				bookedSlots={bookedSlots}
+				dayLabel={dayLabel}
+				isLoading={isBlockDayPending}
+				onClose={() => setIsConflictModalOpen(false)}
+				onConfirm={() => {
+					setIsConflictModalOpen(false);
+					onBlockAll();
+				}}
+				open={isConflictModalOpen}
+			/>
 			<Modal
 				openModal={open}
 				title={dayLabel}
@@ -95,7 +114,13 @@ export const DayHeaderPopover = ({
 								<Button
 									disabled={isBlockDayPending || isPastDay}
 									loading={isBlockDayPending}
-									onClick={() => setConfirmAction('block-all')}
+									onClick={() => {
+										if (summary.booked > 0) {
+											setIsConflictModalOpen(true);
+										} else {
+											setConfirmAction('block-all');
+										}
+									}}
 									severity='error'
 									small
 							>

--- a/src/pages/availability/week/drawer/views/slot-available-body/SlotAvailableBody.styles.tsx
+++ b/src/pages/availability/week/drawer/views/slot-available-body/SlotAvailableBody.styles.tsx
@@ -4,6 +4,31 @@ import { Text } from '@psycron/components/text/Text';
 import { hexToRgba, palette } from '@psycron/theme/palette/palette.theme';
 import { spacing } from '@psycron/theme/spacing/spacing.theme';
 
+export const SectionWrapper = styled(Box)`
+	display: flex;
+	flex-direction: column;
+	gap: ${spacing.small};
+`;
+
+export const SectionHeader = styled(Box)`
+	display: flex;
+	align-items: center;
+	gap: ${spacing.xs};
+
+	& svg {
+		width: 14px;
+		height: 14px;
+	}
+`;
+
+export const SectionLabel = styled(Text)`
+	font-size: 12px;
+	font-weight: 600;
+	color: ${palette.gray['05']};
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+`;
+
 export const BookingLinkSection = styled(Box)`
 	display: flex;
 	flex-direction: column;

--- a/src/pages/availability/week/drawer/views/slot-available-body/SlotAvailableBody.tsx
+++ b/src/pages/availability/week/drawer/views/slot-available-body/SlotAvailableBody.tsx
@@ -15,6 +15,12 @@ import { Divider } from '@psycron/components/divider/Divider';
 import { ContactsForm } from '@psycron/components/form/components/contacts/ContactsForm';
 import { PreferredContactForm } from '@psycron/components/form/components/preferred-contact/PreferredContactForm';
 import { TimezoneSelect } from '@psycron/components/form/components/timezone/TimezoneSelect';
+import {
+	Account,
+	Appointment,
+	Phone,
+	Send,
+} from '@psycron/components/icons';
 import { externalUrls } from '@psycron/pages/urls';
 
 import { FormWrapper } from '../../AvailabilityWeekDrawer.styles';
@@ -24,6 +30,7 @@ import { SlotRecurrenceSection } from '../slot-recurrence-section/SlotRecurrence
 import { SlotSessionDeliverySection } from '../slot-session-delivery/SlotSessionDeliverySection';
 import { SlotSessionSection } from '../slot-session-section/SlotSessionSection';
 
+import { AvailableSection } from './available-section/AvailableSection';
 import {
 	BookingLinkHeader,
 	BookingLinkHint,
@@ -96,86 +103,115 @@ export const SlotAvailableBody = ({
 		<FormProvider {...methods}>
 			<Box component='form'>
 				<FormWrapper>
-					<SlotSessionSection {...sessionDetails} />
-					{reopenedCancellationNote && (
-						<ReopenedNote>
-							<ReopenedNoteLabel>
-								{t('availability.week.drawer.reopened-note-label')}
-							</ReopenedNoteLabel>
-							<ReopenedNoteText>{reopenedCancellationNote}</ReopenedNoteText>
-						</ReopenedNote>
-					)}
-					<Divider />
-					<BookingLinkSection>
-						<BookingLinkHeader>
-							<BookingLinkLabel>
-								{t('availability.week.drawer.booking-link-label')}
-							</BookingLinkLabel>
-							<ShareButton
-								absoluteUrl={bookingLink}
-								preferNativeShare
-								textKey={shareText}
-								titleKey={shareTitle}
-							/>
-						</BookingLinkHeader>
-						<BookingLinkValueRow>
-							<BookingLinkValue>{bookingLink}</BookingLinkValue>
-						</BookingLinkValueRow>
-						<BookingLinkHint>
-							{t('availability.week.drawer.booking-link-hint')}
-						</BookingLinkHint>
-					</BookingLinkSection>
-					<Divider />
-					<PatientNameAutocomplete
-						methods={methods}
-						onPatientSelect={onPatientSelect}
-						onSelectionClear={onSelectionClear}
-						results={results}
-						searchIsLoading={searchIsLoading}
-						searchQuery={searchQuery}
-						selectedPatient={selectedPatient}
-						setSearchQuery={setSearchQuery}
-					/>
-					<TextField
-						label={t('availability.week.drawer.patient-last-name')}
-						fullWidth
-						placeholder={t('availability.week.drawer.patient-last-name')}
-						{...register('lastName', {
-							required: t('components.form.validation.required', {
-								name: t('availability.week.drawer.patient-last-name'),
-							}),
-						})}
-						error={Boolean(lastNameError)}
-						helperText={
-							typeof lastNameError?.message === 'string'
-								? lastNameError.message
-								: undefined
-						}
-						slotProps={{ inputLabel: { shrink: !!lastNameValue } }}
-						required
-					/>
-					{sessionType === 'BOTH' && <SlotSessionDeliverySection />}
+					<AvailableSection
+						icon={<Appointment />}
+						title={t('availability.week.drawer.section.session')}
+					>
+						<SlotSessionSection {...sessionDetails} />
+						{reopenedCancellationNote && (
+							<ReopenedNote>
+								<ReopenedNoteLabel>
+									{t('availability.week.drawer.reopened-note-label')}
+								</ReopenedNoteLabel>
+								<ReopenedNoteText>{reopenedCancellationNote}</ReopenedNoteText>
+							</ReopenedNote>
+						)}
+					</AvailableSection>
 
-					{(isOnline || selectedPreferredType) && <PreferredContactForm />}
+					<Divider />
 
-					{showContactsForm && (
-						<ContactsForm<ICreatePatientForm>
-							atLeastOneContact={requireContacts}
-							fullWidth
-							fields={{
-								email: 'email',
-								hasWhatsApp: 'hasWhatsApp',
-								isPhoneWpp: 'isPhoneWpp',
-								phone: 'phone',
-								whatsapp: 'whatsapp',
-							}}
-							labelEmail={t('availability.week.drawer.patient-email')}
-							placeholderEmail={t('availability.week.drawer.patient-email')}
+					<AvailableSection
+						icon={<Send />}
+						title={t('availability.week.drawer.section.booking-link')}
+					>
+						<BookingLinkSection>
+							<BookingLinkHeader>
+								<BookingLinkLabel>
+									{t('availability.week.drawer.booking-link-label')}
+								</BookingLinkLabel>
+								<ShareButton
+									absoluteUrl={bookingLink}
+									preferNativeShare
+									textKey={shareText}
+									titleKey={shareTitle}
+								/>
+							</BookingLinkHeader>
+							<BookingLinkValueRow>
+								<BookingLinkValue>{bookingLink}</BookingLinkValue>
+							</BookingLinkValueRow>
+							<BookingLinkHint>
+								{t('availability.week.drawer.booking-link-hint')}
+							</BookingLinkHint>
+						</BookingLinkSection>
+					</AvailableSection>
+
+					<Divider />
+
+					<AvailableSection
+						icon={<Account />}
+						title={t('availability.week.drawer.section.patient')}
+					>
+						<PatientNameAutocomplete
+							methods={methods}
+							onPatientSelect={onPatientSelect}
+							onSelectionClear={onSelectionClear}
+							results={results}
+							searchIsLoading={searchIsLoading}
+							searchQuery={searchQuery}
+							selectedPatient={selectedPatient}
+							setSearchQuery={setSearchQuery}
 						/>
-					)}
-					{isInPerson && <SlotLocationSection {...locationProps} />}
+						<TextField
+							label={t('availability.week.drawer.patient-last-name')}
+							fullWidth
+							placeholder={t('availability.week.drawer.patient-last-name')}
+							{...register('lastName', {
+								required: t('components.form.validation.required', {
+									name: t('availability.week.drawer.patient-last-name'),
+								}),
+							})}
+							error={Boolean(lastNameError)}
+							helperText={
+								typeof lastNameError?.message === 'string'
+									? lastNameError.message
+									: undefined
+							}
+							slotProps={{ inputLabel: { shrink: !!lastNameValue } }}
+							required
+						/>
+					</AvailableSection>
+
+					<Divider />
+
+					<AvailableSection
+						icon={<Phone />}
+						title={t('availability.week.drawer.section.contact-delivery')}
+					>
+						{sessionType === 'BOTH' && <SlotSessionDeliverySection />}
+						{(isOnline || selectedPreferredType) && <PreferredContactForm />}
+						{showContactsForm && (
+							<ContactsForm<ICreatePatientForm>
+								atLeastOneContact={requireContacts}
+								fullWidth
+								fields={{
+									email: 'email',
+									hasWhatsApp: 'hasWhatsApp',
+									isPhoneWpp: 'isPhoneWpp',
+									phone: 'phone',
+									whatsapp: 'whatsapp',
+								}}
+								labelEmail={t('availability.week.drawer.patient-email')}
+								placeholderEmail={t('availability.week.drawer.patient-email')}
+							/>
+						)}
+						{isInPerson && <SlotLocationSection {...locationProps} />}
+					</AvailableSection>
+
+					<Divider />
+
 					<SlotRecurrenceSection />
 					<TimezoneSelect />
+
 					{!selectedPatient ? (
 						<ConsentBox>
 							<Controller

--- a/src/pages/availability/week/drawer/views/slot-available-body/available-section/AvailableSection.tsx
+++ b/src/pages/availability/week/drawer/views/slot-available-body/available-section/AvailableSection.tsx
@@ -1,0 +1,21 @@
+import {
+	SectionHeader,
+	SectionLabel,
+	SectionWrapper,
+} from '../SlotAvailableBody.styles';
+
+import type { AvailableSectionProps } from './AvailableSection.types';
+
+export const AvailableSection = ({
+	children,
+	icon,
+	title,
+}: AvailableSectionProps) => (
+	<SectionWrapper>
+		<SectionHeader>
+			{icon}
+			<SectionLabel>{title}</SectionLabel>
+		</SectionHeader>
+		{children}
+	</SectionWrapper>
+);

--- a/src/pages/availability/week/drawer/views/slot-available-body/available-section/AvailableSection.types.ts
+++ b/src/pages/availability/week/drawer/views/slot-available-body/available-section/AvailableSection.types.ts
@@ -1,0 +1,7 @@
+import type { ReactNode } from 'react';
+
+export interface AvailableSectionProps {
+	children: ReactNode;
+	icon?: ReactNode;
+	title: string;
+}


### PR DESCRIPTION
## Summary

- **PR-319 FE**: `DAY_BLOCK` added to `ConflictType` and `IBookingConflictMetadata`. New `DayBlockConflictDetail` component (appointment date + time). `ConflictDetail` routes `DAY_BLOCK` to new component with Cancel appointment / Dismiss actions. `ConflictsFiltersDrawer` and utils updated. Nav badge already wired.
- **PR-318 FE**: `BlockDayConflictModal` — 2-step modal intercepts block-all when booked slots exist. Step 1 lists booked slots with patient names/times. Step 2 shows confirmation summary. `DayHeaderPopover` routes to modal when `summary.booked > 0`, falls back to simple confirm otherwise.
- **PR-308 FE**: `SlotAvailableBody` redesigned with sectioned layout matching `SlotBookedBody` pattern. New `AvailableSection` component. Four sections: Session, Booking link, Patient, Contact & Delivery. All existing form fields preserved.
- **i18n**: EN + PT keys added for `day-block` type, conflict actions, drawer sections, and block-conflict-modal copy.

## Test plan

- [ ] Block a day with booked appointments → `BlockDayConflictModal` opens instead of simple confirm
- [ ] Confirm in modal → block proceeds, conflict appears in Action Center with type "Day block"
- [ ] Cancel appointment from conflict panel → slot cancelled, conflict resolved
- [ ] Available slot drawer shows sectioned layout (Session / Booking link / Patient / Contact & Delivery)
- [ ] All existing booking form fields still work (patient search, contacts, recurrence, timezone, consent)
- [ ] Conflict type filter in Action Center includes "Day block" option
- [ ] No regression on existing slot-replication and patient-duplicate conflict flows

Closes PR-318, PR-319 (FE), PR-308

🤖 Generated with [Claude Code](https://claude.com/claude-code)