### PR TITLE
fix: stop stale onboarding draft from forcing availability redirect

### DIFF
--- a/src/components/guards/AvailabilityGate.tsx
+++ b/src/components/guards/AvailabilityGate.tsx
@@ -31,31 +31,37 @@ export const AvailabilityGate = ({ children }: AvailabilityGateProps) => {
 	const isOnGeneratePage = location.pathname.includes(AVAILABILITYGENERATE);
 	const hasAvailability = data !== null;
 	const hasDraft = !!localStorage.getItem(STORAGE_KEY);
-	// Once the query resolves, a missing availability (or a pending draft) means
-	// we are about to redirect — we must not render children for that frame, or
-	// the dashboard flashes briefly before the navigation lands.
-	const willRedirect =
-		!isLoading && !isOnGeneratePage && (!hasAvailability || hasDraft);
+	// Published availability is authoritative: a leftover onboarding draft must
+	// never bounce a user who already has availability back into the generate
+	// flow. A draft only means "resume onboarding" when no availability exists.
+	// Once the query resolves, a missing availability means we are about to
+	// redirect — we must not render children for that frame, or the dashboard
+	// flashes briefly before the navigation lands.
+	const willRedirect = !isLoading && !isOnGeneratePage && !hasAvailability;
 
 	useEffect(() => {
 		if (isLoading) return;
-		if (isOnGeneratePage) return;
 
-		if (!hasAvailability) {
-			if (!hasAlerted.current && !!localStorage.getItem(ONBOARDING_KEY)) {
-				hasAlerted.current = true;
-				showAlert({
-					message: t('availability.gate.deleted-notice'),
-					severity: 'warning',
-				});
+		if (hasAvailability) {
+			// Drop a stale draft so it can't trap the user in generate on the
+			// next load — but not while they're actively on the generate page
+			// (e.g. regenerating), where the draft is legitimately in flight.
+			if (hasDraft && !isOnGeneratePage) {
+				localStorage.removeItem(STORAGE_KEY);
 			}
-			navigate(`/${i18n.language}/${AVAILABILITYGENERATE}`, { replace: true });
 			return;
 		}
 
-		if (hasDraft) {
-			navigate(`/${i18n.language}/${AVAILABILITYGENERATE}`, { replace: true });
+		if (isOnGeneratePage) return;
+
+		if (!hasAlerted.current && !!localStorage.getItem(ONBOARDING_KEY)) {
+			hasAlerted.current = true;
+			showAlert({
+				message: t('availability.gate.deleted-notice'),
+				severity: 'warning',
+			});
 		}
+		navigate(`/${i18n.language}/${AVAILABILITYGENERATE}`, { replace: true });
 	}, [
 		hasAvailability,
 		hasDraft,

--- a/src/pages/patients/hooks/usePatientListPageState.ts
+++ b/src/pages/patients/hooks/usePatientListPageState.ts
@@ -15,6 +15,7 @@ import {
 	useInfiniteQuery,
 	useMutation,
 	useQuery,
+	useQueryClient,
 } from '@tanstack/react-query';
 
 import type {
@@ -35,6 +36,7 @@ export const usePatientListPageState = () => {
 	const { isSmallerThanTablet } = useViewport();
 	const { isUserDetailsLoading, therapistId } = useUserDetails();
 	const { showAlert } = useAlert();
+	const queryClient = useQueryClient();
 
 	const [searchQuery, setSearchQuery] = useState('');
 	const [debouncedSearch, setDebouncedSearch] = useState('');
@@ -53,6 +55,12 @@ export const usePatientListPageState = () => {
 
 	const scanMutation = useMutation({
 		mutationFn: () => scanPatientDuplicates(therapistId),
+		// The scan may open, refresh, or auto-dismiss duplicate conflicts. Refetch
+		// the conflict queries so the list pills (and the open-count badge) reflect
+		// the post-scan state instead of the snapshot read on mount.
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['conflicts'] });
+		},
 		onError: (error: CustomError) => {
 			showAlert({ message: error.message, severity: 'error' });
 		},


### PR DESCRIPTION
## What

Two frontend fixes:

1. **`AvailabilityGate`** now treats published availability as authoritative over a leftover onboarding draft in `localStorage`. A user who already has availability is no longer redirected to `/availability/generate` on login (and no longer trapped there); a stale draft is purged once they're off the generate page. Users *without* availability still get redirected to onboarding — unchanged.
2. **`usePatientListPageState`** invalidates the conflicts query after the patient duplicate scan, so the list's duplicate pills and open-count badge reflect newly created conflicts instead of the snapshot read on mount.

## Why

A stale draft was bouncing users with availability back into the generate flow on every login and re-persisting itself so they couldn't leave. And the duplicate-scan result never refreshed the UI because the conflicts query wasn't invalidated after the scan.

Decision record: vault `07 Decisions/2026-07-22 Availability Gate Draft Precedence.md`.

## Pairs with

Backend duplicate-scan change: psycron-be#119 (same branch name).

## Accepted low-severity tradeoff

Silent discard of an in-progress regenerate draft when a user with availability leaves `/generate` without publishing — tracked in PR-411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)