### PR TITLE
feat(legal): point in-app consent links at app-level legal docs (PR-330)

### DIFF
--- a/src/pages/urls.tsx
+++ b/src/pages/urls.tsx
@@ -65,12 +65,23 @@ export const PATIENTAPPOINTMENTSLIST = `${PATIENTID}/${APPOINTMENTS}`;
 
 export const ADDPATIENT = 'patient/create';
 
+// Website-level legal documents — govern the public psycron.app marketing site.
 export const PRIVACY_POLICY = 'privacy-policy';
 export const TERMS_OF_SERVICE = 'terms-of-use';
 export const MARKETING_COMMS = 'marketing-communications';
 
+// App-level legal documents — govern use of the Psycron application itself and
+// establish the practitioner as data controller with Psycron as processor
+// (LGPD Art. 39 / GDPR Art. 28). These are the documents users consent to in-app.
+export const APP_PRIVACY_POLICY = 'app/privacy';
+export const APP_TERMS_OF_SERVICE = 'app/terms';
+export const APP_DATA_PROCESSING_AGREEMENT = 'app/data-processing-agreement';
+
 export const externalUrls = (locale: string) => ({
-	PRIVACY: `${DOMAIN}/${locale}/${PRIVACY_POLICY}`,
-	TERMS: `${DOMAIN}/${locale}/${TERMS_OF_SERVICE}`,
+	PRIVACY: `${DOMAIN}/${locale}/${APP_PRIVACY_POLICY}`,
+	TERMS: `${DOMAIN}/${locale}/${APP_TERMS_OF_SERVICE}`,
+	DPA: `${DOMAIN}/${locale}/${APP_DATA_PROCESSING_AGREEMENT}`,
 	MARKETING: `${DOMAIN}/${locale}/${MARKETING_COMMS}`,
+	WEBSITE_PRIVACY: `${DOMAIN}/${locale}/${PRIVACY_POLICY}`,
+	WEBSITE_TERMS: `${DOMAIN}/${locale}/${TERMS_OF_SERVICE}`,
 });


### PR DESCRIPTION
[PR-330](https://psycron.atlassian.net/browse/PR-330) — LGPD/GDPR launch requirement.

## Why

Every in-app consent surface linked to the **website** privacy policy and terms. Those documents scope themselves to *"only the public psycron.app marketing site"* and say nothing about Platform use or the practitioner-as-controller relationship — so signup was collecting consent against the wrong text.

## What changed

`src/pages/urls.tsx` only:

- `externalUrls().PRIVACY` / `.TERMS` now point at the app-level documents (`/:locale/app/privacy`, `/:locale/app/terms`).
- Website documents stay reachable as `WEBSITE_PRIVACY` / `WEBSITE_TERMS`.
- Adds `DPA`, which the Application Terms of Service incorporate by reference.

All five consumers are Platform-use consent surfaces, so all five are correct to repoint:

| Surface | File |
|---|---|
| Email signup consent | `SignUpEmail.tsx` |
| Google signup consent | `SignUpStart.tsx` |
| Account security section | `UserDetailsCard.tsx` |
| Patient booking consent | `PublicBookingForm.tsx` |
| Availability slot drawer | `SlotAvailableBody.tsx` |

Satisfies the ticket's acceptance criteria that the signup form links to both documents and that both are reachable without authentication.

## Dependencies

Needs psycron-landing [#25](https://github.com/psycron-app/landing-page/pull/25) to serve the routes, which in turn waits on Legal merging `draft/app-legal-docs`. **Merging this before the content is live points signup at a 404** — land it after the landing PR.

Pairs with psycron-be [#123](https://github.com/psycron-app/psycron-be/pull/123), which persists and versions the consent these links describe.

## Not included

Signup copy is unchanged — adding a visible DPA link means editing EN + PT `Trans` strings, which needs a translation review. Flagged as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)