### PR TITLE
fix(availability): scope readiness sidebar toggle to the calendar index only

### DIFF
--- a/src/pages/availability/workspace/AvailabilityWorkspaceShell.tsx
+++ b/src/pages/availability/workspace/AvailabilityWorkspaceShell.tsx
@@ -145,9 +145,10 @@ export const AvailabilityWorkspaceShell = forwardRef<
 			return () => window.cancelAnimationFrame(frameId);
 		}, [isPanelOpen, isSmallerThanTablet]);
 
-		// The readiness sidebar (edge toggle + scrim + panel) is irrelevant during
-		// the Jupiter onboarding conversation, so hide it in chat mode.
-		const showReadinessPanel = Boolean(panel) && contentMode !== 'chat';
+		// The readiness sidebar (edge toggle + scrim + panel) belongs only to the
+		// calendar scope — the strict /availability index. Keep it off settings
+		// ('page') and the Jupiter onboarding conversation ('chat').
+		const showReadinessPanel = Boolean(panel) && contentMode === 'calendar';
 
 		return (
 			<WorkspaceRoot


### PR DESCRIPTION
## What & why

The readiness edge toggle (`#availability-right-sidebar-toggle`), its scrim and panel were rendered whenever `contentMode !== 'chat'`. That blocklist let them leak onto the **availability settings** child route (`contentMode: 'page'`), where they don't belong.

## Change

`AvailabilityWorkspaceShell` now gates the readiness sidebar on `contentMode === 'calendar'` (allowlist) instead of `!== 'chat'`. The toggle/scrim/panel appear only on the strict `/availability` calendar index; they stay off settings (`page`) and the Jupiter onboarding conversation (`chat`).

## Verification
- `npm run build` passes (husky pre-commit).
- `/availability` → toggle visible. `/availability/settings` → toggle gone. Jupiter chat → unchanged (already hidden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)