### PR TITLE
feat(navbar): responsive menu polish — rail restyle, icons, badges, language globe

### DIFF
--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -416,6 +416,7 @@
         "appointments": "Appointments",
         "appointments-manager": "Manage your appointments",
         "change-language": "Change language",
+        "coming-soon-label": "Coming soon",
         "help": "Help center",
         "logout": "Logout",
         "plan": "Plan",

--- a/src/assets/locales/pt/translation.json
+++ b/src/assets/locales/pt/translation.json
@@ -416,6 +416,7 @@
         "appointments": "Atendimentos",
         "appointments-manager": "Gerencie seus atendimentos",
         "change-language": "Mude o idioma",
+        "coming-soon-label": "Em breve",
         "help": "Centro de suporte",
         "logout": "Sair",
         "plan": "Plano",

--- a/src/components/icons/TriangleAlert.tsx
+++ b/src/components/icons/TriangleAlert.tsx
@@ -1,0 +1,18 @@
+export const TriangleAlert: React.FC = (props) => (
+	<svg
+		xmlns='http://www.w3.org/2000/svg'
+		width='24'
+		height='24'
+		viewBox='0 0 24 24'
+		fill='none'
+		stroke='currentColor'
+		strokeWidth='2'
+		strokeLinecap='round'
+		strokeLinejoin='round'
+		{...props}
+	>
+		<path d='m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3' />
+		<path d='M12 9v4' />
+		<path d='M12 17h.01' />
+	</svg>
+);

--- a/src/components/icons/Wallet.tsx
+++ b/src/components/icons/Wallet.tsx
@@ -1,0 +1,17 @@
+export const Wallet: React.FC = (props) => (
+	<svg
+		xmlns='http://www.w3.org/2000/svg'
+		width='24'
+		height='24'
+		viewBox='0 0 24 24'
+		fill='none'
+		stroke='currentColor'
+		strokeWidth='2'
+		strokeLinecap='round'
+		strokeLinejoin='round'
+		{...props}
+	>
+		<path d='M19 7V4a1 1 0 0 0-1-1H5a2 2 0 0 0 0 4h15a1 1 0 0 1 1 1v4h-3a2 2 0 0 0 0 4h3a1 1 0 0 0 1-1v-2a1 1 0 0 0-1-1' />
+		<path d='M3 5v14a2 2 0 0 0 2 2h15a1 1 0 0 0 1-1v-4' />
+	</svg>
+);

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -86,7 +86,9 @@ import { Security as IconSecurity } from './Security';
 import { SendInvoice as IconSendInvoice } from './SendInvoice';
 import { Settings as IconSettings } from './Settings';
 import { Subscription as IconSubscription } from './Subscription';
+import { TriangleAlert as IconTriangleAlert } from './TriangleAlert';
 import { Visible as IconVisible } from './Visible';
+import { Wallet as IconWallet } from './Wallet';
 import { Watch as IconWatch } from './Watch';
 import { WhatsApp as IconWhatsApp } from './Whatsapp';
 
@@ -176,3 +178,5 @@ export const Month = withIconColor(IconMonth);
 export const Plus = withIconColor(IconPlus);
 export const Jupiter = withIconColor(IconJupiter);
 export const Settings = withIconColor(IconSettings);
+export const TriangleAlert = withIconColor(IconTriangleAlert);
+export const Wallet = withIconColor(IconWallet);

--- a/src/components/localization/Localization.styles.tsx
+++ b/src/components/localization/Localization.styles.tsx
@@ -1,4 +1,5 @@
-import { Box, styled } from '@mui/material';
+import { Box, IconButton, styled } from '@mui/material';
+import { palette } from '@psycron/theme/palette/palette.theme';
 import { spacing } from '@psycron/theme/spacing/spacing.theme';
 
 export const StyledSelectWrapper = styled(Box, {
@@ -6,4 +7,20 @@ export const StyledSelectWrapper = styled(Box, {
 })<{ hasMargin?: boolean }>`
 	width: 4.2rem;
 	margin-left: ${({ hasMargin }) => (hasMargin ? spacing.small : 0)};
+`;
+
+// Matches the navigation rail item: 48px rounded square, subtle grey hover.
+export const LanguageTrigger = styled(IconButton)`
+	width: 48px;
+	height: 48px;
+	border-radius: ${spacing.small};
+	color: ${palette.gray['07']};
+	transition:
+		background-color 0.18s ease,
+		color 0.18s ease;
+
+	&:hover {
+		background-color: ${palette.gray['00']};
+		color: ${palette.text.primary};
+	}
 `;

--- a/src/components/localization/Localization.tsx
+++ b/src/components/localization/Localization.tsx
@@ -1,16 +1,23 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import {
+	Menu as MuiMenu,
+	MenuItem as MuiMenuItem,
+	Tooltip as MuiTooltip,
+} from '@mui/material';
+import { Globe } from '@psycron/components/icons';
 import { Select } from '@psycron/components/select/Select';
 import Cookies from 'js-cookie';
 
-import { StyledSelectWrapper } from './Localization.styles';
+import { LanguageTrigger, StyledSelectWrapper } from './Localization.styles';
 import type { ILocalization } from './Localization.types';
 
 export const LANGKEY = 'i18nextLng';
 
-export const Localization = ({ hasMargin }: ILocalization) => {
-	const { i18n } = useTranslation();
+export const Localization = ({ hasMargin, iconVariant }: ILocalization) => {
+	const { i18n, t } = useTranslation();
+	const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 	const { locale } = useParams<{ locale: string }>();
 	const navigate = useNavigate();
 	const location = useLocation();
@@ -63,11 +70,54 @@ export const Localization = ({ hasMargin }: ILocalization) => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [i18n, locale]);
 
+	const currentLang = defaultLang.split('-')[0];
+
+	if (iconVariant) {
+		return (
+			<>
+				<MuiTooltip
+					arrow
+					placement='right'
+					title={t('globals.change-language')}
+				>
+					<LanguageTrigger
+						aria-label={t('globals.change-language')}
+						onClick={(e) => {
+							e.stopPropagation();
+							setAnchorEl(e.currentTarget);
+						}}
+					>
+						<Globe />
+					</LanguageTrigger>
+				</MuiTooltip>
+				<MuiMenu
+					anchorEl={anchorEl}
+					open={Boolean(anchorEl)}
+					onClose={() => setAnchorEl(null)}
+				>
+					{availableLanguages.map((lang) => (
+						<MuiMenuItem
+							key={lang.value}
+							selected={currentLang === lang.value}
+							onClick={(e) => {
+								e.stopPropagation();
+								changeLanguage(lang.value);
+								setAnchorEl(null);
+							}}
+						>
+							{lang.name}
+						</MuiMenuItem>
+					))}
+				</MuiMenu>
+			</>
+		);
+	}
+
 	return (
 		<StyledSelectWrapper hasMargin={hasMargin}>
 			<Select
 				name='language-select'
-				value={defaultLang.split('-')[0]}
+				value={currentLang}
 				onChangeSelect={(e) => changeLanguage(e.target.value as string)}
 				items={availableLanguages}
 			/>

--- a/src/components/localization/Localization.types.ts
+++ b/src/components/localization/Localization.types.ts
@@ -1,3 +1,6 @@
 export interface ILocalization {
 	hasMargin?: boolean;
+	// Render a globe icon trigger (for the navigation rail) instead of the
+	// inline language Select dropdown.
+	iconVariant?: boolean;
 }

--- a/src/components/navbar/Navbar.styles.tsx
+++ b/src/components/navbar/Navbar.styles.tsx
@@ -15,7 +15,7 @@ export const NavbarWrapper = styled(Box)`
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	padding: ${spacing.small};
+	padding-right: ${spacing.xs};
 	height: 100%;
 	justify-content: space-between;
 `;
@@ -30,14 +30,16 @@ export const MobileNavbarWrapper = styled(Box)`
 
 export const MobileNavbarMenu = styled(Box)`
 	svg {
-		height: auto;
 		width: 30px;
+		height: auto;
 	}
 `;
 
 export const ColoredLogo = styled(Box)`
+	padding: ${spacing.xs} 0;
 	svg {
-		width: 45px;
+		width: 32px;
+		height: auto;
 	}
 `;
 
@@ -45,7 +47,7 @@ export const NavbarFooterIcons = styled(Box)`
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	gap: ${spacing.small};
+	gap: 0;
 `;
 
 const dropdownAnimation = keyframes`
@@ -126,7 +128,7 @@ export const DesktopkMenuWrapper = styled(Box)`
 	display: flex;
 	flex-direction: column;
 	justify-content: flex-start;
-	gap: ${spacing.small};
+	gap: ${spacing.xs};
 `;
 
 export const MobileMenuWrapper = styled(Box)`

--- a/src/components/navbar/menu/Menu.tsx
+++ b/src/components/navbar/menu/Menu.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Box, Divider } from '@mui/material';
 import { useAuth } from '@psycron/context/user/auth/UserAuthenticationContext';
 import useViewport from '@psycron/hooks/useViewport';
@@ -15,23 +15,40 @@ export const Menu = ({
 	isFullList,
 }: IMenuItems) => {
 	const navigate = useNavigate();
+	const location = useLocation();
 	const { logout } = useAuth();
 
 	const { isMobile, isTablet } = useViewport();
 
+	// Strip the locale segment so the remaining path can be matched against a
+	// menu item's route (e.g. "/en/action-center" -> "action-center").
+	const currentPath = location.pathname.split('/').filter(Boolean).slice(1).join('/');
+
+	const isItemActive = (path?: string) =>
+		!!path &&
+		path !== LOGOUT &&
+		(currentPath === path || currentPath.startsWith(`${path}/`));
+
 	const handleClick = (path?: string, onClick?: () => void) => {
 		if (path?.includes(LOGOUT)) {
 			logout();
-		} else {
-			if (onClick && !(isMobile || isTablet)) {
-				onClick();
-			} else {
-				if (path) {
-					navigate(`/${i18n.language}/${path}`, { replace: true });
-				}
-				closeMenu?.();
-			}
+			return;
 		}
+		// Action-only items (e.g. external help link) carry an onClick and no
+		// route — run it on every viewport instead of trying to navigate.
+		if (onClick && !path) {
+			onClick();
+			closeMenu?.();
+			return;
+		}
+		if (onClick && !(isMobile || isTablet)) {
+			onClick();
+			return;
+		}
+		if (path) {
+			navigate(`/${i18n.language}/${path}`, { replace: true });
+		}
+		closeMenu?.();
 	};
 
 	return (
@@ -40,6 +57,7 @@ export const Menu = ({
 				(
 					{
 						badgeCount,
+						comingSoon,
 						icon,
 						name,
 						path,
@@ -61,10 +79,12 @@ export const Menu = ({
 								<>
 									<MenuItem
 										badgeCount={badgeCount}
+										comingSoon={comingSoon}
 										key={`item-${name}-${index}`}
 										icon={icon}
 										name={name}
 										path={path}
+										isActive={isItemActive(path)}
 										isFooterIcon={isFooterIcon}
 										isFullList={isFullList}
 										disabled={disabled}

--- a/src/components/navbar/menu/components/item/MenuItem.styles.tsx
+++ b/src/components/navbar/menu/components/item/MenuItem.styles.tsx
@@ -9,13 +9,62 @@ export const MobileMenuIconWrapper = styled(Box)`
 	border-radius: 100%;
 `;
 
-export const MenuIconWrap = styled('span')`
+export const MenuIconWrap = styled('span', {
+	shouldForwardProp: (prop) => prop !== '$active' && prop !== '$disabled',
+})<{ $active?: boolean; $disabled?: boolean }>`
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
 	position: relative;
-	padding: ${spacing.xs};
-	border-radius: 100%;
+	width: 48px;
+	height: 48px;
+	border-radius: ${spacing.small};
+	color: ${palette.gray['07']};
+	transition:
+		background-color 0.18s ease,
+		color 0.18s ease;
+
+	&:hover {
+		background-color: ${palette.gray['00']};
+		color: ${palette.text.primary};
+	}
+
+	${({ $active }) =>
+		$active
+			? css`
+					background-color: ${palette.brand.light};
+					color: ${palette.brand.purple};
+
+					&:hover {
+						background-color: ${palette.brand.light};
+						color: ${palette.brand.purple};
+					}
+
+					&::before {
+						content: '';
+						position: absolute;
+						left: -10px;
+						top: 10px;
+						bottom: 10px;
+						width: 3px;
+						border-radius: 3px;
+						background-color: ${palette.brand.purple};
+					}
+				`
+			: css``}
+
+	${({ $disabled }) =>
+		$disabled
+			? css`
+					color: ${palette.gray['03']};
+					cursor: not-allowed;
+
+					&:hover {
+						background-color: transparent;
+						color: ${palette.gray['03']};
+					}
+				`
+			: css``}
 `;
 
 export const MenuBadge = styled('span')`
@@ -55,8 +104,8 @@ export const StyledMenuItem = styled(Tooltip, {
 `;
 
 export const MobileMenuItem = styled(Box, {
-	shouldForwardProp: (props) => props !== 'disabled',
-})<{ disabled?: boolean }>`
+	shouldForwardProp: (props) => props !== 'disabled' && props !== '$active',
+})<{ $active?: boolean; disabled?: boolean }>`
 	display: flex;
 	flex-direction: row;
 	align-items: center;
@@ -71,6 +120,13 @@ export const MobileMenuItem = styled(Box, {
 		color: ${palette.brand.purple};
 		font-weight: 500;
 	}
+
+	${({ $active }) =>
+		$active
+			? css`
+					background-color: ${palette.brand.light};
+				`
+			: css``}
 
 	${({ disabled }) =>
 		disabled

--- a/src/components/navbar/menu/components/item/MenuItem.tsx
+++ b/src/components/navbar/menu/components/item/MenuItem.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Text } from '@psycron/components/text/Text';
 import { useCanHover } from '@psycron/hooks/userCanHover';
 
@@ -13,36 +14,48 @@ import type { IMenuItem } from './MenuItem.types';
 
 export const MenuItem = ({
 	badgeCount,
+	comingSoon,
 	icon,
 	name,
+	isActive,
 	isFooterIcon,
 	isFullList,
 	disabled,
 	hoverIcon,
 }: IMenuItem) => {
 	const canHover = useCanHover();
+	const { t } = useTranslation();
 	const [isHovered, setIsHovered] = useState(false);
 
 	const shouldSwap = !isFullList && canHover && Boolean(hoverIcon);
 
 	const renderedIcon = shouldSwap && isHovered && hoverIcon ? hoverIcon : icon;
 
+	// A "coming soon" item stays visually disabled but keeps its tooltip so the
+	// reason is surfaced instead of being a silent grey icon.
+	const tooltipTitle = comingSoon
+		? `${name} · ${t('globals.coming-soon-label')}`
+		: name;
+
 	return (
 		<>
 			{isFullList ? (
-				<MobileMenuItem disabled={disabled}>
+				<MobileMenuItem disabled={disabled} $active={isActive}>
 					<MobileMenuIconWrapper>{icon}</MobileMenuIconWrapper>
-					<Text textTransform='capitalize'>{name}</Text>
+					<Text textTransform='capitalize'>{tooltipTitle}</Text>
 				</MobileMenuItem>
 			) : (
 				<StyledMenuItem
-					title={name}
+					title={tooltipTitle}
 					placement='right'
-					disabled={disabled}
+					disabled={disabled && !comingSoon}
+					plainHover
 					$disabled={disabled}
 					$isFooterIcon={isFooterIcon}
 				>
 					<MenuIconWrap
+						$active={isActive}
+						$disabled={disabled}
 						onMouseEnter={() => {
 							if (shouldSwap) setIsHovered(true);
 						}}

--- a/src/components/navbar/menu/components/item/MenuItem.types.ts
+++ b/src/components/navbar/menu/components/item/MenuItem.types.ts
@@ -3,10 +3,12 @@ import type { ReactNode } from 'react';
 export interface IMenuItem {
 	badgeCount?: number;
 	closeMenu?: () => void;
+	comingSoon?: boolean;
 	component?: ReactNode;
 	disabled?: boolean;
 	hoverIcon?: ReactNode;
-	icon: ReactNode;
+	icon?: ReactNode;
+	isActive?: boolean;
 	isFooterIcon?: boolean;
 	isFullList?: boolean;
 	name: string;

--- a/src/components/tooltip/Tooltip.styles.tsx
+++ b/src/components/tooltip/Tooltip.styles.tsx
@@ -5,24 +5,33 @@ import { shadowSmallPurple } from '@psycron/theme/shadow/shadow.theme';
 import { spacing } from '@psycron/theme/spacing/spacing.theme';
 
 export const TootleTipIconButton = styled(IconButton, {
-	shouldForwardProp: (props) => props !== 'disabled',
-})<{ disabled?: boolean }>`
+	shouldForwardProp: (props) => props !== 'disabled' && props !== '$plainHover',
+})<{ $plainHover?: boolean; disabled?: boolean }>`
 	border-radius: ${spacing.small};
 	color: ${palette.text.disabled};
 	padding: 0;
 
-	${({ disabled }) =>
+	${({ disabled, $plainHover }) =>
 		disabled
 			? css`
 					pointer-events: none;
 					opacity: 0.55;
 					color: ${palette.gray['03']};
 				`
-			: css`
-					:hover {
-						background-color: ${palette.brand.purple};
-						color: ${palette.white};
-						box-shadow: ${shadowSmallPurple};
-					}
-				`}
+			: $plainHover
+				? css`
+						color: inherit;
+
+						:hover {
+							background-color: transparent;
+							box-shadow: none;
+						}
+					`
+				: css`
+						:hover {
+							background-color: ${palette.brand.purple};
+							color: ${palette.white};
+							box-shadow: ${shadowSmallPurple};
+						}
+					`}
 `;

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -11,6 +11,7 @@ export const Tooltip = ({
 	title,
 	open,
 	disabled = false,
+	plainHover = false,
 	'aria-label': ariaLabel,
 }: PsycronTooltipProps) => {
 	const Title =
@@ -48,6 +49,7 @@ export const Tooltip = ({
 							: undefined)
 					}
 					disabled={disabled}
+					$plainHover={plainHover}
 					onClick={onClick}
 				>
 					{children}

--- a/src/components/tooltip/Tooltip.types.ts
+++ b/src/components/tooltip/Tooltip.types.ts
@@ -2,4 +2,7 @@ import type { TooltipProps } from '@mui/material';
 
 export interface PsycronTooltipProps extends TooltipProps {
 	disabled?: boolean;
+	// Opt out of the default purple hover fill/glow when the wrapping
+	// component supplies its own hover treatment (e.g. the navigation rail).
+	plainHover?: boolean;
 }

--- a/src/layouts/app/app-layout/AppLayout.styles.tsx
+++ b/src/layouts/app/app-layout/AppLayout.styles.tsx
@@ -42,11 +42,11 @@ export const LayoutWrapper = styled(Box)`
 	height: 100vh;
 	justify-content: flex-start;
 	padding: ${spacing.small};
+
 	overflow: hidden;
 
 	${isBiggerThanMediumMedia} {
 		flex-direction: row;
-		padding: ${spacing.medium} ${spacing.small};
 	}
 
 	${isMobileMedia} {

--- a/src/layouts/app/app-layout/AppLayout.tsx
+++ b/src/layouts/app/app-layout/AppLayout.tsx
@@ -3,21 +3,21 @@ import { useTranslation } from 'react-i18next';
 import { Outlet } from 'react-router-dom';
 import { Box, Divider } from '@mui/material';
 import { AppAnalytics } from '@psycron/analytics/posthog/AppAnalytics';
+import { getNotifications } from '@psycron/api/notifications';
 import { getAvailabilityCalendar } from '@psycron/api/user';
 import { getConflictCount } from '@psycron/api/user/conflicts';
 import { EnvironmentBanner } from '@psycron/components/environment-banner/EnvironmentBanner';
 import { AvailabilityGate } from '@psycron/components/guards/AvailabilityGate';
 import {
-	Alert,
+	Bell,
 	Calendar,
 	DashboardIcon,
 	Help,
-	Language,
 	Logout,
 	PatientList,
-	Payment,
-	Send,
-	UserSettings,
+	Settings,
+	TriangleAlert,
+	Wallet,
 } from '@psycron/components/icons';
 import { Localization } from '@psycron/components/localization/Localization';
 import { Navbar } from '@psycron/components/navbar/Navbar';
@@ -36,12 +36,14 @@ import {
 	ACTIONCENTER,
 	AVAILABILITYPATH,
 	DASHBOARD,
+	getHelpUrl,
 	LOGOUT,
 	NOTIFICATIONS,
 	PATIENTS,
 	PAYMENTS,
 } from '@psycron/pages/urls';
 import { useQuery } from '@tanstack/react-query';
+import { format, subDays } from 'date-fns';
 
 import {
 	Content,
@@ -51,7 +53,7 @@ import {
 } from './AppLayout.styles';
 
 export const AppLayout: FC = () => {
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
 	const { isMobile, isTablet } = useViewport();
 	const { isTestingEnv } = useRuntimeEnv();
 
@@ -95,17 +97,34 @@ export const AppLayout: FC = () => {
 		[cancellationRecoveryData?.dates]
 	);
 
+	// Badge the Notifications item with failed deliveries from the last day —
+	// the actionable subset a practitioner needs to retry.
+	const notificationsFrom = useMemo(
+		() => format(subDays(new Date(), 1), 'yyyy-MM-dd'),
+		[]
+	);
+	const { data: failedNotificationsData } = useQuery({
+		queryKey: ['failedNotificationsCount', userDetails?._id, notificationsFrom],
+		queryFn: () =>
+			getNotifications({
+				from: notificationsFrom,
+				limit: 100,
+				status: 'FAILED',
+			}),
+		enabled: Boolean(userDetails?._id),
+		gcTime: 1000 * 60 * 30,
+		staleTime: 1000 * 60 * 5,
+	});
+	const failedNotificationsCount =
+		failedNotificationsData?.total ??
+		failedNotificationsData?.notifications.length ??
+		0;
+
 	const menuItems = [
 		{
 			name: t('components.navbar.dashboard'),
 			icon: <DashboardIcon />,
 			path: DASHBOARD,
-		},
-		{
-			name: t('components.navbar.user-settings'),
-			icon: <UserSettings />,
-			path: `${userDetails?._id}`,
-			onClick: () => toggleUserDetails(),
 		},
 		{
 			name: t('globals.appointments-manager'),
@@ -114,14 +133,15 @@ export const AppLayout: FC = () => {
 		},
 		{
 			name: t('components.navbar.action-center'),
-			icon: <Alert />,
+			icon: <TriangleAlert />,
 			path: ACTIONCENTER,
 			badgeCount: (conflictCountData?.count ?? 0) + cancellationRecoveryCount,
 		},
 		{
 			name: t('components.navbar.notifications'),
-			icon: <Send />,
+			icon: <Bell />,
 			path: NOTIFICATIONS,
+			badgeCount: failedNotificationsCount,
 		},
 		{
 			name: t('globals.patients'),
@@ -130,23 +150,33 @@ export const AppLayout: FC = () => {
 		},
 		{
 			name: t('globals.billing-manager'),
-			icon: <Payment />,
+			icon: <Wallet />,
 			path: PAYMENTS,
 			disabled: true,
+			comingSoon: true,
 		},
 	];
 
 	const footerItems = [
 		{
+			name: t('components.navbar.user-settings'),
+			icon: <Settings />,
+			path: `${userDetails?._id}`,
+			onClick: () => toggleUserDetails(),
+		},
+		{
 			name: t('globals.change-language'),
-			icon: <Language />,
-			component: <Localization />,
+			component: <Localization iconVariant />,
 		},
 		{
 			name: t('globals.help'),
 			icon: <Help />,
-			path: '/help-center',
-			disabled: true,
+			onClick: () =>
+				window.open(
+					getHelpUrl(i18n.language),
+					'_blank',
+					'noopener,noreferrer'
+				),
 		},
 		{ name: t('globals.logout'), icon: <Logout />, path: LOGOUT },
 	];

--- a/src/pages/urls.tsx
+++ b/src/pages/urls.tsx
@@ -3,6 +3,8 @@ export const DOMAIN = 'https://psycron.app';
 export const HOMEPAGE = '';
 export const LOCALISATION = ':locale';
 export const BASE_API_URL = 'https://api.psycron.app/api/v1/';
+// Public help/support page served from the marketing site (locale-prefixed).
+export const getHelpUrl = (locale: string) => `${DOMAIN}/${locale}/help`;
 
 // ID
 export const USERID = ':userId';


### PR DESCRIPTION
## What

Navigation rail / menu polish, aligning the live menu with the approved redesign preview.

### Changes
- **Active state** — route-driven highlight on the rail and the mobile list (`brand.light` fill + 3px purple indicator), replacing the old circles.
- **Icon set** — `Settings` (gear), `TriangleAlert` (action center), `Bell` (notifications), `Wallet` (billing). Two new wrappers added to `@psycron/components/icons`.
- **Footer reorg** — user-settings moved to the bottom cluster (settings · language · help · logout).
- **Help** — enabled, opens the locale-aware public page `psycron.app/{locale}/help` (`getHelpUrl`).
- **Billing** — "coming soon" affordance (tooltip surfaces the reason instead of a silent grey icon) + `globals.coming-soon-label` (EN/PT).
- **Hover** — scoped `plainHover` on `Tooltip` removes the purple fill/glow **in the menu only**; every other tooltip is unchanged.
- **Notifications badge** — wired to failed deliveries from the last day.
- **Language** — globe trigger + EN/PT menu (`Localization` `iconVariant`); public booking keeps the Select dropdown.
- Logo to 32px; rail spacing tightened to match the design.

## Verification
- `npm run lint` clean; `tsc` introduces no new errors (pre-existing count unchanged).
- Production build passes (pre-commit hook).

## Notes / follow-ups
- Notifications badge currently counts **failed** deliveries (no unread concept yet) — easy to re-scope.
- Future (separate): consolidate all settings into one glass card (deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)