### PR TITLE
fix(availability): resolve 3 pre-launch critical bugs (PR-345, PR-346, PR-347)

### DIFF
--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -1358,7 +1358,10 @@
       "response-with-suggestion": "How do you usually conduct your sessions? I have a suggestion based on your specialty — pick what works best for you.",
       "chip-online": "Online only",
       "chip-in-person": "In person only",
-      "chip-both": "Both online and in person"
+      "chip-both": "Both online and in person",
+      "ONLINE": "Online only",
+      "IN_PERSON": "In person only",
+      "BOTH": "Both online and in person"
     },
     "timezone": {
       "response": "Almost there! I’ll use your device’s timezone to schedule appointments accurately. This helps ensure your clients book at the right time for you. Sound good?",

--- a/src/assets/locales/pt/translation.json
+++ b/src/assets/locales/pt/translation.json
@@ -1358,7 +1358,10 @@
       "response-with-suggestion": "Como você costuma realizar suas sessões? Tenho uma sugestão com base na sua especialidade — escolha o que funciona melhor para você.",
       "chip-online": "Apenas online",
       "chip-in-person": "Apenas presencial",
-      "chip-both": "Online e presencial"
+      "chip-both": "Online e presencial",
+      "ONLINE": "Apenas online",
+      "IN_PERSON": "Apenas presencial",
+      "BOTH": "Online e presencial"
     },
     "timezone": {
       "response": "Quase lá! Vou usar o fuso horário do seu dispositivo para agendar consultas com precisão. Assim, seus clientes sempre vão agendar no horário certo. Tudo bem?",

--- a/src/components/guards/AvailabilityGate.tsx
+++ b/src/components/guards/AvailabilityGate.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { getAvailability } from '@psycron/api/availability';
+import { Loader } from '@psycron/components/loader/Loader';
 import { useAlert } from '@psycron/context/alert/AlertContext';
 import {
 	ONBOARDING_KEY,
@@ -52,6 +53,10 @@ export const AvailabilityGate = ({ children }: AvailabilityGateProps) => {
 			navigate(`/${i18n.language}/${AVAILABILITYGENERATE}`, { replace: true });
 		}
 	}, [data, isLoading, location.pathname, navigate, i18n.language, showAlert, t]);
+
+	if (isLoading && data === undefined) {
+		return <Loader />;
+	}
 
 	return <>{children}</>;
 };

--- a/src/pages/availability/jupiter-conversation/useJupiterFlow.ts
+++ b/src/pages/availability/jupiter-conversation/useJupiterFlow.ts
@@ -14,6 +14,7 @@ import {
 	importGoogleCalendarSchedule,
 	type RecurrencePattern,
 } from '@psycron/api/jupiter';
+import { QUERY_KEYS } from '@psycron/api/queryKeys';
 import { editUserById } from '@psycron/api/user';
 import { useAlert } from '@psycron/context/alert/AlertContext';
 import { AVAILABILITYGENERATE, AVAILABILITYPATH } from '@psycron/pages/urls';
@@ -485,6 +486,7 @@ export const useJupiterFlow = ({
 			};
 			queryClient.setQueryData<IAvailabilityRecord>(['availability'], record);
 			queryClient.setQueryData<IAvailabilityRecord>(['availabilityGate'], record);
+			queryClient.invalidateQueries({ queryKey: QUERY_KEYS.therapistAvailability(therapistId) });
 			showAlert({ message: t('jupiter.post-publish.success-toast'), severity: 'success' });
 			showAlert({ message: t('jupiter.post-publish.welcome-toast'), severity: 'success' });
 			navigate(`/${i18n.language}/${AVAILABILITYPATH}`);
@@ -493,7 +495,7 @@ export const useJupiterFlow = ({
 		} finally {
 			setIsPublishing(false);
 		}
-	}, [answers, addBotMessage, i18n.language, navigate, queryClient, showAlert, t]);
+	}, [answers, addBotMessage, i18n.language, navigate, queryClient, showAlert, t, therapistId]);
 
 	const handleReset = useCallback(() => {
 		localStorage.removeItem(STORAGE_KEY);


### PR DESCRIPTION
## Summary

Pre-launch P0 fixes found during the 2026-05-22 pre-go-live walkthrough.

- **PR-345** — Missing i18n keys for session type enum values in Preview & Publish step
- **PR-346** — Dashboard flashes during new user onboarding before redirect to `/availability/generate`
- **PR-347** — All availability dates appear as "Closed" immediately after Jupiter publishes

## Changes

### PR-345 · `src/assets/locales/{en,pt}/translation.json`
Added `ONLINE`, `IN_PERSON`, and `BOTH` keys under `jupiter.session-type`. These backend enum values are returned when loading saved availability data, and the preview step was calling `t('jupiter.session-type.ONLINE')` which had no match — showing the raw key string to the user.

### PR-346 · `src/components/guards/AvailabilityGate.tsx`
`AvailabilityGate` wraps all private routes via `AppLayout`. Previously it rendered children (`<Outlet />`) while its `getAvailability` query was in flight — causing the Dashboard to mount and paint before the gate could fire its redirect to `/availability/generate`. Now returns `<Loader />` during initial load (`isLoading && data === undefined`), blocking the render until the check completes. Subsequent navigations are instant (10-min staleTime cache).

### PR-347 · `src/pages/availability/jupiter-conversation/useJupiterFlow.ts`
After Jupiter publishes availability, the flow was only updating `['availability']` and `['availabilityGate']` in the React Query cache. The week view reads from `QUERY_KEYS.therapistAvailability(therapistId)` — a completely different query key that was never invalidated. `getDaySlots()` was therefore returning `[]` for every date, causing `handleDayHeaderClick` to open the "Open this closed day?" modal on every click. Added `queryClient.invalidateQueries({ queryKey: QUERY_KEYS.therapistAvailability(therapistId) })` after publish.

## Test plan

- [ ] Complete Jupiter availability setup → verify Preview & Publish shows "Online only" / "Apenas online" (not raw key `jupiter.session-type.ONLINE`)
- [ ] Sign up as a new Google user → verify no dashboard flash before `/availability/generate` loads
- [ ] Complete Jupiter setup → navigate to `/availability` → click an available date → verify the day detail/week view shows slots, not the "Open this closed day?" modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)