### PR TITLE
fix(availability): prevent dashboard flash during onboarding (PR-346)

### DIFF
--- a/e2e/availability/onboarding-redirect.spec.ts
+++ b/e2e/availability/onboarding-redirect.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+
+import { setupAuthenticatedSession } from '../fixtures/auth.fixtures';
+import { mockAvailability } from '../fixtures/therapist.fixtures';
+
+// PR-346: a new user (no availability yet) must be redirected from the
+// dashboard to /availability/generate by AvailabilityGate, without the
+// dashboard ever becoming the resting route (the "flash"). A user who already
+// has availability must stay on the dashboard.
+
+const DASHBOARD_URL = '/en/dashboard';
+
+test.describe('Onboarding redirect — AvailabilityGate (PR-346)', () => {
+	test.beforeEach(async ({ page }) => {
+		await setupAuthenticatedSession(page);
+		// Make sure no stale draft pushes us to /generate for the wrong reason
+		// (STORAGE_KEY in useJupiterFlow.ts).
+		await page.addInitScript(() => {
+			localStorage.removeItem('_psy_jd');
+		});
+	});
+
+	test('redirects a user with no availability to /availability/generate', async ({
+		page,
+	}) => {
+		// getAvailability() returns null on a non-2xx response → "no availability".
+		await page.route('**/jupiter/availability**', (route) => {
+			route.fulfill({ status: 404, body: 'Not Found' });
+		});
+
+		await page.goto(DASHBOARD_URL);
+
+		await expect(page).toHaveURL(/\/availability\/generate/, { timeout: 5000 });
+	});
+
+	test('keeps a user with availability on the dashboard (no redirect)', async ({
+		page,
+	}) => {
+		await page.route('**/jupiter/availability**', (route) => {
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify(mockAvailability),
+			});
+		});
+
+		await page.goto(DASHBOARD_URL);
+
+		// Give the gate time to (not) redirect, then assert we are still on the
+		// dashboard and were never bounced to /generate.
+		await page.waitForTimeout(1500);
+		await expect(page).toHaveURL(/\/dashboard/);
+		await expect(page).not.toHaveURL(/\/availability\/generate/);
+	});
+});

--- a/src/components/guards/AvailabilityGate.tsx
+++ b/src/components/guards/AvailabilityGate.tsx
@@ -28,14 +28,18 @@ export const AvailabilityGate = ({ children }: AvailabilityGateProps) => {
 		staleTime: 1000 * 60 * 10,
 	});
 
+	const isOnGeneratePage = location.pathname.includes(AVAILABILITYGENERATE);
+	const hasAvailability = data !== null;
+	const hasDraft = !!localStorage.getItem(STORAGE_KEY);
+	// Once the query resolves, a missing availability (or a pending draft) means
+	// we are about to redirect — we must not render children for that frame, or
+	// the dashboard flashes briefly before the navigation lands.
+	const willRedirect =
+		!isLoading && !isOnGeneratePage && (!hasAvailability || hasDraft);
+
 	useEffect(() => {
 		if (isLoading) return;
-
-		const isOnGeneratePage = location.pathname.includes(AVAILABILITYGENERATE);
 		if (isOnGeneratePage) return;
-
-		const hasDraft = !!localStorage.getItem(STORAGE_KEY);
-		const hasAvailability = data !== null;
 
 		if (!hasAvailability) {
 			if (!hasAlerted.current && !!localStorage.getItem(ONBOARDING_KEY)) {
@@ -52,9 +56,18 @@ export const AvailabilityGate = ({ children }: AvailabilityGateProps) => {
 		if (hasDraft) {
 			navigate(`/${i18n.language}/${AVAILABILITYGENERATE}`, { replace: true });
 		}
-	}, [data, isLoading, location.pathname, navigate, i18n.language, showAlert, t]);
+	}, [
+		hasAvailability,
+		hasDraft,
+		isLoading,
+		isOnGeneratePage,
+		navigate,
+		i18n.language,
+		showAlert,
+		t,
+	]);
 
-	if (isLoading && data === undefined) {
+	if ((isLoading && data === undefined) || willRedirect) {
 		return <Loader />;
 	}
 


### PR DESCRIPTION
## What
New users briefly saw the empty dashboard blink before being redirected to `/availability/generate`.

`AvailabilityGate` rendered the loader only while the availability query was in flight. Once it resolved with no availability, the gate rendered the dashboard for one frame, and only the post-render `useEffect` then redirected — the visible blink.

## Fix
Compute the redirect decision synchronously (`willRedirect`) and render `<Loader/>` for that frame, so the dashboard never paints before the navigation lands. The existing redirect `useEffect` is unchanged.

## Testing
- tsc clean on changed file, eslint clean (pre-commit build passed)

## Ticket
PR-346

🤖 Generated with [Claude Code](https://claude.com/claude-code)