### PR TITLE
fix(ci): render Version Tracking progress bar once

### DIFF
--- a/.github/workflows/dev-changelog.yml
+++ b/.github/workflows/dev-changelog.yml
@@ -346,7 +346,9 @@ jobs:
 
             const section = [
               '<p><em>Auto-updated by GitHub Actions on ' + esc(date) + ' from <strong>' + esc(repo) + '</strong></em></p>',
-              progressBar,
+              // Progress bar intentionally NOT rendered here: it is inserted once in the
+              // 'Current Status' section below (which de-dupes prior bars). Rendering it in
+              // both sections produced duplicate/conflicting progress bars on the page.
               reqTable,
               blockerTable,
               '<h3>Dev branch status</h3>',


### PR DESCRIPTION
## What
The `dev-changelog.yml` workflow built the release progress bar once but inserted it in **two** places — the "What's in Dev" section and the "Current Status" section — while the de-dupe regex only cleaned the Current Status copy. Result: duplicate, conflicting progress bars on the Confluence Version Tracking page (e.g. 60% and 98% rendered together).

## Fix
Render the progress bar in a **single** location ("Current Status"), where prior bars are already stripped before re-insertion. The bar is no longer embedded in the "What's in Dev" section.

## Scope
- One file: `.github/workflows/dev-changelog.yml` (3 insertions, 1 deletion).
- No behavior change to the changelog/Jira sync; only removes the duplicate bar.

## Context
Part of the 2026-06-18 product-docs cleanup that made Confluence "Core Features" the single status source and demoted Version Tracking to release history. The page already carries a banner deferring status to Core Features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)