### PR TITLE
fix(auth): send frontend origin to google oauth endpoint so callback redirects correctly

### DIFF
--- a/src/features/auth/google/startGoogleOAuth.ts
+++ b/src/features/auth/google/startGoogleOAuth.ts
@@ -50,6 +50,7 @@ export const startGoogleOAuth = ({
 	url.searchParams.set('timeZone', getTimeZone());
 	url.searchParams.set('returnTo', `/${returnPath}`);
 	url.searchParams.set('intent', intent);
+	url.searchParams.set('frontendOrigin', window.location.origin);
 
 	if (shouldIncludeStayConnected && typeof stayConnected === 'boolean') {
 		url.searchParams.set('stayConnected', String(stayConnected));


### PR DESCRIPTION
## Summary

`startGoogleOAuth` was navigating the browser to the Google OAuth URL without including the originating domain. The backend's `resolveFrontendOrigin()` fell back to `FRONTEND_URL` (the production URL `https://psycron.app`) because:
1. Browser navigations don't send an `Origin` header
2. `Referer` is stripped on cross-origin navigations by default
3. `frontendOrigin` query param was never sent

**Fix:** one-line change — add `url.searchParams.set('frontendOrigin', window.location.origin)`. The BE already validates this via `isAllowedFrontendOrigin()` and `dev.psycron.app` is in the allowlist.

## Test plan
- [ ] Sign up/in with Google on `dev.psycron.app` → redirected to `dev.psycron.app/en/auth/callback` (not `psycron.app`)
- [ ] Sign up/in with Google on `psycron.app` → redirected to `psycron.app/en/auth/callback` (unchanged)
- [ ] No regression on Google Calendar connect flow

Closes PR-336

🤖 Generated with [Claude Code](https://claude.com/claude-code)