### PR TITLE
fix(patients): duplicate pill nested-button DOM error in patient list

### DIFF
--- a/src/pages/patients/PatientListPage.styles.tsx
+++ b/src/pages/patients/PatientListPage.styles.tsx
@@ -290,7 +290,7 @@ export const StatusPill = styled(Box, {
 	text-transform: uppercase;
 `;
 
-export const DuplicateWarningPill = styled('button')`
+export const DuplicateWarningPill = styled('span')`
 	align-items: center;
 	background: ${hexToRgba(palette.warning.main, 0.12)};
 	border: 1px solid ${hexToRgba(palette.warning.main, 0.22)};

--- a/src/pages/patients/PatientListPage.tsx
+++ b/src/pages/patients/PatientListPage.tsx
@@ -86,9 +86,18 @@ export const PatientListPage = () => {
 		statusFilter,
 	} = usePatientListPageState();
 
-	const goToConflicts = (event: React.MouseEvent) => {
+	const goToConflicts = (event: React.SyntheticEvent) => {
 		event.stopPropagation();
 		navigate(`/${locale}/${CONFLICTS}?type=PATIENT_DUPLICATE`);
+	};
+
+	// The duplicate pill lives inside the row <button>, so it renders as a span
+	// (a nested <button> is invalid DOM) with explicit button semantics.
+	const handleDuplicatePillKeyDown = (event: React.KeyboardEvent) => {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			goToConflicts(event);
+		}
 	};
 
 	const isFiltering = Boolean(searchQuery) || statusFilter !== 'all';
@@ -357,9 +366,11 @@ export const PatientListPage = () => {
 										</SecondaryValue>
 										{duplicatePatientIds.has(patient._id) ? (
 											<DuplicateWarningPill
-												onClick={goToConflicts}
-												type='button'
 												data-testid={`patient-duplicate-${patient._id}`}
+												onClick={goToConflicts}
+												onKeyDown={handleDuplicatePillKeyDown}
+												role='button'
+												tabIndex={0}
 											>
 												{t('patients.list.possible-duplicate')}
 											</DuplicateWarningPill>
@@ -420,9 +431,11 @@ export const PatientListPage = () => {
 										<MobileCardBadges>
 											{duplicatePatientIds.has(patient._id) ? (
 												<DuplicateWarningPill
-													onClick={goToConflicts}
-													type='button'
 													data-testid={`patient-duplicate-mobile-${patient._id}`}
+													onClick={goToConflicts}
+													onKeyDown={handleDuplicatePillKeyDown}
+													role='button'
+													tabIndex={0}
 												>
 													{t('patients.list.possible-duplicate')}
 												</DuplicateWarningPill>


### PR DESCRIPTION
## What & why

`validateDOMNesting(...): <button> cannot appear as a descendant of <button>` on the patient list. The "possible duplicate" pill (`DuplicateWarningPill`) was a `<button>` rendered inside the patient row / mobile card, which are themselves `<button>`s. Invalid DOM, and a source of flaky click handling.

## Fix

- `DuplicateWarningPill` is now a `span` (valid inside the row button) with explicit button semantics: `role="button"`, `tabIndex={0}`, and an `onKeyDown` (Enter/Space) handler.
- `goToConflicts` still calls `stopPropagation`, so clicking the pill opens the conflicts queue without also triggering the row's navigate-to-profile.

## Verification
- `eslint` clean on the changed files; Vercel build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)