### PR TITLE
fix(availability-settings): pinned drawer footer and active-hours stat (PR-361)

### DIFF
--- a/src/components/drawer/Drawer.styles.tsx
+++ b/src/components/drawer/Drawer.styles.tsx
@@ -74,8 +74,12 @@ export const DrawerActions = styled(Box)`
 `;
 
 export const DrawerActionsSection = styled(Box)`
-	padding-top: ${spacing.medium};
-	padding-bottom: ${spacing.large};
+	flex-shrink: 0;
+	padding: ${spacing.medium} ${spacing.mediumLarge} ${spacing.large};
+
+	${isMobileMedia} {
+		padding: ${spacing.small} ${spacing.medium} ${spacing.medium};
+	}
 `;
 
 // ─── Generic drawer body / description ────────────────────────────────────────

--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -32,15 +32,13 @@ export const Drawer = ({
 				</Box>
 				<CloseButton onClick={onClose} />
 			</DrawerHeader>
-			<DrawerContent>
-				{children}
-				{actions && (
-					<DrawerActionsSection>
-						<Divider />
-						<DrawerActions>{actions}</DrawerActions>
-					</DrawerActionsSection>
-				)}
-			</DrawerContent>
+			<DrawerContent>{children}</DrawerContent>
+			{actions && (
+				<DrawerActionsSection>
+					<Divider />
+					<DrawerActions>{actions}</DrawerActions>
+				</DrawerActionsSection>
+			)}
 		</DrawerPanel>
 	</>
 );

--- a/src/pages/availability/availability-settings/useAvailabilitySettings.ts
+++ b/src/pages/availability/availability-settings/useAvailabilitySettings.ts
@@ -376,13 +376,13 @@ export const useAvailabilitySettings = (): UseAvailabilitySettingsReturn => {
 
 		let activeHoursPerWeek = 0;
 		if (availability?.timeRange && availability.workingDays?.length) {
-			const parts = availability.timeRange.split(/\s*[-–—]\s*/);
-			if (parts.length === 2) {
-				const [sh, sm] = parts[0].split(':').map(Number);
-				const [eh, em] = parts[1].split(':').map(Number);
-				const hoursPerDay = (eh * 60 + em - (sh * 60 + sm)) / 60;
+			const { end, start } = parseTimeRangeToInputs(availability.timeRange);
+			const [sh, sm] = start.split(':').map(Number);
+			const [eh, em] = end.split(':').map(Number);
+			const minutesPerDay = eh * 60 + em - (sh * 60 + sm);
+			if (Number.isFinite(minutesPerDay) && minutesPerDay > 0) {
 				activeHoursPerWeek = Math.round(
-					hoursPerDay * availability.workingDays.length
+					(minutesPerDay / 60) * availability.workingDays.length
 				);
 			}
 		}


### PR DESCRIPTION
## PR-361 follow-up — Frontend

From dev testing feedback:
- **Drawer actions now pinned to the bottom** of the panel (moved out of the scrollable content area). Applies to every drawer using the shared `Drawer`.
- **Active hours NaN fix**: `statusStats` split `timeRange` naively on `:`, but Júpiter stores AM/PM (`"9:00 AM"`), so `Number("00 AM")` → NaN. Now reuses `parseTimeRangeToInputs` (24h) with a finite-number guard.

Not included (still open): "Sync now" does not yet apply Google data to availability — see BE #99 diagnostic logging; apply-logic pending data review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)