### PR TITLE
fix(jupiter): verify imported schedule, auto-skip recurrence, picker ux (PR-354/355/356)

### DIFF
--- a/src/api/jupiter/index.ts
+++ b/src/api/jupiter/index.ts
@@ -85,6 +85,7 @@ export const generateJupiterAvailability = async (
 
 export interface GoogleCalendarSchedule {
 	endTime: string;
+	recurrencePattern?: 'WEEKLY' | 'MONTHLY';
 	startTime: string;
 	workingDays: string[];
 }

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -1468,7 +1468,8 @@
     "calendar-picker": {
       "title": "Which calendar should Psycron use?",
       "primary": "primary",
-      "confirm": "Use this calendar"
+      "confirm": "Use this calendar",
+      "back": "Go back"
     },
     "google-calendar": {
       "permissions-intro": "We’ll securely connect to your Google Calendar to:",

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -1487,6 +1487,7 @@
       "define-hours-fallback": "Got it! Google Calendar import is coming soon. Let’s set your working hours manually for now.",
       "importing": "Give me a moment — I’m importing your schedule from Google Calendar...",
       "imported": "Done! I found your working days and hours. Just a couple more things to set up.",
+      "imported-summary": "Done! I found your schedule: {{days}}, from {{hours}}. Just a couple more things to set up.",
       "import-failed": "I couldn’t read your calendar schedule. Let’s set your working hours manually."
     },
     "errors": {

--- a/src/assets/locales/pt/translation.json
+++ b/src/assets/locales/pt/translation.json
@@ -1468,7 +1468,8 @@
     "calendar-picker": {
       "title": "Qual calendário o Psycron deve usar?",
       "primary": "principal",
-      "confirm": "Usar este calendário"
+      "confirm": "Usar este calendário",
+      "back": "Voltar"
     },
     "google-calendar": {
       "permissions-intro": "Vamos conectar sua Google Agenda com segurança para:",

--- a/src/assets/locales/pt/translation.json
+++ b/src/assets/locales/pt/translation.json
@@ -1487,6 +1487,7 @@
       "define-hours-fallback": "Entendido! A importação do Google Agenda estará disponível em breve. Por enquanto, vamos definir seus horários manualmente.",
       "importing": "Um momento — estou importando sua agenda do Google Agenda...",
       "imported": "Pronto! Encontrei seus dias e horários de trabalho. Só mais algumas configurações.",
+      "imported-summary": "Pronto! Encontrei sua agenda: {{days}}, das {{hours}}. Só mais algumas configurações.",
       "import-failed": "Não consegui ler sua agenda. Vamos definir seus horários de trabalho manualmente."
     },
     "errors": {

--- a/src/pages/availability/google-calendar-path/GoogleCalendarPicker.styles.tsx
+++ b/src/pages/availability/google-calendar-path/GoogleCalendarPicker.styles.tsx
@@ -24,11 +24,43 @@ export const PickerCard = styled(Box)`
 	animation: slideIn 300ms ease-out;
 `;
 
+export const PickerHeader = styled(Box)`
+	display: flex;
+	align-items: center;
+	gap: ${spacing.xs};
+	margin-bottom: ${spacing.extraSmall};
+`;
+
+export const BackBtn = styled('button')`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	border-radius: 8px;
+	border: none;
+	background: ${hexToRgba(palette.brand.purple, 0.08)};
+	cursor: pointer;
+	transition: background 150ms ease;
+	flex-shrink: 0;
+	color: ${palette.brand.purple};
+	padding: 0;
+
+	&:hover {
+		background: ${hexToRgba(palette.brand.purple, 0.16)};
+	}
+
+	& svg {
+		width: 16px;
+		height: 16px;
+	}
+`;
+
 export const PickerTitle = styled(Typography)`
 	font-size: 14px;
 	font-weight: 600;
 	color: ${palette.text.primary};
-	margin-bottom: ${spacing.extraSmall};
+	text-align: left;
 `;
 
 export const CalendarList = styled(Box)`
@@ -55,6 +87,7 @@ export const CalendarOption = styled(Box, {
 		isSelected ? hexToRgba(palette.brand.purple, 0.08) : 'transparent'};
 	cursor: pointer;
 	transition: all 150ms ease;
+	text-align: left;
 
 	&:hover {
 		border-color: ${palette.brand.purple};
@@ -74,16 +107,20 @@ export const CalendarName = styled(Typography)`
 	font-size: 13px;
 	color: ${palette.text.primary};
 	flex: 1;
+	text-align: left;
 `;
 
 export const PrimaryBadge = styled(Typography)`
 	font-size: 11px;
 	color: ${palette.text.secondary};
-	font-style: italic;
+	background-color: ${hexToRgba(palette.brand.purple, 0.06)};
+	padding: 2px 8px;
+	border-radius: 6px;
+	font-weight: 500;
 `;
 
 export const ConfirmBtn = styled(Box)`
 	display: flex;
-	justify-content: flex-end;
+	justify-content: flex-start;
 	margin-top: ${spacing.xs};
 `;

--- a/src/pages/availability/google-calendar-path/GoogleCalendarPicker.tsx
+++ b/src/pages/availability/google-calendar-path/GoogleCalendarPicker.tsx
@@ -2,26 +2,31 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { CalendarItem } from '@psycron/api/auth';
 import { Button } from '@psycron/components/button/Button';
+import { ChevronLeft } from '@psycron/components/icons';
 
 import {
+	BackBtn,
 	CalendarDot,
 	CalendarList,
 	CalendarName,
 	CalendarOption,
 	ConfirmBtn,
 	PickerCard,
+	PickerHeader,
 	PickerTitle,
 	PrimaryBadge,
 } from './GoogleCalendarPicker.styles';
 
 interface GoogleCalendarPickerProps {
 	calendars: CalendarItem[];
+	onBack?: () => void;
 	onSelect: (calendarId: string) => void;
 }
 
 export const GoogleCalendarPicker = ({
 	calendars,
 	onSelect,
+	onBack,
 }: GoogleCalendarPickerProps) => {
 	const { t } = useTranslation();
 
@@ -36,7 +41,14 @@ export const GoogleCalendarPicker = ({
 
 	return (
 		<PickerCard>
-			<PickerTitle>{t('jupiter.calendar-picker.title')}</PickerTitle>
+			<PickerHeader>
+				{onBack && (
+					<BackBtn onClick={onBack} type='button'>
+						<ChevronLeft />
+					</BackBtn>
+				)}
+				<PickerTitle>{t('jupiter.calendar-picker.title')}</PickerTitle>
+			</PickerHeader>
 
 			<CalendarList>
 				{calendars.map((cal) => (

--- a/src/pages/availability/google-calendar-path/GoogleCalendarPicker.tsx
+++ b/src/pages/availability/google-calendar-path/GoogleCalendarPicker.tsx
@@ -43,7 +43,11 @@ export const GoogleCalendarPicker = ({
 		<PickerCard>
 			<PickerHeader>
 				{onBack && (
-					<BackBtn onClick={onBack} type='button'>
+					<BackBtn
+						onClick={onBack}
+						type='button'
+						aria-label={t('jupiter.calendar-picker.back')}
+					>
 						<ChevronLeft />
 					</BackBtn>
 				)}

--- a/src/pages/availability/jupiter-conversation/JupiterConversation.styles.tsx
+++ b/src/pages/availability/jupiter-conversation/JupiterConversation.styles.tsx
@@ -176,8 +176,8 @@ export const IconRow = styled(Box, {
 
 export const ChipsInline = styled(Box)`
 	display: flex;
-	align-items: center;
-	justify-content: center;
+	align-items: flex-start;
+	justify-content: flex-start;
 	flex-direction: column;
 `;
 

--- a/src/pages/availability/jupiter-conversation/JupiterConversation.tsx
+++ b/src/pages/availability/jupiter-conversation/JupiterConversation.tsx
@@ -463,6 +463,7 @@ export const JupiterConversation = () => {
 					<GoogleCalendarPicker
 						calendars={calendarList}
 						onSelect={handleCalendarPicked}
+						onBack={handleGoogleBack}
 					/>
 				);
 

--- a/src/pages/availability/jupiter-conversation/useJupiterFlow.ts
+++ b/src/pages/availability/jupiter-conversation/useJupiterFlow.ts
@@ -408,6 +408,28 @@ export const useJupiterFlow = ({
 		[commit, t]
 	);
 
+	const advanceAfterTimezone = useCallback(() => {
+		// Skip recurrence step if already detected from Google Calendar import
+		setAnswers((prev) => {
+			if (prev.recurrencePattern) {
+				const summaryKey =
+					prev.recurrencePattern === 'WEEKLY'
+						? 'jupiter.recurrence-pattern.summary-weekly'
+						: 'jupiter.recurrence-pattern.summary-monthly';
+				setTimeout(() => {
+					addBotMessage(t(summaryKey));
+					setStep('preview');
+				}, 300);
+			} else {
+				setTimeout(() => {
+					addBotMessage(t('jupiter.recurrence-pattern.response'));
+					setStep('recurrence-pattern');
+				}, 300);
+			}
+			return prev;
+		});
+	}, [addBotMessage, t]);
+
 	const handleTimezone = useCallback(
 		(key: string) => {
 			if (key === 'chip-yes') {
@@ -417,23 +439,23 @@ export const useJupiterFlow = ({
 					timezone: detectedTimezone,
 					timezoneConfirmed: true,
 				}));
-				advance('jupiter.recurrence-pattern.response', 'recurrence-pattern', 300);
+				advanceAfterTimezone();
 			} else {
 				addUserMessage(t('jupiter.timezone.chip-no'));
 				addBotMessage(t('jupiter.timezone.follow-up'));
 				setAnswers((prev) => ({ ...prev, timezoneConfirmed: false }));
 			}
 		},
-		[addBotMessage, addUserMessage, advance, detectedTimezone, t]
+		[addBotMessage, addUserMessage, advanceAfterTimezone, detectedTimezone, t]
 	);
 
 	const handleTimezoneSelect = useCallback(
 		(tz: string) => {
 			addUserMessage(tz);
 			setAnswers((prev) => ({ ...prev, timezone: tz }));
-			advance('jupiter.recurrence-pattern.response', 'recurrence-pattern', 300);
+			advanceAfterTimezone();
 		},
-		[addUserMessage, advance]
+		[addUserMessage, advanceAfterTimezone]
 	);
 
 	const handleRecurrencePattern = useCallback(
@@ -585,13 +607,35 @@ export const useJupiterFlow = ({
 
 					if (schedule && schedule.workingDays.length > 0) {
 						const timeRange = `${schedule.startTime} - ${schedule.endTime}`;
-						setAnswers((prev) => ({
-							...prev,
+
+						const updatedAnswers: Partial<JupiterAnswers> = {
 							workingDays: schedule.workingDays,
 							timeRange,
-						}));
+						};
+
+						// Auto-set recurrence if the calendar had recurring events
+						if (schedule.recurrencePattern) {
+							updatedAnswers.recurrencePattern = schedule.recurrencePattern;
+						}
+
+						setAnswers((prev) => ({ ...prev, ...updatedAnswers }));
+
+						// Show the user what was imported so they can verify
+						const dayLabels = schedule.workingDays
+							.map((d) => {
+								const chipKey = CANONICAL_TO_CHIP[d];
+								return chipKey ? t(`jupiter.working-days.${chipKey}`) : d;
+							})
+							.join(', ');
+
 						setTimeout(() => {
-							addBotMessage(t('jupiter.google-calendar.imported'), false);
+							addBotMessage(
+								t('jupiter.google-calendar.imported-summary', {
+									days: dayLabels,
+									hours: timeRange,
+								}),
+								false
+							);
 							setStep('session-duration');
 						}, 300);
 					} else {


### PR DESCRIPTION
## What
Improves the Júpiter Google Calendar import flow.

- **PR-355**: after import, Júpiter shows a **summary of detected working days + hours** (`imported-summary`, EN+PT) so the user can verify before continuing.
- **PR-356**: when import returns a `recurrencePattern`, the recurrence step is **auto-skipped** with a confirmation message (`summary-weekly`/`summary-monthly`).
- **PR-354 (UX)**: calendar picker gains a **back button** and left-aligned layout; `ChipsInline` left-aligned; primary-calendar badge restyled.

Adds `recurrencePattern?: 'WEEKLY' | 'MONTHLY'` to the `GoogleCalendarSchedule` type (pairs with the BE PR).

## Testing
- `tsc` clean on changed files, eslint clean (pre-commit build passed)

## Tickets
PR-354, PR-355, PR-356

🤖 Generated with [Claude Code](https://claude.com/claude-code)