### PR TITLE
chore(release): mark Google Calendar requirement done

### DIFF
--- a/.github/release-requirements.json
+++ b/.github/release-requirements.json
@@ -5,19 +5,8 @@
     { "name": "Júpiter + Availability Builder", "status": "done" },
     {
       "name": "Scheduling & Availability Management",
-      "status": "in-progress",
-      "tickets": [
-        {
-          "key": "PR-291",
-          "url": "https://psycron.atlassian.net/browse/PR-291",
-          "summary": "Google Meet/Zoom auto-links"
-        },
-        {
-          "key": "PR-294",
-          "url": "https://psycron.atlassian.net/browse/PR-294",
-          "summary": "Booked slot drawer UX overhaul"
-        }
-      ]
+      "status": "done",
+      "note": "Google Calendar full integration (PR-337) + permissions (PR-289) merged to dev 2026-06-14 (BE #107, FE #102): first-class mirror, slot provenance, BUSY status, occlusion guards. PR-294 (booked slot drawer) done. PR-291 (Meet/Zoom auto-links) + live inbound events.watch sync deferred to v1.1.0."
     },
     { "name": "Public Booking Pages", "status": "done" },
     {
@@ -81,7 +70,7 @@
       "name": "Google Calendar Permissions Fix",
       "ticket": "PR-289",
       "url": "https://psycron.atlassian.net/browse/PR-289",
-      "status": "pending"
+      "status": "done"
     }
   ]
 }


### PR DESCRIPTION
## What & why

Reconciles `.github/release-requirements.json` with the Google-mirror availability work merged to `dev` on 2026-06-14 ([FE #102](https://github.com/psycron-app/psycron-fe/pull/102), [BE #107](https://github.com/psycron-app/psycron-be/pull/107)).

- **Scheduling & Availability Management**: `in-progress` → `done`, with a note crediting PR-337 (full integration) + PR-294 (booked slot drawer), and flagging PR-291 (Meet/Zoom auto-links) + live inbound `events.watch` sync as v1.1.0-deferred.
- **Blocker "Google Calendar Permissions Fix" (PR-289)**: `pending` → `done`.

Jira [PR-337](https://psycron.atlassian.net/browse/PR-337) and [PR-289](https://psycron.atlassian.net/browse/PR-289) are already Done; the [Core Features](https://psycron.atlassian.net/wiki/spaces/Product/pages/57376785/Core+Features) page is reconciled. Merging this triggers the **Version Tracking** Confluence page refresh on push to `dev`.

## Scope

Config-only (one JSON file). No code or runtime impact. QA/e2e for the underlying feature is assigned to Eduardo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)