### PR TITLE
feat(availability-settings): refresh calendar views after google sync (PR-361)

### DIFF
--- a/src/pages/availability/availability-settings/useAvailabilitySettings.ts
+++ b/src/pages/availability/availability-settings/useAvailabilitySettings.ts
@@ -665,6 +665,13 @@ export const useAvailabilitySettings = (): UseAvailabilitySettingsReturn => {
 			const status = await syncGoogleCalendar();
 			setLastSyncAt(status.lastSyncAt);
 			setSyncEnabled(status.syncEnabled);
+			// Auto-update the calendar, week view and settings config without a
+			// manual refresh — the ingestion just rewrote availability slots.
+			queryClient.invalidateQueries({ queryKey: ['therapistAvailability'] });
+			queryClient.invalidateQueries({ queryKey: ['availabilityByDay'] });
+			queryClient.invalidateQueries({
+				queryKey: [JUPITER_AVAILABILITY_CONFIG_KEY],
+			});
 			showAlert({
 				message: t('availability.settings.google-calendar-synced'),
 				severity: 'success',
@@ -678,7 +685,7 @@ export const useAvailabilitySettings = (): UseAvailabilitySettingsReturn => {
 		} finally {
 			setIsSyncing(false);
 		}
-	}, [showAlert, t]);
+	}, [queryClient, showAlert, t]);
 
 	const handleChangeCalendar = useCallback(
 		async (calendarId: string) => {


### PR DESCRIPTION
## What

After a manual Google Calendar sync, the BE ingestion now rewrites availability slots (see psycron-be `feat/PR-361-gcal-sync-ingestion`). This invalidates the relevant queries so the change is reflected immediately:

- `therapistAvailability` — the month calendar
- `availabilityByDay` — the week/day view
- Júpiter availability config — settings page

So the practitioner no longer has to manually refresh to see the blocked slots that just landed.

## Why

The sync result was correct on the server but invisible in the UI until a hard refresh, reinforcing the "nothing happens" perception.

## Tests

`npm run lint` clean; husky pre-commit (`lint && build`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)