### PR TITLE
fix(navigation): fix back button SPA bug and specialty retry loop (PR-348, PR-349)

### DIFF
--- a/src/components/link/Link.tsx
+++ b/src/components/link/Link.tsx
@@ -34,14 +34,8 @@ export const Link = ({
 
 		if (to === 'go-back') {
 			e.preventDefault();
-			const referrer = document.referrer;
-			const isInternalReferrer = referrer.includes(window.location.origin);
-
-			if (isInternalReferrer) {
-				navigate(-1);
-			} else {
-				navigate(`/${locale ?? 'en'}`);
-			}
+			navigate(-1);
+			return;
 		}
 
 		const label = isString(to) ? to : to.pathname;

--- a/src/pages/availability/jupiter-conversation/JupiterConversation.tsx
+++ b/src/pages/availability/jupiter-conversation/JupiterConversation.tsx
@@ -42,6 +42,7 @@ export const JupiterConversation = () => {
 	const [customInputFor, setCustomInputFor] = useState<string | null>(null);
 	const [customValue, setCustomValue] = useState('');
 	const [isParsing, setIsParsing] = useState(false);
+	const specialtyRetryCount = useRef(0);
 
 	const { therapistId, userDetails } = useUserDetails();
 
@@ -83,6 +84,13 @@ export const JupiterConversation = () => {
 
 	const handleSpecialtyOtherSubmit = useCallback(
 		async (raw: string) => {
+			// After 2 failed parse attempts, accept raw input to unblock the user
+			if (specialtyRetryCount.current >= 2) {
+				specialtyRetryCount.current = 0;
+				handleSpecialtyFromText([raw]);
+				return;
+			}
+
 			setIsParsing(true);
 			const result = await parseJupiterInput('specialty', raw);
 			setIsParsing(false);
@@ -90,13 +98,17 @@ export const JupiterConversation = () => {
 			if (result.valid && Array.isArray(result.parsed)) {
 				const flag = 'flag' in result ? result.flag : 'accepted';
 				if (flag === 'rejected') {
+					specialtyRetryCount.current += 1;
 					retrySpeciality(true);
 				} else if (flag === 'rephrase') {
+					specialtyRetryCount.current += 1;
 					retrySpeciality(false);
 				} else {
+					specialtyRetryCount.current = 0;
 					handleSpecialtyFromText(result.parsed);
 				}
 			} else {
+				specialtyRetryCount.current += 1;
 				retrySpeciality(false);
 			}
 		},


### PR DESCRIPTION
## Summary

Two P1 pre-launch bugs found during the 2026-05-22 walkthrough.

- **PR-349** — Back button always navigates to home/dashboard instead of previous page
- **PR-348** — "Other" specialty free-text loops the same error indefinitely for non-English input

## Changes

### PR-349 · `src/components/link/Link.tsx`

The `go-back` handler checked `document.referrer` to determine if navigation should go back or fall through to the root. In a SPA, `document.referrer` reflects the *external page that loaded the app* (or is empty for direct navigation), not the previous React Router route. `isInternalReferrer` was therefore always `false`, making every back-button click navigate to `/${locale}` (dashboard) rather than the previous page.

**Fix:** Remove the referrer check. React Router's `navigate(-1)` only traverses its own internal history stack — it cannot navigate out of the SPA, making the external-referrer guard unnecessary.

### PR-348 · `src/pages/availability/jupiter-conversation/JupiterConversation.tsx`

`handleSpecialtyOtherSubmit` had no retry counter. Every failed parse (rejected/rephrase/invalid) called `retrySpeciality()`, which reset the input and showed the same error — users could loop indefinitely, particularly if typing in a non-English language that the parser doesn't recognize.

**Fix:** Added `specialtyRetryCount` ref. After 2 failed attempts, the raw input is passed directly to `handleSpecialtyFromText([raw])`, bypassing validation and unblocking the user. Counter resets on success.

## Test plan

- [ ] Navigate: Dashboard → `/availability` → click a date → `/availability/week/:date` → click back → should land on `/availability`, not dashboard
- [ ] Navigate: Availability settings → click back → should land on previous page
- [ ] Jupiter specialty step → type a non-English word → get error → type again → get error → type again → **third attempt should succeed and proceed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)