### PR TITLE
feat(user): prefill and google re-sync on edit-user (PR-336)

### DIFF
--- a/e2e/edit-user-prefill.spec.ts
+++ b/e2e/edit-user-prefill.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test } from '@playwright/test';
+
+import { setupAuthenticatedSession } from './fixtures/auth.fixtures';
+import { mockTherapist, THERAPIST_ID } from './fixtures/therapist.fixtures';
+
+// A therapist whose contact + clinic details were pre-filled from their Google
+// profile during OAuth sign-up (PR-336). The edit page must surface these so the
+// user.phonenumbers.read / user.addresses.read scopes are demonstrably used.
+const googlePrefilledTherapist = {
+	...mockTherapist,
+	authProvider: 'google',
+	dateOfBirth: '1990-03-07T00:00:00.000Z',
+	contacts: { email: 'ana@clinic.com', phone: '+351911234567' },
+	clinicAddress: {
+		street: 'Rua Augusta 10',
+		city: 'Lisbon',
+		country: 'Portugal',
+		postcode: '1100-053',
+	},
+	consent: {
+		marketingEmailsAcceptedAt: null,
+		termsAcceptedAt: '2026-01-01T00:00:00.000Z',
+		privacyPolicyAcceptedAt: '2026-01-01T00:00:00.000Z',
+		dataProcessingAcceptedAt: '2026-01-01T00:00:00.000Z',
+	},
+};
+
+test.describe('Edit user — Google profile pre-fill', () => {
+	test.beforeEach(async ({ page }) => {
+		await setupAuthenticatedSession(page);
+
+		// Keep token refresh succeeding so an incidental 401 from an unmocked
+		// layout-level call can't trip the interceptor into a sign-in redirect.
+		await page.route('**/token/refresh-token', (route) => {
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({
+					accessToken: 'mock-access-token',
+					refreshToken: 'mock-refresh-token',
+				}),
+			});
+		});
+
+		// AvailabilityGate redirects to /availability/generate when getAvailability
+		// returns null, so return a non-null record to keep us on the edit page.
+		await page.route('**/jupiter/availability', (route) => {
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ id: 'availability-001' }),
+			});
+		});
+
+		// The edit page also fetches sub-resources (conflicts count, availability).
+		// Left unmocked they hit the real backend, 401, and trip the axios 401
+		// interceptor → logout, which unmounts the form before we can assert.
+		await page.route(`**/users/${THERAPIST_ID}/**`, (route) => {
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ count: 0, dates: [] }),
+			});
+		});
+
+		await page.route(`**/users/${THERAPIST_ID}`, (route) => {
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ user: googlePrefilledTherapist }),
+			});
+		});
+	});
+
+	test('pre-fills the clinic address from the Google profile', async ({
+		page,
+	}) => {
+		await page.goto(`/en/edit/${THERAPIST_ID}/clinicAddress`);
+
+		await expect(page.getByTestId('edit-user-section-clinic')).toBeVisible();
+
+		await expect(page.getByTestId('address-form-street')).toHaveValue(
+			'Rua Augusta 10'
+		);
+		await expect(page.getByTestId('address-form-city')).toHaveValue('Lisbon');
+		await expect(page.getByTestId('address-form-postcode')).toHaveValue(
+			'1100-053'
+		);
+		await expect(page.getByTestId('address-form-country')).toHaveValue(
+			'Portugal'
+		);
+	});
+
+	test('pre-fills the phone number from the Google profile', async ({
+		page,
+	}) => {
+		await page.goto(`/en/edit/${THERAPIST_ID}/contacts`);
+
+		await expect(page.getByTestId('edit-user-section-contact')).toBeVisible();
+
+		const phoneInput = page.getByTestId('contacts-form-phone').locator('input');
+		const value = await phoneInput.inputValue();
+		// react-phone-number-input formats the value, so compare on digits only.
+		expect(value.replace(/\D/g, '')).toContain('911234567');
+	});
+
+	test('pre-fills the date of birth from the Google profile', async ({
+		page,
+	}) => {
+		await page.goto(`/en/edit/${THERAPIST_ID}/name`);
+
+		await expect(page.getByTestId('edit-user-section-name')).toBeVisible();
+		await expect(page.getByTestId('name-form-date-of-birth')).toHaveValue(
+			'1990-03-07'
+		);
+	});
+});

--- a/src/api/user/index.ts
+++ b/src/api/user/index.ts
@@ -30,6 +30,16 @@ export const editUserById = async ({
 	return response.data;
 };
 
+export const resyncGoogleProfile = async (
+	userId: string
+): Promise<IUserByIdResponse> => {
+	const response = await apiClient.post<IUserByIdResponse>(
+		`/users/${userId}/google/resync`
+	);
+
+	return response.data;
+};
+
 export const changePassword = async ({ data, userId }: IChangePass) => {
 	const response = await apiClient.post<IResponse>(
 		`/users/password-change/${userId}`,

--- a/src/components/form/components/address/AddressForm.tsx
+++ b/src/components/form/components/address/AddressForm.tsx
@@ -76,6 +76,7 @@ export const AddressForm = <T extends FieldValues>({
 					helperText={streetState.error?.message as string | undefined}
 					autoComplete='street-address'
 					disabled={disabled}
+					slotProps={{ htmlInput: { 'data-testid': 'address-form-street' } }}
 				/>
 			</Grid>
 			<Grid size={{ xs: 12, md: 6 }}>
@@ -89,6 +90,7 @@ export const AddressForm = <T extends FieldValues>({
 					helperText={cityState.error?.message as string | undefined}
 					autoComplete='address-level2'
 					disabled={disabled}
+					slotProps={{ htmlInput: { 'data-testid': 'address-form-city' } }}
 				/>
 			</Grid>
 			<Grid size={{ xs: 12, md: 6 }}>
@@ -102,6 +104,7 @@ export const AddressForm = <T extends FieldValues>({
 					helperText={postcodeState.error?.message as string | undefined}
 					autoComplete='postal-code'
 					disabled={disabled}
+					slotProps={{ htmlInput: { 'data-testid': 'address-form-postcode' } }}
 				/>
 			</Grid>
 			<Grid size={{ xs: 12 }}>
@@ -115,6 +118,7 @@ export const AddressForm = <T extends FieldValues>({
 					helperText={countryState.error?.message as string | undefined}
 					autoComplete='country-name'
 					disabled={disabled}
+					slotProps={{ htmlInput: { 'data-testid': 'address-form-country' } }}
 				/>
 			</Grid>
 		</Grid>

--- a/src/components/form/components/contacts/ContactsForm.tsx
+++ b/src/components/form/components/contacts/ContactsForm.tsx
@@ -84,7 +84,10 @@ export const ContactsForm = <T extends FieldValues>({
 					helperText={emailError}
 					required={required}
 					disabled={disabled}
-					slotProps={{ inputLabel: { shrink: !!emailValue } }}
+					slotProps={{
+						inputLabel: { shrink: !!emailValue },
+						htmlInput: { 'data-testid': 'contacts-form-email' },
+					}}
 				/>
 
 			{!hidePhone && (
@@ -108,6 +111,7 @@ export const ContactsForm = <T extends FieldValues>({
 							disabled={disabled}
 							defaultValue={defaultValues?.phone ?? ''}
 							labelKey='globals.phone'
+							testId='contacts-form-phone'
 						/>
 					</InputWrapper>
 				)}

--- a/src/components/form/components/name/NameForm.tsx
+++ b/src/components/form/components/name/NameForm.tsx
@@ -16,6 +16,7 @@ export const NameForm = <T extends FieldValues>({
 	placeholderLastName,
 	labelFirstName,
 	labelLastName,
+	showDateOfBirth = false,
 }: NameFormProps<T>) => {
 	const { t } = useTranslation();
 
@@ -26,6 +27,7 @@ export const NameForm = <T extends FieldValues>({
 
 	const firstNamePath = fields?.firstName ?? ('firstName' as Path<T>);
 	const lastNamePath = fields?.lastName ?? ('lastName' as Path<T>);
+	const dateOfBirthPath = fields?.dateOfBirth ?? ('dateOfBirth' as Path<T>);
 
 	const firstNameError = errors[firstNamePath];
 	const lastNameError = errors[lastNamePath];
@@ -85,6 +87,23 @@ export const NameForm = <T extends FieldValues>({
 					disabled={disabled}
 				/>
 			</NameInputWrapper>
+
+			{showDateOfBirth ? (
+				<NameInputWrapper>
+					<TextField
+						type='date'
+						label={t('components.form.signup.date-of-birth', 'Date of birth')}
+						fullWidth
+						id={String(dateOfBirthPath)}
+						{...register(dateOfBirthPath)}
+						disabled={disabled}
+						slotProps={{
+							inputLabel: { shrink: true },
+							htmlInput: { 'data-testid': 'name-form-date-of-birth' },
+						}}
+					/>
+				</NameInputWrapper>
+			) : null}
 		</NameFormWrapper>
 	);
 };

--- a/src/components/form/components/name/NameForm.types.ts
+++ b/src/components/form/components/name/NameForm.types.ts
@@ -1,6 +1,7 @@
 import type { FieldValues, Path } from 'react-hook-form';
 
 export type NameFormFields<T extends FieldValues> = {
+	dateOfBirth?: Path<T>;
 	firstName: Path<T>;
 	lastName: Path<T>;
 };
@@ -23,4 +24,6 @@ export interface NameFormProps<T extends FieldValues> {
 
 	placeholderLastName?: string;
 	required?: boolean;
+	/** Opt-in: render an optional date-of-birth field (used on the edit page). */
+	showDateOfBirth?: boolean;
 }

--- a/src/components/form/components/phone/PhoneInput.tsx
+++ b/src/components/form/components/phone/PhoneInput.tsx
@@ -25,6 +25,7 @@ export const PhoneInputComponent = <T extends FieldValues>({
 	disabled,
 	labelKey,
 	required,
+	testId,
 	validateFn,
 }: PhoneInputComponentProps<T>) => {
 	const { t } = useTranslation();
@@ -95,6 +96,7 @@ export const PhoneInputComponent = <T extends FieldValues>({
 						isFocused={focused}
 						hasError={Boolean(error)}
 						isDisabled={Boolean(disabled)}
+						data-testid={testId}
 					>
 						<PhoneInput
 							labels={labels}

--- a/src/components/form/components/phone/PhoneInput.types.ts
+++ b/src/components/form/components/phone/PhoneInput.types.ts
@@ -6,6 +6,7 @@ export type PhoneInputComponentProps<T extends FieldValues> = {
 	labelKey?: string;
 	name: Path<T>;
 	required?: boolean;
+	testId?: string;
 	validateFn?: (value: string) => string | true;
 };
 

--- a/src/context/user/auth/UserAuthenticationContext.types.ts
+++ b/src/context/user/auth/UserAuthenticationContext.types.ts
@@ -81,6 +81,7 @@ export interface IBaseUser {
 	_id: string;
 	contacts: IContactInfo;
 	createdAt?: ISODateString;
+	dateOfBirth?: ISODateString | null;
 	firstName: string;
 	lastName: string;
 	updatedAt?: ISODateString;

--- a/src/pages/user/edit-user/EditUser.tsx
+++ b/src/pages/user/edit-user/EditUser.tsx
@@ -5,9 +5,10 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { capture } from '@psycron/analytics/posthog/events';
 import { PostHogEvent } from '@psycron/analytics/posthog/types';
 import type { CustomError } from '@psycron/api/error';
-import { editUserById } from '@psycron/api/user';
+import { editUserById, resyncGoogleProfile } from '@psycron/api/user';
 import type { IEditUser } from '@psycron/api/user/index.types';
 import { AvatarUploader } from '@psycron/components/avatar/avatar-uploader/AvatarUploader';
+import { Button } from '@psycron/components/button/Button';
 import { AddressForm } from '@psycron/components/form/components/address/AddressForm';
 import { ContactsForm } from '@psycron/components/form/components/contacts/ContactsForm';
 import { FormFooter } from '@psycron/components/form/components/footer/FormFooter';
@@ -126,6 +127,28 @@ export const EditUser = () => {
 		},
 	});
 
+	const resyncGoogleMutation = useMutation({
+		mutationFn: () => resyncGoogleProfile(_id),
+		onSuccess: async () => {
+			await queryClient.invalidateQueries({
+				queryKey: ['userDetails', userId],
+			});
+			showAlert({
+				message: t(
+					'components.user-details.google-resync-success',
+					'Profile synced from Google'
+				),
+				severity: 'success',
+			});
+		},
+		onError: (error: CustomError) => {
+			showAlert({
+				message: error.message || t('globals.error.internal-server-error'),
+				severity: 'error',
+			});
+		},
+	});
+
 	if (
 		isUserDetailsLoading ||
 		!isUserDetailsSucces ||
@@ -189,6 +212,8 @@ export const EditUser = () => {
 			<FormProvider {...methods}>
 				<EditUserFormContainer
 					as='form'
+					id='edit-user-form'
+					data-testid='edit-user-form'
 					onSubmit={methods.handleSubmit(onSubmit)}
 				>
 					<EditUserDetailsAvatarWrapper>
@@ -198,9 +223,24 @@ export const EditUser = () => {
 							lastName={lastName}
 							picture={pictureUrl}
 						/>
+						{isGoogleUser ? (
+							<Button
+								secondary
+								small
+								loading={resyncGoogleMutation.isPending}
+								onClick={() => resyncGoogleMutation.mutate()}
+								data-testid='resync-google-button'
+							>
+								{t(
+									'components.user-details.sync-from-google',
+									'Sync from Google'
+								)}
+							</Button>
+						) : null}
 					</EditUserDetailsAvatarWrapper>
 
 					<EditSection
+						testId='edit-user-section-name'
 						title={t('globals.name')}
 						isEnabled={enabled.name}
 						onToggle={() => {
@@ -211,12 +251,18 @@ export const EditUser = () => {
 						<NameForm<EditUserFormValues>
 							required
 							disabled={!enabled.name}
-							fields={{ firstName: 'firstName', lastName: 'lastName' }}
+							fields={{
+								firstName: 'firstName',
+								lastName: 'lastName',
+								dateOfBirth: 'dateOfBirth',
+							}}
 							placeholderFirstName={firstName}
 							placeholderLastName={lastName}
+							showDateOfBirth
 						/>
 					</EditSection>
 					<EditSection
+						testId='edit-user-section-contact'
 						title={t('components.user-details.section.title.contact')}
 						isEnabled={enabled.contacts}
 						onToggle={() => {
@@ -238,6 +284,7 @@ export const EditUser = () => {
 						/>
 					</EditSection>
 					<EditSection
+						testId='edit-user-section-clinic'
 						title={t('components.user-details.section.title.clinic')}
 						isEnabled={enabled.clinicAddress}
 						onToggle={() => {
@@ -251,6 +298,7 @@ export const EditUser = () => {
 						/>
 					</EditSection>
 					<EditSection
+						testId='edit-user-section-password'
 						title={t('globals.password')}
 						isEnabled={enabled.password}
 						disabled={!canEdit.password}

--- a/src/pages/user/edit-user/EditUser.types.ts
+++ b/src/pages/user/edit-user/EditUser.types.ts
@@ -30,6 +30,7 @@ export type EditUserFormValues = {
 		phone?: string;
 		whatsapp?: string;
 	};
+	dateOfBirth?: string;
 	firstName: string;
 	lastName: string;
 	password: string;

--- a/src/pages/user/edit-user/components/EditSection.tsx
+++ b/src/pages/user/edit-user/components/EditSection.tsx
@@ -10,9 +10,10 @@ export const EditSection = ({
 	onToggle,
 	children,
 	disabled = false,
+	testId,
 }: EditSectionProps) => {
 	return (
-		<Box display='flex' flexDirection='column' gap={2}>
+		<Box display='flex' flexDirection='column' gap={2} data-testid={testId}>
 			<Box display='flex' justifyContent='space-between' alignItems='center'>
 				<Text variant='subtitle1' fontWeight={700}>
 					{title}

--- a/src/pages/user/edit-user/components/EditSection.types.ts
+++ b/src/pages/user/edit-user/components/EditSection.types.ts
@@ -5,5 +5,6 @@ export interface EditSectionProps {
 	disabled?: boolean;
 	isEnabled: boolean;
 	onToggle: (next: boolean) => void;
+	testId?: string;
 	title: string;
 }

--- a/src/pages/user/edit-user/edituser.mapper.test.ts
+++ b/src/pages/user/edit-user/edituser.mapper.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildEditUserPayload, toEditUserDefaults } from './edituser.mapper';
+
+describe('toEditUserDefaults', () => {
+	it('pre-fills contacts.phone and clinicAddress from Google-sourced user details', () => {
+		const defaults = toEditUserDefaults({
+			firstName: 'Ada',
+			lastName: 'Lovelace',
+			contacts: { email: 'ada@example.com', phone: '+351911234567' },
+			clinicAddress: {
+				street: 'Rua Augusta 10',
+				city: 'Lisbon',
+				country: 'Portugal',
+				postcode: '1100-053',
+			},
+		});
+
+		expect(defaults.contacts.phone).toBe('+351911234567');
+		expect(defaults.clinicAddress).toEqual({
+			street: 'Rua Augusta 10',
+			city: 'Lisbon',
+			country: 'Portugal',
+			postcode: '1100-053',
+		});
+	});
+
+	it('falls back to empty strings when phone/address are absent', () => {
+		const defaults = toEditUserDefaults({
+			firstName: 'Ada',
+			lastName: 'Lovelace',
+			contacts: { email: 'ada@example.com' },
+		});
+
+		expect(defaults.contacts.phone).toBe('');
+		expect(defaults.dateOfBirth).toBe('');
+		expect(defaults.clinicAddress).toEqual({
+			street: '',
+			city: '',
+			country: '',
+			postcode: '',
+		});
+	});
+
+	it('normalizes an ISO datetime dateOfBirth to a YYYY-MM-DD date-input value', () => {
+		const defaults = toEditUserDefaults({
+			firstName: 'Ada',
+			lastName: 'Lovelace',
+			contacts: { email: 'ada@example.com' },
+			dateOfBirth: '1990-03-07T00:00:00.000Z',
+		});
+
+		expect(defaults.dateOfBirth).toBe('1990-03-07');
+	});
+});
+
+describe('buildEditUserPayload', () => {
+	const original = toEditUserDefaults({
+		firstName: 'Ada',
+		lastName: 'Lovelace',
+		contacts: { email: 'ada@example.com', phone: '+351911234567' },
+		clinicAddress: {
+			street: 'Rua Augusta 10',
+			city: 'Lisbon',
+			country: 'Portugal',
+			postcode: '1100-053',
+		},
+	});
+
+	it('includes clinicAddress only when the clinic section is enabled', () => {
+		const payload = buildEditUserPayload({
+			userId: 'user-1',
+			values: original,
+			enabled: { clinicAddress: true, contacts: false, name: false },
+			original,
+		});
+
+		expect(payload.data.clinicAddress).toEqual({
+			street: 'Rua Augusta 10',
+			city: 'Lisbon',
+			country: 'Portugal',
+			postcode: '1100-053',
+		});
+		expect(payload.data.contacts).toBeUndefined();
+	});
+
+	it('sends dateOfBirth when the name section is enabled, null when empty', () => {
+		const withDob = buildEditUserPayload({
+			userId: 'user-1',
+			values: { ...original, dateOfBirth: '1990-03-07' },
+			enabled: { clinicAddress: false, contacts: false, name: true },
+			original,
+		});
+		expect(withDob.data.dateOfBirth).toBe('1990-03-07');
+
+		const cleared = buildEditUserPayload({
+			userId: 'user-1',
+			values: { ...original, dateOfBirth: '' },
+			enabled: { clinicAddress: false, contacts: false, name: true },
+			original,
+		});
+		expect(cleared.data.dateOfBirth).toBeNull();
+	});
+
+	it('keeps the prefilled phone when contacts are edited without changing it', () => {
+		const payload = buildEditUserPayload({
+			userId: 'user-1',
+			values: original,
+			enabled: { clinicAddress: false, contacts: true, name: false },
+			original,
+		});
+
+		expect(payload.data.contacts?.phone).toBe('+351911234567');
+	});
+});

--- a/src/pages/user/edit-user/edituser.mapper.ts
+++ b/src/pages/user/edit-user/edituser.mapper.ts
@@ -13,6 +13,7 @@ type Contacts = {
 type UserDetailsLike = {
 	clinicAddress?: Partial<IClinicAddress>;
 	contacts: Contacts;
+	dateOfBirth?: string | null;
 	firstName: string;
 	lastName: string;
 	password?: string;
@@ -27,6 +28,8 @@ export const toEditUserDefaults = (
 		postcode: user.clinicAddress?.postcode ?? '',
 		street: user.clinicAddress?.street ?? '',
 	},
+	// Native date input expects 'YYYY-MM-DD'; the API returns an ISO datetime.
+	dateOfBirth: user.dateOfBirth ? String(user.dateOfBirth).slice(0, 10) : '',
 	firstName: user.firstName ?? '',
 	lastName: user.lastName ?? '',
 	contacts: {
@@ -50,6 +53,8 @@ export const buildEditUserPayload = (args: {
 	if (enabled.name) {
 		data.firstName = values.firstName.trim() || original.firstName;
 		data.lastName = values.lastName.trim() || original.lastName;
+		// '' clears the DOB; the BE guard treats an empty value as "unset".
+		data.dateOfBirth = values.dateOfBirth?.trim() || null;
 	}
 
 	if (enabled.clinicAddress) {


### PR DESCRIPTION
## What

Frontend half of PR-336 — surface the Google-sourced profile data on the edit-user page and let Google users re-sync it on demand.

- **NameForm** gains an opt-in `showDateOfBirth` field; edit-user maps the ISO DOB to the native `date` input and sends `''` as `null` to clear it.
- **Re-sync**: `resyncGoogleProfile` API + mutation; the "Sync from Google" button renders only for Google-auth users.
- **Testids** added across name/contacts/address/phone forms and edit sections for e2e.

## Pairs with

Backend: psycron-app/psycron-be#111 (`POST /users/:id/google/resync`, People API DOB/postcode mapping).

## Testing

- `edituser.mapper` unit tests: 6/6 (DOB ISO→date-input normalization, `''`→`null`, prefill/clear).
- `e2e/edit-user-prefill.spec.ts` covers address/phone/DOB prefill.
- `eslint` + `vite build` clean (husky pre-commit).

## Note

Branched clean off `dev` — this PR contains **only** the edit-user prefill work. Unrelated gcal week-drawer commits and in-progress Jupiter-onboarding e2e instrumentation that were sitting on the old local branch are intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)