### PR TITLE
ci: gate pull requests on the unit-test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [dev, main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+      - run: npm run test:unit
+
+  # NOTE: Playwright E2E (`npm run test:e2e`) is intentionally not gated yet.
+  # 17 of 26 specs pass standalone, but the google-calendar specs need a
+  # backend / authenticated session mocked via page.route(). Enable a job
+  # here once those specs are self-contained.


### PR DESCRIPTION
## Summary
- Adds a CI workflow that runs the vitest unit suite (`npm run test:unit`, 30 tests) on every PR and on pushes to `dev`/`main` — the FE previously had **no test gate** (the BE got its equivalent in psycron-be#110)
- Concurrency group cancels superseded runs on rapid pushes
- Playwright E2E intentionally not gated yet: the google-calendar specs need a mocked backend session before they're self-contained (noted in the workflow)

## Test plan
- [x] `npm run test:unit` passes locally (30/30)
- [x] CI check appears and passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)